### PR TITLE
Add NceBlasUnbiasedAdapter to manage models with no bias in the output layer

### DIFF
--- a/src/Lm/BlasNceUnbiasedSoftmaxAdapter.cc
+++ b/src/Lm/BlasNceUnbiasedSoftmaxAdapter.cc
@@ -1,0 +1,59 @@
+/** Copyright 2020 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "BlasNceUnbiasedSoftmaxAdapter.hh"
+
+#include <Math/Blas.hh>
+
+#include "DummyCompressedVectorFactory.hh"
+
+namespace Lm {
+
+void BlasNceUnbiasedSoftmaxAdapter::init(Tensorflow::Session& session, Tensorflow::TensorInputMap const& input_map, Tensorflow::TensorOutputMap const& output_map) {
+    auto const& weight_tensor_info = output_map.get_info("weights");
+    session.run({}, {weight_tensor_info.tensor_name()}, {}, tensors_);
+}
+
+Score BlasNceUnbiasedSoftmaxAdapter::get_score(Lm::CompressedVectorPtr<float> const& nn_out, size_t output_idx) {
+    std::vector<float>                   nn_output;
+    float const*                         data;
+    Lm::UncompressedVector<float> const* vec = dynamic_cast<Lm::UncompressedVector<float> const*>(nn_out.get());
+
+    if (vec != nullptr) {
+        data = vec->data();
+    }
+    else {
+        nn_output.resize(nn_out->size());
+        nn_out->uncompress(nn_output.data(), nn_output.size());
+        data = nn_output.data();
+    }
+
+    float result = Math::dot(nn_out->size(), data, 1, tensors_[0].data<float>(output_idx, 0), 1);
+
+    return result;
+}
+
+std::vector<Score> BlasNceUnbiasedSoftmaxAdapter::get_scores(Lm::CompressedVectorPtr<float> const& nn_out, std::vector<size_t> const& output_idxs) {
+    std::vector<float> nn_output(nn_out->size());
+    nn_out->uncompress(nn_output.data(), nn_output.size());
+
+    std::vector<Score> result(output_idxs.size());
+    for (size_t i = 0ul; i < output_idxs.size(); i++) {
+        result[i] = Math::dot(nn_output.size(), nn_output.data(), 1, tensors_[0].data<float>(output_idxs[i], 0), 1);
+    }
+
+    return result;
+}
+
+}  // namespace Lm

--- a/src/Lm/BlasNceUnbiasedSoftmaxAdapter.hh
+++ b/src/Lm/BlasNceUnbiasedSoftmaxAdapter.hh
@@ -1,0 +1,45 @@
+/** Copyright 2020 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef _LM_BLAS_NCE_UNBIASED_SOFTMAX_ADAPTER_HH
+#define _LM_BLAS_NCE_UNBIASED_SOFTMAX_ADAPTER_HH
+
+#include "SoftmaxAdapter.hh"
+
+namespace Lm {
+
+class BlasNceUnbiasedSoftmaxAdapter : public SoftmaxAdapter {
+public:
+    using Precursor = SoftmaxAdapter;
+
+    BlasNceUnbiasedSoftmaxAdapter(Core::Configuration const& config);
+    virtual ~BlasNceUnbiasedSoftmaxAdapter() = default;
+
+    virtual void               init(Tensorflow::Session& session, Tensorflow::TensorInputMap const& input_map, Tensorflow::TensorOutputMap const& output_map);
+    virtual Score              get_score(Lm::CompressedVectorPtr<float> const& nn_out, size_t output_idx);
+    virtual std::vector<Score> get_scores(Lm::CompressedVectorPtr<float> const& nn_out, std::vector<size_t> const& output_idxs);
+
+private:
+    std::vector<Tensorflow::Tensor> tensors_;
+};
+
+// inline implementations
+
+inline BlasNceUnbiasedSoftmaxAdapter::BlasNceUnbiasedSoftmaxAdapter(Core::Configuration const& config)
+        : Precursor(config) {
+}
+
+}  // namespace Lm
+
+#endif /* _LM_BLAS_NCE_SOFTMAX_ADAPTER_HH */

--- a/src/Lm/Makefile
+++ b/src/Lm/Makefile
@@ -40,6 +40,7 @@ LIBSPRINTLM_O += $(OBJDIR)/FFNeuralNetworkLanguageModel.o
 endif
 ifdef MODULE_LM_TFRNN
 LIBSPRINTLM_O += $(OBJDIR)/BlasNceSoftmaxAdapter.o
+LIBSPRINTLM_O += $(OBJDIR)/BlasNceUnbiasedSoftmaxAdapter.o
 LIBSPRINTLM_O += $(OBJDIR)/CompressedVector.o
 LIBSPRINTLM_O += $(OBJDIR)/FixedQuantizationCompressedVectorFactory.o
 LIBSPRINTLM_O += $(OBJDIR)/LstmStateManager.o

--- a/src/Lm/TFRecurrentLanguageModel.cc
+++ b/src/Lm/TFRecurrentLanguageModel.cc
@@ -17,6 +17,7 @@
 #include <functional>
 
 #include "BlasNceSoftmaxAdapter.hh"
+#include "BlasNceUnbiasedSoftmaxAdapter.hh"
 #include "LstmStateManager.hh"
 #include "Module.hh"
 #include "NceSoftmaxAdapter.hh"
@@ -185,6 +186,7 @@ std::unique_ptr<StateManager> createStateManager(Core::Configuration const& conf
 
 enum SoftmaxAdapterType {
     BlasNceSoftmaxAdapterType,
+    BlasNceUnbiasedSoftmaxAdapterType,
     NceSoftmaxAdapterType,
     PassthroughSoftmaxAdapterType,
     QuantizedBlasNceSoftmaxAdapter16BitType
@@ -193,6 +195,7 @@ enum SoftmaxAdapterType {
 const Core::Choice softmaxAdapterTypeChoice(
         "blas_nce", BlasNceSoftmaxAdapterType,  // included for backward compatibility
         "blas-nce", BlasNceSoftmaxAdapterType,  // more consistent with RASR conventions
+	"blas-nce-unbiased", BlasNceUnbiasedSoftmaxAdapterType,
         "nce", NceSoftmaxAdapterType,
         "passthrough", PassthroughSoftmaxAdapterType,
         "quantized-blas-nce-16bit", QuantizedBlasNceSoftmaxAdapter16BitType,
@@ -206,6 +209,7 @@ const Core::ParameterChoice softmaxAdapterTypeParam(
 std::unique_ptr<SoftmaxAdapter> createSoftmaxAdapter(Core::Configuration const& config) {
     switch (softmaxAdapterTypeParam(config)) {
         case BlasNceSoftmaxAdapterType: return std::unique_ptr<SoftmaxAdapter>(new Lm::BlasNceSoftmaxAdapter(config));
+	case BlasNceUnbiasedSoftmaxAdapterType: return std::unique_ptr<SoftmaxAdapter>(new Lm::BlasNceUnbiasedSoftmaxAdapter(config));
         case NceSoftmaxAdapterType: return std::unique_ptr<SoftmaxAdapter>(new Lm::NceSoftmaxAdapter(config));
         case PassthroughSoftmaxAdapterType: return std::unique_ptr<SoftmaxAdapter>(new Lm::PassthroughSoftmaxAdapter(config));
         case QuantizedBlasNceSoftmaxAdapter16BitType: return std::unique_ptr<SoftmaxAdapter>(new Lm::QuantizedBlasNceSoftmaxAdapter16Bit(config));


### PR DESCRIPTION
This is a solution to #11, which requires changing the configuration parameter value.