### PR TITLE
Add remove-corpus-name-prefix parameter

### DIFF
--- a/src/Bliss/CorpusDescription.cc
+++ b/src/Bliss/CorpusDescription.cc
@@ -51,13 +51,13 @@ std::string NamedCorpusEntity::fullName() const {
         new_name = parent()->fullName() + "/" + name();
     else
         new_name = name();
-
     if (!removePrefix_.empty()) {
         auto res = std::mismatch(removePrefix_.begin(), removePrefix_.end(), new_name.begin());
         if (res.first == removePrefix_.end()){
             new_name = std::string(res.second, new_name.end());
         }
     }
+    return new_name;
 }
 
 // ========================================================================

--- a/src/Bliss/CorpusDescription.cc
+++ b/src/Bliss/CorpusDescription.cc
@@ -45,9 +45,12 @@ NamedCorpusEntity::NamedCorpusEntity(ParentEntity* _parent)
           name_(anonymous) {}
 
 std::string NamedCorpusEntity::fullName() const {
-    if (parent())
-        return parent()->fullName() + "/" + name();
-    else
+    if (parent()) {
+        if (parent()->fullName() == anonymous)
+            return name();
+        else
+            return parent()->fullName() + "/" + name();
+    } else
         return name();
 }
 

--- a/src/Bliss/CorpusDescription.cc
+++ b/src/Bliss/CorpusDescription.cc
@@ -42,16 +42,22 @@ const char* const NamedCorpusEntity::anonymous = "ANONYMOUS";
 
 NamedCorpusEntity::NamedCorpusEntity(ParentEntity* _parent)
         : parent_(_parent),
-          name_(anonymous) {}
+          name_(anonymous),
+          remove_prefix(std::string()) {}
 
 std::string NamedCorpusEntity::fullName() const {
-    if (parent()) {
-        if (parent()->fullName() == anonymous)
-            return name();
-        else
-            return parent()->fullName() + "/" + name();
-    } else
-        return name();
+    std::string new_name;
+    if (parent())
+        new_name = parent()->fullName() + "/" + name();
+    else
+        new_name = name();
+
+    if (!remove_prefix_.empty()) {
+        auto res = std::mismatch(remove_prefix_.begin(), remove_prefix_.end(), new_name.begin());
+        if (res.first == foo.end()){
+            new_name = std::string(res.second, new_name.end());
+        }
+    }
 }
 
 // ========================================================================

--- a/src/Bliss/CorpusDescription.cc
+++ b/src/Bliss/CorpusDescription.cc
@@ -43,7 +43,7 @@ const char* const NamedCorpusEntity::anonymous = "ANONYMOUS";
 NamedCorpusEntity::NamedCorpusEntity(ParentEntity* _parent)
         : parent_(_parent),
           name_(anonymous),
-          remove_prefix(std::string()) {}
+          removePrefix_(std::string()) {}
 
 std::string NamedCorpusEntity::fullName() const {
     std::string new_name;
@@ -52,9 +52,9 @@ std::string NamedCorpusEntity::fullName() const {
     else
         new_name = name();
 
-    if (!remove_prefix_.empty()) {
-        auto res = std::mismatch(remove_prefix_.begin(), remove_prefix_.end(), new_name.begin());
-        if (res.first == foo.end()){
+    if (!removePrefix_.empty()) {
+        auto res = std::mismatch(removePrefix_.begin(), removePrefix_.end(), new_name.begin());
+        if (res.first == removePrefix_.end()){
             new_name = std::string(res.second, new_name.end());
         }
     }

--- a/src/Bliss/CorpusDescription.hh
+++ b/src/Bliss/CorpusDescription.hh
@@ -44,7 +44,7 @@ class NamedCorpusEntity {
 private:
     ParentEntity*            parent_;
     std::string              name_;
-    std::string              removal_prefix_;
+    std::string              removePrefix_;
     static const char* const anonymous /*= "ANONYMOUS"*/;
 
 protected:
@@ -70,6 +70,10 @@ public:
         require(n != anonymous);
         require(n.empty() || (n[0] != '/' && n[n.size() - 1] != '/'));
         name_ = n;
+    }
+
+    void setRemovePrefix(const std::string& p) {
+        removePrefix_ = p;
     }
 
     bool isAnonymous() const {

--- a/src/Bliss/CorpusDescription.hh
+++ b/src/Bliss/CorpusDescription.hh
@@ -44,6 +44,7 @@ class NamedCorpusEntity {
 private:
     ParentEntity*            parent_;
     std::string              name_;
+    std::string              removal_prefix_;
     static const char* const anonymous /*= "ANONYMOUS"*/;
 
 protected:

--- a/src/Bliss/CorpusParser.cc
+++ b/src/Bliss/CorpusParser.cc
@@ -160,20 +160,16 @@ const Core::ParameterBool CorpusDescriptionParser::paramGemenizeTranscriptions(
         "convert all transcriptions to lower case: yes/no",
         false);
 
-const Core::ParameterBool CorpusDescriptionParser::paramIgnoreSuperCorpusName(
-        "ignore-super-corpus-name",
-        "if the top-level corpus name should be ignored. Can be useful to get the original names of merged corpora.",
-        false);
-
 const Core::ParameterBool CorpusDescriptionParser::paramProgress(
         "progress",
         "show progress meter",
         false);
 
-const Core::ParameterString CorpusDescriptionParser::paramRemovePrefix(
-        "remove_prefix",
-        "remove this prefix from all corpus full-names",
-        std::string());
+const Core::ParameterString CorpusDescriptionParser::paramRemoveCorpusNamePrefix(
+        "remove_corpus_name_prefix",
+        "remove this prefix from the corpus part full-names",
+        "",
+        "Remove this prefix from the top-level corpus and corpora for the full segment name. Can be useful to get the original names of merged corpora.");
 
 void CorpusDescriptionParser::initSchema() {
     XmlElement* conditionDesc        = collect(new ConditionDescriptionElement(
@@ -369,8 +365,8 @@ void CorpusDescriptionParser::startCorpus(const XmlAttributes atts) {
     else {
         verify(!superCorpus_);
         corpus_ = new Corpus();
-        if (!shallIgnoreSuperCorpusName_)
-            corpus_->setName(name);
+        corpus_->setName(name);
+        corpus_->setRemovePrefix(removeCorpusNamePrefix_);
         if (corpusVisitor_) {
             corpusVisitor_->enterCorpus(corpus_);
         }
@@ -395,6 +391,7 @@ void CorpusDescriptionParser::startSubcorpus(const XmlAttributes atts) {
     else {
         superCorpus_->reserveName(name);
         corpus_->setName(name);
+        corpus_->setRemovePrefix(removeCorpusNamePrefix_);
     }
 
     currentSection_ = corpus_;
@@ -736,8 +733,8 @@ int CorpusDescriptionParser::accept(const std::string& filename, CorpusVisitor* 
     corpusDir_                     = Core::directoryName(filename);
     audioDir_                      = paramAudioDir(config, corpusDir_);
     videoDir_                      = paramVideoDir(config, corpusDir_);
+    removeCorpusNamePrefix_        = paramRemoveCorpusNamePrefix(config);
     shallCaptializeTranscriptions_ = paramCaptializeTranscriptions(config);
     shallGemenizeTranscriptions_   = paramGemenizeTranscriptions(config);
-    shallIgnoreSuperCorpusName_    = paramIgnoreSuperCorpusName(config);
     return XmlParser::parseFile(filename.c_str());
 }

--- a/src/Bliss/CorpusParser.cc
+++ b/src/Bliss/CorpusParser.cc
@@ -160,6 +160,11 @@ const Core::ParameterBool CorpusDescriptionParser::paramGemenizeTranscriptions(
         "convert all transcriptions to lower case: yes/no",
         false);
 
+const Core::ParameterBool CorpusDescriptionParser::paramIgnoreSuperCorpusName(
+        "ignore-super-corpus-name",
+        "if the top-level corpus name should be ignored. Can be useful to get the original names of merged corpora.",
+        false);
+
 const Core::ParameterBool CorpusDescriptionParser::paramProgress(
         "progress",
         "show progress meter",
@@ -359,7 +364,8 @@ void CorpusDescriptionParser::startCorpus(const XmlAttributes atts) {
     else {
         verify(!superCorpus_);
         corpus_ = new Corpus();
-        corpus_->setName(name);
+        if (!shallIgnoreSuperCorpusName_)
+            corpus_->setName(name);
         if (corpusVisitor_) {
             corpusVisitor_->enterCorpus(corpus_);
         }
@@ -727,5 +733,6 @@ int CorpusDescriptionParser::accept(const std::string& filename, CorpusVisitor* 
     videoDir_                      = paramVideoDir(config, corpusDir_);
     shallCaptializeTranscriptions_ = paramCaptializeTranscriptions(config);
     shallGemenizeTranscriptions_   = paramGemenizeTranscriptions(config);
+    shallIgnoreSuperCorpusName_    = paramIgnoreSuperCorpusName(config);
     return XmlParser::parseFile(filename.c_str());
 }

--- a/src/Bliss/CorpusParser.cc
+++ b/src/Bliss/CorpusParser.cc
@@ -170,6 +170,11 @@ const Core::ParameterBool CorpusDescriptionParser::paramProgress(
         "show progress meter",
         false);
 
+const Core::ParameterString CorpusDescriptionParser::paramRemovePrefix(
+        "remove_prefix",
+        "remove this prefix from all corpus full-names",
+        std::string());
+
 void CorpusDescriptionParser::initSchema() {
     XmlElement* conditionDesc        = collect(new ConditionDescriptionElement(
             this, ConditionDescriptionElement::handler(&Self::defineCondition)));

--- a/src/Bliss/CorpusParser.cc
+++ b/src/Bliss/CorpusParser.cc
@@ -166,7 +166,7 @@ const Core::ParameterBool CorpusDescriptionParser::paramProgress(
         false);
 
 const Core::ParameterString CorpusDescriptionParser::paramRemoveCorpusNamePrefix(
-        "remove_corpus_name_prefix",
+        "remove-corpus-name-prefix",
         "remove this prefix from the corpus part full-names",
         "",
         "Remove this prefix from the top-level corpus and corpora for the full segment name. Can be useful to get the original names of merged corpora.");

--- a/src/Bliss/CorpusParser.hh
+++ b/src/Bliss/CorpusParser.hh
@@ -46,6 +46,7 @@ private:
     std::string    videoDir_;
     bool           shallCaptializeTranscriptions_;
     bool           shallGemenizeTranscriptions_;
+    bool           shallIgnoreSuperCorpusName_;
     bool           isSubParser_;
     Corpus *       superCorpus_, *corpus_;
     Recording*     recording_;
@@ -96,6 +97,7 @@ public:
     static const Core::ParameterString paramVideoDir;
     static const Core::ParameterBool   paramCaptializeTranscriptions;
     static const Core::ParameterBool   paramGemenizeTranscriptions;
+    static const Core::ParameterBool   paramIgnoreSuperCorpusName;
     static const Core::ParameterBool   paramProgress;
 
     CorpusDescriptionParser(const Core::Configuration&);

--- a/src/Bliss/CorpusParser.hh
+++ b/src/Bliss/CorpusParser.hh
@@ -44,9 +44,9 @@ private:
     std::string    corpusDir_;
     std::string    audioDir_;
     std::string    videoDir_;
+    std::string    removeCorpusNamePrefix_;
     bool           shallCaptializeTranscriptions_;
     bool           shallGemenizeTranscriptions_;
-    bool           shallIgnoreSuperCorpusName_;
     bool           isSubParser_;
     Corpus *       superCorpus_, *corpus_;
     Recording*     recording_;
@@ -95,9 +95,9 @@ private:
 public:
     static const Core::ParameterString paramAudioDir;
     static const Core::ParameterString paramVideoDir;
+    static const Core::ParameterString paramRemoveCorpusNamePrefix;
     static const Core::ParameterBool   paramCaptializeTranscriptions;
     static const Core::ParameterBool   paramGemenizeTranscriptions;
-    static const Core::ParameterBool   paramIgnoreSuperCorpusName;
     static const Core::ParameterBool   paramProgress;
 
     CorpusDescriptionParser(const Core::Configuration&);


### PR DESCRIPTION
This is a draft PR for code that allows to remove the top-level/super corpus name from the segment full-name. 

This can be used to merge bliss files using the subcorpora mode while at the same time just merging feature and alignment bundle files without the necessity to rename all entries and create new files.

I am open to better naming suggestions of the parameter.

~~I am also not sure if I can hijack the "anonymous" default value like that, but this seemed to be the easiest approach so far.~~