### PR TITLE
Keep 0 depth roots in TreeBuilder during minimize

### DIFF
--- a/src/Search/AdvancedTreeSearch/TreeBuilder.hh
+++ b/src/Search/AdvancedTreeSearch/TreeBuilder.hh
@@ -233,6 +233,10 @@ protected:
 
     typedef Core::HashMap<StatePredecessor, Search::StateId, StatePredecessor::Hash> PredecessorsHash;
     PredecessorsHash                                                                 predecessors_;
+protected:
+    void updateHashFromMap(const std::vector<StateId>& map, const std::vector<u32>& exitMap);
+    void mapCoarticulationJointHash(CoarticulationJointHash& hash, const std::vector<StateId>& map, const std::vector<u32>& exitMap);
+    void mapSuccessors(const std::set<StateId>&, std::set<StateId>&, const std::vector<StateId>&, const std::vector<u32>&);
 };
 
 #endif


### PR DESCRIPTION
- Minimize function in TreeBuilder may remove 0-depth roots.
- This can lead to a violation of an assertion later (see https://github.com/rwth-i6/rasr/pull/27).
- These changes keep these roots around and fix the assertion issue.
- Even though they may not be needed at the moment, this can help extensions in the future if needed (e.g. dynamic lexicon update).
- Code is adapted from AppTek RASR.