### PR TITLE
deleted feature vectors copying in setLookAhead()

### DIFF
--- a/src/Search/AdvancedTreeSearch/AcousticLookAhead.cc
+++ b/src/Search/AdvancedTreeSearch/AcousticLookAhead.cc
@@ -664,18 +664,18 @@ void AcousticLookAhead::getSuccessorMixtures(const PersistentStateTree&         
     }
 }
 
-void AcousticLookAhead::setLookAhead(std::vector<Mm::FeatureVector> lookahead) {
+void AcousticLookAhead::setLookAhead(std::deque<Core::Ref<const Mm::Feature>> const& lookahead) {
+    
     if (!acousticLookAheadScorer_)
         return;
 
-    if (lookahead.size() > acousticLookaheadDepth_)
-        lookahead.resize(acousticLookaheadDepth_);
+    size_t lookahead_size = std::min(int(lookahead.size()), int(acousticLookaheadDepth_));
 
     acousticLookAhead_.clear();
 
-    for (u32 a = 0; a < lookahead.size(); ++a) {
-        acousticLookAhead_.push_back(std::make_pair(acousticLookAheadScorer_->multiplyAndQuantize(lookahead.at(a))[0],
-                                                    acousticLookAheadScorer_->getScorer(lookahead.at(a))));
+    for (u32 a = 0; a < lookahead_size; ++a) {
+        acousticLookAhead_.push_back(std::make_pair(acousticLookAheadScorer_->multiplyAndQuantize(*(*lookahead.at(a)).mainStream())[0],
+                                                    acousticLookAheadScorer_->getScorer(*(*lookahead.at(a)).mainStream())));
         verify(acousticLookAhead_[a].first.size());
     }
 }

--- a/src/Search/AdvancedTreeSearch/AcousticLookAhead.hh
+++ b/src/Search/AdvancedTreeSearch/AcousticLookAhead.hh
@@ -207,7 +207,7 @@ public:
     /// compute look-ahead scores
     int length() const;
 
-    void setLookAhead(std::vector<Mm::FeatureVector> lookahead);
+    void setLookAhead(std::deque<Core::Ref<const Mm::Feature>> const& lookahead);
 
     void clear();
 

--- a/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.cc
+++ b/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.cc
@@ -610,10 +610,10 @@ Search::SearchAlgorithm::RecognitionContext AdvancedTreeSearchManager::setContex
     return ss_->setContext(context);
 }
 
-void AdvancedTreeSearchManager::setLookAhead(const std::vector<Mm::FeatureVector>& lookahead) {
+void AdvancedTreeSearchManager::setLookAhead(const std::deque<Core::Ref<const Mm::Feature>>& lookahead) {
     if ((int)lookahead.size() < lookAheadLength())
         // Disable acoustic look-ahead if we don't have enough data
-        ss_->setLookAhead(std::vector<Mm::FeatureVector>());
+        ss_->setLookAhead(std::deque<Core::Ref<const Mm::Feature>>());
     else
         ss_->setLookAhead(lookahead);
 }

--- a/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.hh
+++ b/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.hh
@@ -27,6 +27,8 @@
 #include <Speech/ModelCombination.hh>
 #include "DynamicBeamPruningStrategy.hh"
 #include "Trace.hh"
+#include <Mm/Types.hh> // include this so that the Mm::Feature type in setLookAhead() function can be recognized
+
 
 namespace Speech {
 class StateTying;
@@ -119,7 +121,7 @@ public:
     virtual PruningRef describePruning();
 
     virtual u32                lookAheadLength();
-    virtual void               setLookAhead(const std::vector<Mm::FeatureVector>& lookahead);
+    virtual void               setLookAhead(const std::deque<Core::Ref<const Mm::Feature>>& lookahead);
     virtual RecognitionContext setContext(RecognitionContext context);
 };
 }  // namespace Search

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -3382,7 +3382,7 @@ Search::SearchAlgorithm::RecognitionContext SearchSpace::setContext(Search::Sear
     return ret;
 }
 
-void SearchSpace::setLookAhead(const std::vector<Mm::FeatureVector>& lookahead) {
+void SearchSpace::setLookAhead(const std::deque<Core::Ref<const Mm::Feature>>& lookahead) {
     acousticLookAhead_->setLookAhead(lookahead);
 }
 

--- a/src/Search/AdvancedTreeSearch/SearchSpace.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.hh
@@ -355,7 +355,7 @@ public:
     u32 nActiveTrees() const;
 
     int                                         lookAheadLength() const;
-    void                                        setLookAhead(const std::vector<Mm::FeatureVector>&);
+    void                                        setLookAhead(const std::deque<Core::Ref<const Mm::Feature>>&);
     Search::SearchAlgorithm::RecognitionContext setContext(Search::SearchAlgorithm::RecognitionContext);
 
     ///Returns the best prospect, eg. the score of the best state hypothesis including the look-ahead score

--- a/src/Search/Search.hh
+++ b/src/Search/Search.hh
@@ -126,7 +126,7 @@ public:
      * as returned by lookaheadLength().  At the end of a segment, less than requested,
      * or even zero feature vectors may be given.
      */
-    virtual void setLookAhead(const std::vector<Mm::FeatureVector>&) {}
+    virtual void setLookAhead(const std::deque<Core::Ref<const Speech::Feature>>&) {}
 
     class Pruning : public Core::ReferenceCounted {
     public:

--- a/src/Speech/DelayedRecognizer.cc
+++ b/src/Speech/DelayedRecognizer.cc
@@ -144,10 +144,7 @@ Core::Ref<const Feature> RecognizerDelayHandler::flush() {
 
 void RecognizerDelayHandler::setLookAhead() {
     // @todo avoid copying the feature vectors, use vector< Core::Ref<FeatureVector> > instead.
-    std::vector<Mm::FeatureVector> lah;
-    for (FeatureBuffer::const_iterator f = featureBuffer_.begin(); f != featureBuffer_.end(); ++f)
-        lah.push_back(*(*f)->mainStream());
-    recognizer_->setLookAhead(lah);
+    recognizer_->setLookAhead(featureBuffer_);
 }
 
 void RecognizerDelayHandler::initializeBatchScorer() {


### PR DESCRIPTION
In DelayedRecognizer.cc file, the feature vector copying in the RecognizerDelayHandler::setLookAhead() function took approximately 10% of the time of RecognizerDelayHandler::flush(), which turned out to be unnecessary overhead. 

So this copying part was deleted and featureBuffer_ is now passed directly, where the function signatures were also adapted.