### PR TITLE
Fix char conversion in PythonControl callback

### DIFF
--- a/src/Nn/PythonControl.cc
+++ b/src/Nn/PythonControl.cc
@@ -847,9 +847,12 @@ struct PythonControl::Internal : public Core::Component {
             PyErr_SetString(PyExc_TypeError, "PythonControl callback(): requires at least one arg. try callback('help')");
             return NULL;
         }
-
-        PyObject*   cmd    = PyTuple_GetItem(args, 0);  // borrowed
-        const char* cmd_cs = PyUnicode_AS_DATA(cmd);
+        PyObject* cmd    = PyTuple_GetItem(args, 0);  // borrowed
+        if (PyUnicode_KIND(cmd) != PyUnicode_1BYTE_KIND){
+            PyErr_SetString(PyExc_TypeError, "PythonControl callback(): first arg is not a 1BYTE unicode string");
+            return NULL;
+        }
+        const char* cmd_cs = (const char*)PyUnicode_1BYTE_DATA(cmd);
         if (!cmd_cs) {
             PyErr_SetString(PyExc_TypeError, "PythonControl callback(): first arg must be a string");
             return NULL;

--- a/src/Nn/PythonControl.cc
+++ b/src/Nn/PythonControl.cc
@@ -847,7 +847,8 @@ struct PythonControl::Internal : public Core::Component {
             PyErr_SetString(PyExc_TypeError, "PythonControl callback(): requires at least one arg. try callback('help')");
             return NULL;
         }
-        PyObject* cmd    = PyTuple_GetItem(args, 0);  // borrowed
+
+        PyObject* cmd = PyTuple_GetItem(args, 0);  // borrowed
         if (PyUnicode_KIND(cmd) != PyUnicode_1BYTE_KIND){
             PyErr_SetString(PyExc_TypeError, "PythonControl callback(): first arg is not a 1BYTE unicode string");
             return NULL;


### PR DESCRIPTION
I had a Bug when working with Python 3.8 that it a callback call in RETURNN, e.g. `callback("version")` would result in the error `"PythonControl callback(): unknown command 'v'"`, because only the first letter would be extracted from the first argument.

After some search I found this statement in the [Python-C documentation](https://docs.python.org/3.8/c-api/unicode.html?highlight=unicode_as_data#c.PyUnicode_AS_DATA) for the (actually deprecated) `PyUnicode_AS_DATA`
**It may also contain embedded null code points, which would cause the string to be truncated when used in most C functions** 

So I replaced this by the (hopefully correct) `PyUnicode_1BYTE_DATA` call including a check.