### PR TITLE
Fix 2 build issues

### DIFF
--- a/singularity/rasr.def
+++ b/singularity/rasr.def
@@ -16,8 +16,8 @@ Stage: rasr
     /opt/tensorflow/bazel_out/external/eigen_archive
     /opt/tensorflow/bazel_out/external/com_google_protobuf/src
     /opt/tensorflow/bazel_out/external/com_google_absl
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_cc.so.1.15.4
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_framework.so.1.15.4
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_cc.so.1.15.5
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_framework.so.1.15.5
 
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service.grpc.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service.pb.h
@@ -122,7 +122,7 @@ Stage: rasr
     ln -s /opt/tensorflow/bazel_out/external/com_google_absl         bazel-tensorflow/external/com_google_absl
 
     cd /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/
-    ln -s libtensorflow_cc.so.1.15.4        libtensorflow_cc.so
-    ln -s libtensorflow_cc.so.1.15.4        libtensorflow_cc.so.1
-    ln -s libtensorflow_framework.so.1.15.4 libtensorflow_framework.so
-    ln -s libtensorflow_framework.so.1.15.4 libtensorflow_framework.so.1
+    ln -s libtensorflow_cc.so.1.15.5        libtensorflow_cc.so
+    ln -s libtensorflow_cc.so.1.15.5        libtensorflow_cc.so.1
+    ln -s libtensorflow_framework.so.1.15.5 libtensorflow_framework.so
+    ln -s libtensorflow_framework.so.1.15.5 libtensorflow_framework.so.1

--- a/singularity/tensorflow.def
+++ b/singularity/tensorflow.def
@@ -24,9 +24,9 @@ Stage: tensorflow
     mkdir -p /opt/tensorflow/
     cd /opt/tensorflow/
 
-    wget https://github.com/tensorflow/tensorflow/archive/v1.15.4.tar.gz
-    tar xzvf v1.15.4.tar.gz
-    mv tensorflow-1.15.4 tensorflow
+    wget https://github.com/tensorflow/tensorflow/archive/v1.15.5.tar.gz
+    tar xzvf v1.15.5.tar.gz
+    mv tensorflow-1.15.5 tensorflow
 
     cat << EOF > /opt/tensorflow/tensorflow/.tf_configure.bazelrc
 build --host_force_python=PY3

--- a/src/Lm/QuantizedCompressedVectorFactory.cc
+++ b/src/Lm/QuantizedCompressedVectorFactory.cc
@@ -14,6 +14,10 @@
  */
 #include "QuantizedCompressedVectorFactory.hh"
 
+#ifdef __AVX__
+#include <immintrin.h>
+#endif
+
 namespace Lm {
 
 // --------------------------- QuantizedFloatVector ---------------------------


### PR DESCRIPTION
1. TF 1.15.4 dependencies no longer available (-> upgrade to 1.15.5)
2. Add missing header include for AVX capable hosts

I noticed this when I build the singularity image to test another PR for compilation.