### PR TITLE
Remove TreeSearch unpushedCoarticulatedRootStates assertion

### DIFF
--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -726,7 +726,7 @@ void StaticSearchAutomaton::buildBatches() {
         network.dumpDotGraph(paramDumpDotGraph(config), stateDepths);
 
     // Print some useful statistics about pushed and unpushed labels
-    verify(!network.unpushedCoarticulatedRootStates.empty());
+    // verify(!network.unpushedCoarticulatedRootStates.empty());
 
     u32 unpushedLabels = 0;
     u32 pushedLabels   = 0;

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -726,6 +726,7 @@ void StaticSearchAutomaton::buildBatches() {
         network.dumpDotGraph(paramDumpDotGraph(config), stateDepths);
 
     // Print some useful statistics about pushed and unpushed labels
+    // this assertion is not needed and leads to crashes. not clear why
     // verify(!network.unpushedCoarticulatedRootStates.empty());
 
     u32 unpushedLabels = 0;


### PR DESCRIPTION
When running a `AdvancedTreeSearchLmImageAndGlobalCacheJob` in a basic pipeline (cf. https://github.com/rwth-i6/i6_experiments/pull/74/) there is the following assertion error:

```cpp
PROGRAM DEFECTIVE:
assertion !network.unpushedCoarticulatedRootStates.empty() violated
in void Search::StaticSearchAutomaton::buildBatches() file SearchSpace.cc line 729
```

after speaking with @christophmluscher @Marvin84 and @SimBe195 I got told that this issue is known and commenting this out is a quick fix. Since other people might encouter this I am opening this PR as a draft so they can use the fix, but I am aware that this most likely is not the intended (full) fix.