### PR TITLE
Arm support and SSE check update

### DIFF
--- a/config/proc-aarch64.make
+++ b/config/proc-aarch64.make
@@ -2,9 +2,9 @@
 
 ifdef _ADD_OPENFST
 ifeq ($(shell test -d $(OPENFSTDIR)/lib64 && echo 1),1)
-LDFLAGS 	+= -L$(OPENFSTDIR)/lib64 $(OPENFSTLIBS)
+LDFLAGS         += -L$(OPENFSTDIR)/lib64 $(OPENFSTLIBS)
 else
-LDFLAGS 	+= -L$(OPENFSTDIR)/lib -Wl,-rpath=$(OPENFSTDIR)/lib $(OPENFSTLIBS)
+LDFLAGS         += -L$(OPENFSTDIR)/lib -Wl,-rpath=$(OPENFSTDIR)/lib $(OPENFSTLIBS)
 endif
 endif
 
@@ -13,7 +13,6 @@ ifeq ($(COMPILER),gcc)
 CCFLAGS		+= -ffast-math
 # CCFLAGS     += -mfpmath=sse
 # CCFLAGS     += -funroll-loops
-CCFLAGS     += -msse3
 ifneq ($(findstring($(CPU),Opteron)),)
 CCFLAGS     += -march=opteron
 endif

--- a/src/Mm/IntelOptimization.cc
+++ b/src/Mm/IntelOptimization.cc
@@ -12,7 +12,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-#if (defined(PROC_intel) || defined(PROC_x86_64))
 
 #include "IntelOptimization.hh"
 #include <Core/Application.hh>
@@ -22,16 +21,16 @@ using namespace Mm;
 FeatureScorerIntelOptimization::FeatureScorerIntelOptimization(
         const Core::Configuration& c, ComponentIndex dimension)
         : Precursor(c)
-#if !defined(DISABLE_SIMD)
+#if defined(__SSE__)
           ,
           l2norm_(c, dimension)
-#if !defined(ENABLE_SSE2)
+#if !defined(__SSE2__)
           ,
           reset_(c)
 #endif
 #endif
 {
-#if defined(DISABLE_SIMD)
+#if defined(__SSE2__)
     Core::Application::us()->warning("SIMD is not supported (in Valgrind executables)");
 #endif
 }
@@ -66,7 +65,7 @@ void FeatureScorerIntelOptimization::multiplyAndQuantize(const std::vector<Featu
     std::fill(ri, r.end(), 0);
 }
 
-#if defined(DISABLE_SIMD)
+#if !defined(__SSE__)
 
 int FeatureScorerIntelOptimization::distance(const PreparedFeatureVector& mean, const PreparedFeatureVector& featureVector) const {
     int            df, score = 0;
@@ -114,4 +113,3 @@ int FeatureScorerIntelOptimization::distance(const PreparedFeatureVector& mean, 
 
 #endif  // DISABLE_SIMD
 
-#endif  // PROC_intel

--- a/src/Mm/IntelOptimization.cc
+++ b/src/Mm/IntelOptimization.cc
@@ -30,7 +30,7 @@ FeatureScorerIntelOptimization::FeatureScorerIntelOptimization(
 #endif
 #endif
 {
-#if defined(__SSE2__)
+#if !defined(__SSE__)
     Core::Application::us()->warning("SIMD is not supported (in Valgrind executables)");
 #endif
 }

--- a/src/Mm/IntelOptimization.cc
+++ b/src/Mm/IntelOptimization.cc
@@ -111,5 +111,5 @@ int FeatureScorerIntelOptimization::distance(const PreparedFeatureVector& mean, 
     return score;
 }
 
-#endif  // DISABLE_SIMD
+#endif  // !(__SSE__)
 

--- a/src/Mm/IntelOptimization.hh
+++ b/src/Mm/IntelOptimization.hh
@@ -86,7 +86,7 @@ public:
                  const PreparedFeatureVector& featureVector) const {
         return l2norm_.run(&mean[0], &featureVector[0]);
     }
-#if defined(ENABLE_SSE2)
+#if defined(__SSE2__)
     void resetFloatingPointCalculation() const {}
 #else
     void resetFloatingPointCalculation() const {

--- a/src/Mm/IntelOptimization.hh
+++ b/src/Mm/IntelOptimization.hh
@@ -99,5 +99,4 @@ public:
 
 }  // namespace Mm
 
-//#endif  // PROC_intel
 #endif  //_MM_INTEL_OPTIMAZATION_HH

--- a/src/Mm/IntelOptimization.hh
+++ b/src/Mm/IntelOptimization.hh
@@ -47,10 +47,10 @@ private:
     IntelMMXL2NormCodeGenerator l2norm_;
     IntelMMXResetCodeGenerator  reset_;
     enum {BlockSize = 8};
-#endif  // ENABLE_SSE2
+#endif  // __SSE2__
 #else
     enum { BlockSize = 8 };
-#endif  // DISABLE_SIMD
+#endif  //__SSE__ 
 
 private:
     /** @return is @param vectorSize rounded up to the next integer divisible by BlockSize. */
@@ -92,9 +92,9 @@ public:
     void resetFloatingPointCalculation() const {
         reset_.run();
     }
-#endif  // ENABLE_SSE2
+#endif  // __SSE2__
 
-#endif  // DISABLE_SIMD
+#endif  // __SSE__
 };
 
 }  // namespace Mm

--- a/src/Mm/IntelOptimization.hh
+++ b/src/Mm/IntelOptimization.hh
@@ -17,8 +17,10 @@
 
 #if (defined(PROC_intel) || defined(PROC_x86_64))
 #include "IntelCodeGenerator.hh"
+#endif
+#if defined(__SSE2__)
 #include "SSE2CodeGenerator.hh"
-
+#endif
 #include "CovarianceFeatureScorerElement.hh"
 #include "GaussDensity.hh"
 #include "MixtureFeatureScorerElement.hh"
@@ -37,8 +39,8 @@ public:
     typedef std::vector<QuantizedType>                          PreparedFeatureVector;
 
 private:
-#if !defined(DISABLE_SIMD)
-#if defined(ENABLE_SSE2)
+#if defined(__SSE__)
+#if defined(__SSE2__)
     SSE2L2NormCodeGenerator l2norm_;
     enum {BlockSize = 16};
 #else
@@ -71,7 +73,7 @@ public:
     int distanceNoMmx(const PreparedFeatureVector& mean,
                       const PreparedFeatureVector& featureVector) const;
 
-#if defined(DISABLE_SIMD)
+#if !defined(__SSE__)
     int  distance(const PreparedFeatureVector& mean,
                   const PreparedFeatureVector& featureVector) const;
     void resetFloatingPointCalculation() const {}
@@ -97,5 +99,5 @@ public:
 
 }  // namespace Mm
 
-#endif  // PROC_intel
+//#endif  // PROC_intel
 #endif  //_MM_INTEL_OPTIMAZATION_HH


### PR DESCRIPTION
Added a ARM64 proc file and removed `-DDISABLE_SIMD` and `-DENABLE_SSE2` in favor of the predefined by the compiler `__SSE__` and `__SSE2__` .