### PR TITLE
Allophone State Fsa bug for arc's weight leaving silence 

### DIFF
--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -784,8 +784,8 @@ typedef std::unordered_map<MinimizedState, Fsa::State*, MinimizedState::Hash,
  *  phone1	   the second state of a phone segment
  *
  * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This happens in the legacy
- * StandardApplicator that is buggy, and has been corrector by implementing
- * ApplicatorWithContext, where the weights are read by refering to the correct source state
+ * LegacyApplicator that is buggy, and has been corrector by implementing
+ * CorrectedApplicator, where the weights are read by refering to the correct source state
  * in case we have an epsilon arc
  **/
 Fsa::ConstAutomatonRef ClassicTransducerBuilder::createEmissionLoopTransducer(

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -783,8 +783,8 @@ typedef std::unordered_map<MinimizedState, Fsa::State*, MinimizedState::Hash,
  *  phone0	   the first state of a phone segment
  *  phone1	   the second state of a phone segment
  *
- * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This happens in the s
- * StandardApplicator that is a legacy buggy applicator, and has been corrector by implementing
+ * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This happens in the legacy
+ * StandardApplicator that is buggy, and has been corrector by implementing
  * ApplicatorWithContext, where the weights are read by refering to the correct source state
  * in case we have an epsilon arc
  **/

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -783,7 +783,7 @@ typedef std::unordered_map<MinimizedState, Fsa::State*, MinimizedState::Hash,
  *  phone0	   the first state of a phone segment
  *  phone1	   the second state of a phone segment
  *
- * silence.exit = silence.forward - phone?.forward   but why?
+ * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This is corrected in doExit() funtion.
  **/
 Fsa::ConstAutomatonRef ClassicTransducerBuilder::createEmissionLoopTransducer(
         bool transitionModel) {

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -783,7 +783,10 @@ typedef std::unordered_map<MinimizedState, Fsa::State*, MinimizedState::Hash,
  *  phone0	   the first state of a phone segment
  *  phone1	   the second state of a phone segment
  *
- * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This is corrected in doExit() funtion.
+ * silence.exit = silence.forward - phone?.forward due to epsilon arcs. This happens in the s
+ * StandardApplicator that is a legacy buggy applicator, and has been corrector by implementing
+ * ApplicatorWithContext, where the weights are read by refering to the correct source state
+ * in case we have an epsilon arc
  **/
 Fsa::ConstAutomatonRef ClassicTransducerBuilder::createEmissionLoopTransducer(
         bool transitionModel) {

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -137,12 +137,6 @@ static const Core::ParameterBool paramFixAllophoneContextAtWordBoundaries(
         "Enabling this option would fix that.",
         false);
 
-static const Core::ParameterBool paramFixTdpLeavingEpsilonArc(
-        "fix-tdp-leaving-epsilon-arc",
-        "Calls a different applicator that keeps track of the emission label at previous step "
-        "This solved the inconsistent transition model application due to epsilon arcs ",
-        false);
-
 ClassicTransducerBuilder::ClassicTransducerBuilder(Core::Ref<
                                                    const ClassicAcousticModel>
                                                            model)
@@ -159,7 +153,6 @@ ClassicTransducerBuilder::ClassicTransducerBuilder(Core::Ref<
     inputType_                              = inputAcceptsEmissionLabels;
     filterOutInvalidAllophones_             = paramFilterOutInvalidAllophones(model->getConfiguration());
     fixAllophoneContextAtWordBoundaries_    = paramFixAllophoneContextAtWordBoundaries(model_->getConfiguration());
-    fixTdpLeavingEpsilonArc_                = paramFixTdpLeavingEpsilonArc(model_->getConfiguration());
     statistics_                             = new Statistics;
 }
 
@@ -651,13 +644,7 @@ Fsa::ConstAutomatonRef ClassicTransducerBuilder::applyTransitionModel(
     else if (ff->inputAlphabet() == emissions_)
         silenceLabel = model_->stateTyingRef_->classify(silenceState);
 
-    if (fixTdpLeavingEpsilonArc_){
-        return model_->transitionModel_->applyWithContext(ff, silenceLabel, (nDisambiguators_ == 0));
-    }
-
     return model_->transitionModel_->apply(ff, silenceLabel, (nDisambiguators_ == 0));
-
-
 }
 
 void ClassicTransducerBuilder::applyStateTying() {

--- a/src/Am/ClassicTransducerBuilder.hh
+++ b/src/Am/ClassicTransducerBuilder.hh
@@ -33,7 +33,6 @@ protected:  // configurable options
     } inputType_;
     bool filterOutInvalidAllophones_;
     bool fixAllophoneContextAtWordBoundaries_;
-    bool fixTdpLeavingEpsilonArc_;
 
 public:  // configurable options
     virtual void setDisambiguators(u32);

--- a/src/Am/ClassicTransducerBuilder.hh
+++ b/src/Am/ClassicTransducerBuilder.hh
@@ -33,6 +33,7 @@ protected:  // configurable options
     } inputType_;
     bool filterOutInvalidAllophones_;
     bool fixAllophoneContextAtWordBoundaries_;
+    bool fixTdpLeavingEpsilonArc_;
 
 public:  // configurable options
     virtual void setDisambiguators(u32);

--- a/src/Am/TransitionModel.hh
+++ b/src/Am/TransitionModel.hh
@@ -77,11 +77,13 @@ public:
         phone1,
         nStateTypes
     };
-    enum TyingType { global,
-                     globalPlusNonWord,
-                     cart };
-    enum ApplicatorType { LegacyBuggyApplicator,
-                          CorrectedApplicator };
+    enum TyingType {
+        global            = 1,
+        globalPlusNonWord = 2,
+        cart              = 3 };
+    enum ApplicatorType {
+        LegacyType    = 1,
+        Correctedtype = 2 };
 
     static Core::Choice          choiceTyingType;
     static Core::Choice          choiceApplicatorType;

--- a/src/Am/TransitionModel.hh
+++ b/src/Am/TransitionModel.hh
@@ -78,6 +78,7 @@ public:
         nStateTypes
     };
     class Applicator;
+    class ApplicatorWithContext;
 
 public:
     enum TyingType { global,
@@ -117,6 +118,11 @@ public:
     TransitionModel& operator+=(const TransitionModel& m);
 
     Fsa::ConstAutomatonRef apply(
+            Fsa::ConstAutomatonRef in,
+            Fsa::LabelId           silenceLabel,
+            bool                   applyExitTransitionToFinalStates) const;
+
+    Fsa::ConstAutomatonRef applyWithContext(
             Fsa::ConstAutomatonRef in,
             Fsa::LabelId           silenceLabel,
             bool                   applyExitTransitionToFinalStates) const;
@@ -225,6 +231,12 @@ public:
             Fsa::LabelId           silenceLabel,
             bool                   applyExitTransitionToFinalStates) const {
         return transitionModel_->apply(in, silenceLabel, applyExitTransitionToFinalStates);
+    }
+    Fsa::ConstAutomatonRef applyWithContext(
+            Fsa::ConstAutomatonRef in,
+            Fsa::LabelId           silenceLabel,
+            bool                   applyExitTransitionToFinalStates) const {
+        return transitionModel_->applyWithContext(in, silenceLabel, applyExitTransitionToFinalStates);
     }
     TransitionModel::StateType classify(AllophoneState phone, s8 subState = 0) const {
         return transitionModel_->classify(phone, subState);

--- a/src/Am/TransitionModel.hh
+++ b/src/Am/TransitionModel.hh
@@ -78,12 +78,12 @@ public:
         nStateTypes
     };
     enum TyingType {
-        global            = 1,
-        globalPlusNonWord = 2,
-        cart              = 3 };
+        global,
+        globalPlusNonWord,
+        cart};
     enum ApplicatorType {
-        LegacyType    = 1,
-        Correctedtype = 2 };
+        LegacyType,
+        Correctedtype,};
 
     static Core::Choice          choiceTyingType;
     static Core::Choice          choiceApplicatorType;

--- a/src/Am/TransitionModel.hh
+++ b/src/Am/TransitionModel.hh
@@ -77,14 +77,15 @@ public:
         phone1,
         nStateTypes
     };
-    enum TyingType {
-        global,
-        globalPlusNonWord,
-        cart};
-    enum ApplicatorType {
-        LegacyType,
-        Correctedtype,};
-
+    enum class TyingType {
+        GlobalTransitionModel       = 1,
+        NonWordAwareTransitionModel = 2,
+        CartTransitionModel         = 3
+    };
+    enum class ApplicatorType {
+        LegacyApplicator    = 1,
+        CorrectedApplicator = 2
+    };
     static Core::Choice          choiceTyingType;
     static Core::Choice          choiceApplicatorType;
     static Core::ParameterChoice paramTyingType;

--- a/src/Am/TransitionModel.hh
+++ b/src/Am/TransitionModel.hh
@@ -77,21 +77,21 @@ public:
         phone1,
         nStateTypes
     };
-    class Applicator;
-    class ApplicatorWithContext;
-
-public:
     enum TyingType { global,
                      globalPlusNonWord,
                      cart };
+    enum ApplicatorType { LegacyBuggyApplicator,
+                          CorrectedApplicator };
+
     static Core::Choice          choiceTyingType;
+    static Core::Choice          choiceApplicatorType;
     static Core::ParameterChoice paramTyingType;
+    static Core::ParameterChoice paramApplicatorType;
     static Core::ParameterString paramTdpValuesFile;
+
 
 protected:
     std::vector<StateTransitionModel*> transitionModels_;
-
-protected:
     void dump(Core::XmlWriter&) const;
 
 public:
@@ -118,11 +118,6 @@ public:
     TransitionModel& operator+=(const TransitionModel& m);
 
     Fsa::ConstAutomatonRef apply(
-            Fsa::ConstAutomatonRef in,
-            Fsa::LabelId           silenceLabel,
-            bool                   applyExitTransitionToFinalStates) const;
-
-    Fsa::ConstAutomatonRef applyWithContext(
             Fsa::ConstAutomatonRef in,
             Fsa::LabelId           silenceLabel,
             bool                   applyExitTransitionToFinalStates) const;
@@ -231,12 +226,6 @@ public:
             Fsa::LabelId           silenceLabel,
             bool                   applyExitTransitionToFinalStates) const {
         return transitionModel_->apply(in, silenceLabel, applyExitTransitionToFinalStates);
-    }
-    Fsa::ConstAutomatonRef applyWithContext(
-            Fsa::ConstAutomatonRef in,
-            Fsa::LabelId           silenceLabel,
-            bool                   applyExitTransitionToFinalStates) const {
-        return transitionModel_->applyWithContext(in, silenceLabel, applyExitTransitionToFinalStates);
     }
     TransitionModel::StateType classify(AllophoneState phone, s8 subState = 0) const {
         return transitionModel_->classify(phone, subState);


### PR DESCRIPTION
Given a static allophone Finite State Acceptor (FSA), the `ClassicTransducerBuilder`, applies the transition penalties on the arcs. The Fsa at this level makes use of Epsilon arcs in order to distinguish between different word ends, including silence. In the current implementation, any arc coming after Epsilon arc will have speech forward penalty. This means that after trimming the Epsilon arcs, the transition penalty for leaving silence and final speech state is always the respective exit penalties plus speech forward. This should be corrected in the `doExit()` function in order to subtract the speech forward and add the silence forward, when leaving silence.