### PR TITLE
Fix encoding issues when writing CART examples/trees

### DIFF
--- a/src/Cart/DecisionTree.cc
+++ b/src/Cart/DecisionTree.cc
@@ -193,6 +193,9 @@ void DecisionTree::Path::write(std::ostream& out) const {
 const Core::ParameterString DecisionTree::paramCartFilename(
         "decision-tree-file",
         "name of decision tree (aka cart) file");
+const Core::ParameterString DecisionTree::paramCartEncoding(
+        "encoding",
+        "encoding of the cart file");
 
 DecisionTree::DecisionTree(const Core::Configuration& config,
                            PropertyMapRef             map,
@@ -365,9 +368,10 @@ void DecisionTree::writeXml(Core::XmlWriter& xml, const std::string& name) const
 
 void DecisionTree::writeToFile() const {
     std::string filename(paramCartFilename(config));
+    std::string encoding(paramCartEncoding(config));
     if (!filename.empty()) {
         log() << "write decision tree to \"" << filename << "\"";
-        Core::XmlOutputStream xml(new Core::CompressedOutputStream(filename));
+        Core::XmlOutputStream xml(new Core::CompressedOutputStream(filename), encoding);
         xml.generateFormattingHints(true);
         xml.setIndentation(4);
         xml.setMargin(78);

--- a/src/Cart/DecisionTree.hh
+++ b/src/Cart/DecisionTree.hh
@@ -231,6 +231,7 @@ public:
     typedef std::stack<Node*>        NodePtrStack;
 
     static const Core::ParameterString paramCartFilename;
+    static const Core::ParameterString paramCartEncoding;
 
     // path of a classification
     struct Path {

--- a/src/Cart/Example.cc
+++ b/src/Cart/Example.cc
@@ -176,12 +176,11 @@ void ExampleList::writeToFile() const {
     std::string filename = paramExampleFilename(config);
     std::string encoding = paramExampleFileEncoding(config);
     if (!filename.empty()) {
-        log() << "write example list to \"" << filename << "\"";
-        Core::XmlOutputStream xml(new Core::CompressedOutputStream(filename));
+        log() << "write example list to \"" << filename << "\" with encoding \"" << encoding << "\"";
+        Core::XmlOutputStream xml(new Core::CompressedOutputStream(filename), encoding);
         xml.generateFormattingHints(true);
         xml.setIndentation(4);
         xml.setMargin(78);
-        xml.setEncoding(encoding);
         writeXml(xml);
     }
     else {


### PR DESCRIPTION
backported from AppTek codebase