### PR TITLE
Backport changes from the AppTek RASR fork

### DIFF
--- a/src/Am/AdaptedAcousticModel.cc
+++ b/src/Am/AdaptedAcousticModel.cc
@@ -148,4 +148,3 @@ bool AdaptedAcousticModel::setKey(const std::string& key) {
 
     return setFeatureScorer(featureScorer);
 }
-

--- a/src/Am/ClassicAcousticModel.cc
+++ b/src/Am/ClassicAcousticModel.cc
@@ -106,7 +106,7 @@ const Core::Choice ClassicAcousticModel::choiceStateTying(
         "none", noTying,
         "no-tying", noTying,
         "no-tying-dense", noTyingDense,
-        "diphone-no-tying-dense", diphoneNoStateTyingDense, 
+        "diphone-no-tying-dense", diphoneNoStateTyingDense,
         "monophone", monophoneTying,
         "lut", lutTying,
         "lookup", lutTying,

--- a/src/Am/ClassicStateModel.cc
+++ b/src/Am/ClassicStateModel.cc
@@ -72,8 +72,13 @@ const Core::ParameterString AllophoneAlphabet::paramStoreToFile(
         "");
 
 AllophoneAlphabet::AllophoneAlphabet(const Core::Configuration& config, ConstPhonologyRef phonology, Bliss::LexiconRef lexicon)
-        : Fsa::Alphabet(), Core::Component(config), phonology_(phonology), pi_(phonology->getPhonemeInventory()), isCrossWord_(phonology->isCrossWord()) {
-    nDisambiguators_     = 0;
+        : Fsa::Alphabet(),
+          Core::Component(config),
+          phonology_(phonology),
+          pi_(phonology->getPhonemeInventory()),
+          isCrossWord_(phonology->isCrossWord()),
+          nDisambiguators_(0),
+          storeToFile_(paramStoreToFile(config)) {
     std::string filename = paramAddFromFile(config);
     if (!filename.empty()) {
         load(filename);
@@ -90,7 +95,7 @@ AllophoneAlphabet::AllophoneAlphabet(const Core::Configuration& config, ConstPho
         log("%d allophones after adding all allophones",
             (int)allophones_.size());
     }
-    for (s32 p = 0; p < pi_->nPhonemes(); ++p) {
+    for (u32 p = 0; p < pi_->nPhonemes(); ++p) {
         std::string phoneme(pi_->phoneme(p + 1)->symbol());
         /* names of phonemes must not conflict with allophone specification
            syntax, otherwise allophone-mapping may fail */
@@ -106,11 +111,10 @@ AllophoneAlphabet::AllophoneAlphabet(const Core::Configuration& config, ConstPho
 }
 
 AllophoneAlphabet::~AllophoneAlphabet() {
-    std::string filename = paramStoreToFile(config);
-    if (!filename.empty()) {
+    if (!storeToFile_.empty()) {
         log("store %d allophones to \"%s\"",
-            (int)allophones_.size(), filename.c_str());
-        store(filename);
+            (int)allophones_.size(), storeToFile_.c_str());
+        store(storeToFile_);
     }
     clear();
 }

--- a/src/Am/ClassicStateModel.hh
+++ b/src/Am/ClassicStateModel.hh
@@ -128,6 +128,8 @@ private:
 
     mutable Fsa::LabelId nDisambiguators_;
 
+    const std::string storeToFile_;
+
 protected:
     /**
      *  takes ownership

--- a/src/Am/ClassicStateTying.cc
+++ b/src/Am/ClassicStateTying.cc
@@ -216,7 +216,7 @@ Mm::MixtureIndex NoStateTyingDense::classify(const AllophoneState& a) const {
 
     u32 phoneIdx = a.allophone()->phoneme(0);
     require_lt(phoneIdx, numPhoneClasses_);
-    result += phoneIdx;   
+    result += phoneIdx;
 
     result *= numStates_;
     result += u32(a.state());
@@ -232,9 +232,9 @@ Mm::MixtureIndex NoStateTyingDense::classify(const AllophoneState& a) const {
         result += phoneIdx;
     }
 
-    if (useBoundaryClasses_){ 
-      result *= numBoundaryClasses_;
-      result += a.allophone()->boundary;
+    if (useBoundaryClasses_) {
+        result *= numBoundaryClasses_;
+        result += a.allophone()->boundary;
     }
     require_lt(result, nClasses_);
 
@@ -259,7 +259,7 @@ DiphoneNoStateTyingDense::DiphoneNoStateTyingDense(const Core::Configuration& co
 
     if (classifyDumpChannel_.isOpen()) {
         dumpStateTying(classifyDumpChannel_);
-    }   
+    }
 }
 
 Mm::MixtureIndex DiphoneNoStateTyingDense::classify(const AllophoneState& a) const {
@@ -268,10 +268,10 @@ Mm::MixtureIndex DiphoneNoStateTyingDense::classify(const AllophoneState& a) con
     require_lt(u32(a.state()), numStates_);
     require_eq(contextLength_, 1);
     u32 result = 0;
-    
+
     u32 phoneIdx = a.allophone()->phoneme(0);
     require_lt(phoneIdx, numPhoneClasses_);
-    result += phoneIdx;   
+    result += phoneIdx;
 
     result *= numStates_;
     result += u32(a.state());
@@ -279,9 +279,9 @@ Mm::MixtureIndex DiphoneNoStateTyingDense::classify(const AllophoneState& a) con
     result *= numPhoneClasses_;
     phoneIdx = a.allophone()->phoneme(-1);
     require_lt(phoneIdx, numPhoneClasses_);
-    result += phoneIdx;   
+    result += phoneIdx;
 
-    if (useBoundaryClasses_) { 
+    if (useBoundaryClasses_) {
         result *= numBoundaryClasses_;
         result += a.allophone()->boundary;
     }

--- a/src/Am/ClassicStateTying.hh
+++ b/src/Am/ClassicStateTying.hh
@@ -166,7 +166,6 @@ class DiphoneNoStateTyingDense : public NoStateTyingDense {
 public:
     DiphoneNoStateTyingDense(const Core::Configuration& config, ClassicStateModelRef stateModel);
     virtual Mm::MixtureIndex classify(const AllophoneState& as) const;
-
 };
 
 // ============================================================================

--- a/src/Audio/Ffmpeg.cc
+++ b/src/Audio/Ffmpeg.cc
@@ -176,12 +176,12 @@ bool FfmpegInputNode::openFile_() {
 
     if (internal_->cdc_ctx->channels == 1) {
         // explicitly ask for mono-layout, as swresample can throw an error if the input channel layout is 0 (=default)
-        internal_->cdc_ctx->channel_layout = AV_CH_LAYOUT_MONO;
+        internal_->cdc_ctx->channel_layout         = AV_CH_LAYOUT_MONO;
         internal_->cdc_ctx->request_channel_layout = AV_CH_LAYOUT_MONO;
     }
     else if (internal_->cdc_ctx->channels == 2) {
         // explicitly ask for stereo-layout, as swresample can throw an error if the input channel layout is 0 (=default)
-        internal_->cdc_ctx->channel_layout = AV_CH_LAYOUT_STEREO;
+        internal_->cdc_ctx->channel_layout         = AV_CH_LAYOUT_STEREO;
         internal_->cdc_ctx->request_channel_layout = AV_CH_LAYOUT_STEREO;
     }
 

--- a/src/Audio/Node.hh
+++ b/src/Audio/Node.hh
@@ -92,34 +92,34 @@ private:
 
 protected:
     /** Set total number of sample in audio file.
-         * Call this function from openFile(), if you know the total
-         * length of the audio file.
-         * Note: One samples always means one sample per track! */
+     * Call this function from openFile(), if you know the total
+     * length of the audio file.
+     * Note: One samples always means one sample per track! */
     void setTotalSampleCount(SampleCount);
 
     /** Open audio file and read sample format.
-         * Implement this in concrete input nodes.
-         * @return true on success.  On failure call error() and
-         * return false. */
+     * Implement this in concrete input nodes.
+     * @return true on success.  On failure call error() and
+     * return false. */
     virtual bool openFile_() = 0;
 
     /** Set file position.
-         * Implement this in concrete file input nodes, iff seeking is
-         * possible.  Default implementation disallows seeking.
-         * @param newSamplePos number of next sample to be read,
-         * counted from beginning of stream
-         * @return true on success.  On failure call error() and
-         * return false. */
+     * Implement this in concrete file input nodes, iff seeking is
+     * possible.  Default implementation disallows seeking.
+     * @param newSamplePos number of next sample to be read,
+     * counted from beginning of stream
+     * @return true on success.  On failure call error() and
+     * return false. */
     virtual bool seek(SampleCount newSamplePos);
 
     /** Read at most @c nSamples samples from file.
-         * Implement this in concrete input nodes.
-         * @param nSamples number of samples to read
-         * @param d store pointer of new data packet here. If EOF or
-         * an error occurs d must be set to zero.
-         * @return number of samples read, may be less than @c nSamples.
-         * On failure call error() and return 0.
-         * Note: One samples always means one sample per track! */
+     * Implement this in concrete input nodes.
+     * @param nSamples number of samples to read
+     * @param d store pointer of new data packet here. If EOF or
+     * an error occurs d must be set to zero.
+     * @return number of samples read, may be less than @c nSamples.
+     * On failure call error() and return 0.
+     * Note: One samples always means one sample per track! */
     virtual u32 read(u32 nSamples, Flow::Timestamp*& d) = 0;
 
     /** @return is sample position of startTime_. */
@@ -154,7 +154,8 @@ public:
 };
 
 /** Abstract Flow node for audio output.
-        Forwards all input on its first output port. */
+ *  Forwards all input on its first output port.
+ */
 class SinkNode : public virtual Node {
     typedef Node Predecessor;
 

--- a/src/Cart/DecisionTree.cc
+++ b/src/Cart/DecisionTree.cc
@@ -77,7 +77,10 @@ ScalarQuestion::ScalarQuestion(PropertyMapRef     map,
           valueIndex_(map_->undefinedIndex) {
     verify(map_->isDefined(keyIndex_));
     valueIndex_ = (*map_)[keyIndex_][value];
-    verify(map_->isDefined(valueIndex_));
+    if (!map_->isDefined(valueIndex_)) {
+        std::cerr << "undefined phoneme in question: key='" << key << "' value='" << value << "' (" << desc << ")\n";
+        defect();
+    }
 }
 
 void ScalarQuestion::write(std::ostream& out) const {

--- a/src/Cart/Properties.cc
+++ b/src/Cart/Properties.cc
@@ -13,6 +13,7 @@
  *  limitations under the License.
  */
 #include "Properties.hh"
+#include "Core/Application.hh"
 
 #include <map>
 
@@ -42,8 +43,11 @@ void PropertyMap::set(const StringList&              keys,
     ListOfIndexedStringList::const_iterator valueIt;
     for (choicePtrIt = values_->begin(), valueIt = values.begin();
          choicePtrIt != values_->end(); ++choicePtrIt, ++valueIt) {
-        // it makes no sense to have only one possible answer
-        verify(valueIt->size() > 1);
+        verify(valueIt->size() > 0);
+        if (valueIt->size() == 1) {
+            int i = std::distance(values.begin(), valueIt);
+            Core::Application::us()->warning("The property %s has only one option: %s. If this is not done on purpose, please check your configurations.", (keys[i]).c_str(), ((*valueIt)[0].first).c_str());
+        }
         *choicePtrIt = new Choice(*valueIt);
     }
 }

--- a/src/Cart/check.cc
+++ b/src/Cart/check.cc
@@ -27,18 +27,10 @@ public:
     virtual std::string getUsage() const {
         return "short program to test Cart\n";
     }
-    int main(const std::vector<std::string>& arguments);
-} app;
-
-using namespace Cart;
-
-/*****************************************************************************/
-int TestApplication::main(const std::vector<std::string>& argv)
-/*****************************************************************************/
-{
-    require(!argv.empty());
-    DecisionTree dt(config);
-    return 0;
-}
+    int main(const std::vector<std::string>& arguments) {
+        Cart::DecisionTree dt(config);
+        return 0;
+    }
+};
 
 APPLICATION(TestApplication)

--- a/src/Core/Application.hh
+++ b/src/Core/Application.hh
@@ -118,6 +118,7 @@ protected:
     static bool                     setFromFile(const std::string& filename);
     static std::vector<std::string> setFromCommandline(const std::vector<std::string>& arguments);
     void                            runAtExitFuncs();
+    static bool                     setMaxStackSize(size_t new_size_in_mb);
 
 public:
     Application();
@@ -241,6 +242,9 @@ public:
      * The archive has to be configured through "archive-name.file=..." and "archive-name.read-only=..." configuration
      * */
     MappedArchiveWriter getCacheArchiveWriter(const std::string& archive_name, const std::string& item);
+
+    // update cacheArchives_ to reuse the I/O interface
+    void updateCacheArchive(const std::string& archive, const Core::Configuration& extraConfig, bool reset = false);
 
     /**
      * Main entry point for an application.

--- a/src/Core/Assertions.cc
+++ b/src/Core/Assertions.cc
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "Application.hh"
 #include "Debug.hh"
 
 using namespace Core;

--- a/src/Core/Component.hh
+++ b/src/Core/Component.hh
@@ -18,6 +18,7 @@
 #define _CORE_COMPONENT_HH
 
 #include <cstdarg>
+#include <ctime>
 #include "Channel.hh"
 #include "Choice.hh"
 #include "Configurable.hh"
@@ -81,6 +82,12 @@ protected:
         ErrorTypeCriticalError,
         nErrorTypes
     };
+    enum LogTimingMode {
+        LogTimingNo,
+        LogTimingYes,
+        LogTimingUnix,
+        LogTimingMilliseconds
+    };
 
 private:
     enum ErrorAction {
@@ -90,6 +97,7 @@ private:
     };
 
     static const Choice           errorActionChoice;
+    static const Choice           logTimingChoice;
     static const char*            errorNames[nErrorTypes];
     static const char*            errorChannelNames[nErrorTypes];
     static const Channel::Default errorChannelDefaults[nErrorTypes];
@@ -134,6 +142,16 @@ protected:
      * @return the channel the message was written to.
      **/
     virtual XmlChannel* vErrorMessage(ErrorType mt, const char* msg, va_list) const;
+
+    /**
+     * Child classes should be able to call this method explicitly because
+     * in some cases (see Application) the Configuration object is not
+     * available when the Component c'tor is called.
+     */
+    void          initializeTimeLogging(const Configuration& c);
+    LogTimingMode logTiming_;
+
+    std::string getTime(LogTimingMode mode) const;
 
 public:
     /**

--- a/src/Core/Configuration.cc
+++ b/src/Core/Configuration.cc
@@ -1008,6 +1008,17 @@ void Configuration::writeResolvedResources(XmlWriter& os) const {
     os << XmlFull("selection", getSelection());
 }
 
+std::vector<std::string> Configuration::writeResourcesToCommandlineArgs() const {
+    std::vector<std::string> res;
+    for (std::set<Resource>::const_iterator itResource = db_->getResources().begin();
+         itResource != db_->getResources().end();
+         ++itResource) {
+        res.push_back(std::string("--") + itResource->getName());
+        res.push_back(itResource->getValue());
+    }
+    return res;
+}
+
 void Configuration::writeUsage(XmlWriter& os) const {
     db_->writeUsage(os);
 }

--- a/src/Core/Configuration.hh
+++ b/src/Core/Configuration.hh
@@ -177,6 +177,11 @@ public:
     void writeResources(XmlWriter&) const;
 
     /**
+     * Return all configuration resources in command-line format
+     */
+    std::vector<std::string> writeResourcesToCommandlineArgs() const;
+
+    /**
      * Report how configuration ressources where used by which
      * parameters.
      **/

--- a/src/Core/Dependency.hh
+++ b/src/Core/Dependency.hh
@@ -102,8 +102,9 @@ public:
     unsigned int getChecksum() const {
         unsigned int ret = 0;
 
-        for (DependencySet::Dependencies::const_iterator d = dependencies_.begin(); d != dependencies_.end(); ++d)
+        for (DependencySet::Dependencies::const_iterator d = dependencies_.begin(); d != dependencies_.end(); ++d) {
             ret += d->second.getChecksum();
+        }
 
         return ret;
     }

--- a/src/Core/FileArchive.cc
+++ b/src/Core/FileArchive.cc
@@ -169,7 +169,8 @@ FileArchive::FileArchive(const Configuration& c, const std::string& p, AccessMod
     // create file archive if necessary
     open_ = false;
     struct stat64 fs;
-    if (stat64(path().c_str(), &fs) != 0) {
+    if (stat64(path().c_str(), &fs) != 0 ||
+        (stat64(path().c_str(), &fs) == 0 && fs.st_size == 0)) {
         // create new file archive
         if (access & AccessModeWrite) {
             createDirectory(directoryName(path()));

--- a/src/Core/Hash.hh
+++ b/src/Core/Hash.hh
@@ -25,19 +25,19 @@ namespace Core {
 
 template<class T>
 struct PointerHash {
-    size_t operator()(const T* p) const {
+    size_t operator()(const T* p) const noexcept {
         return reinterpret_cast<size_t>(p);
     }
 };
 
 struct StringHash {
-    size_t operator()(const char* s) const {
+    size_t operator()(const char* s) const noexcept {
         size_t result = 0;
         while (*s)
             result = 5 * result + size_t(*s++);
         return result;
     }
-    size_t operator()(const std::string& s) const {
+    size_t operator()(const std::string& s) const noexcept {
         return (*this)(s.c_str());
     }
 };

--- a/src/Core/IoUtilities.cc
+++ b/src/Core/IoUtilities.cc
@@ -48,4 +48,18 @@ bool writeLargeBlock(int fd, const char* buf, u64 count) {
     return count == 0;
 }
 
+std::string realPath(const std::string& filename) {
+    char  buff[PATH_MAX];
+    char* ret = ::realpath(filename.c_str(), buff);
+    if (ret) {
+        return std::string(buff);
+    }
+    else {
+        if (errno) {
+            std::cerr << "resolveSymlink failed (" << strerror(errno) << ")\n";
+            errno = 0;
+        }
+        return filename;  // safe fall back
+    }
+}
 }  // namespace Core

--- a/src/Core/IoUtilities.hh
+++ b/src/Core/IoUtilities.hh
@@ -17,10 +17,13 @@
 
 #include <Core/Types.hh>
 #include <algorithm>
+#include <cerrno>
 #include <iostream>
 #include <list>
 #include <set>
 #include <vector>
+#include <limits.h>
+#include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -111,6 +114,10 @@ ListWriter<typename std::list<T>::const_iterator> str(const std::list<T>& v, con
  */
 bool writeLargeBlock(int fd, const char* buf, u64 count);
 
+/**
+ * Similar to Linux' readlink -f
+ */
+std::string realPath(const std::string& filename);
 }  // namespace Core
 
 inline std::ostream& operator<<(std::ostream& out, const Core::OStreamWriter& w) {

--- a/src/Core/MappedArchive.hh
+++ b/src/Core/MappedArchive.hh
@@ -277,7 +277,7 @@ public:
 
     template<class T>
     void readVector(std::vector<T>& vec) {
-        u64 size;
+        u64 size = 0ul;
         readValue<u64>(size);
 
         if (!good() || get()->offset_ + sizeof(T) * size > get()->initialOffset_ + get()->size_) {
@@ -292,7 +292,7 @@ public:
 
     template<class T>
     void readVectorVector(std::vector<std::vector<T>>& vectors) {
-        u32 nVectors;
+        u32 nVectors = 0u;
         readValue(nVectors);
         vectors.resize(nVectors);
 
@@ -302,7 +302,7 @@ public:
 
     template<class T>
     void readVector(ConstantVector<T>& vec) {
-        u64 size;
+        u64 size = 0ul;
         readValue<u64>(size);
 
         if (!good() || get()->offset_ + sizeof(T) * size > get()->initialOffset_ + get()->size_) {

--- a/src/Core/Obstack.hh
+++ b/src/Core/Obstack.hh
@@ -136,7 +136,7 @@ public:
     void grow(const Item& i, size_t n) {
         require(begin_);
         provide(n);
-        current_->tail = uninitialized_fill_n(current_->tail, n, i);
+        current_->tail = std::uninitialized_fill_n(current_->tail, n, i);
         new (current_->tail++) Item(i);
     }
 
@@ -144,7 +144,7 @@ public:
         require(begin_);
         require(begin <= end);
         provide(end - begin);
-        current_->tail = uninitialized_copy(begin, end, current_->tail);
+        current_->tail = std::uninitialized_copy(begin, end, current_->tail);
     }
 
     void grow0(const Item* begin, const Item* end) {

--- a/src/Core/ProgressIndicator.cc
+++ b/src/Core/ProgressIndicator.cc
@@ -220,7 +220,7 @@ void ProgressIndicator::sigWinchHandler(int sig) {
 
 ProgressIndicator::ProgressIndicator(const std::string& task,
                                      const std::string& unit)
-        : align_(Left), task_(task), unit_(unit), isVisible_(false), draw(0), write_return_val_(0) {}
+        : align_(Left), task_(task), unit_(unit), done_(0), isVisible_(false), draw(0), write_return_val_(0) {}
 
 ProgressIndicator::~ProgressIndicator() {
     if (activeInstance == this)

--- a/src/Core/ReferenceCounting.hh
+++ b/src/Core/ReferenceCounting.hh
@@ -17,8 +17,8 @@
 #ifndef _CORE_REFERENCE_COUNTING
 #define _CORE_REFERENCE_COUNTING
 
-#include <unordered_set>
 #include <memory>
+#include <unordered_set>
 
 #include "Assertions.hh"
 #include "Types.hh"
@@ -45,7 +45,7 @@ private:
 
     using WeakRefSet = std::unordered_set<WeakRefBase*>;
 
-    mutable u32 referenceCount_;
+    mutable u32                         referenceCount_;
     mutable std::unique_ptr<WeakRefSet> weak_refs_;
 
     explicit ReferenceCounted(u32 rc)

--- a/src/Core/Singleton.hh
+++ b/src/Core/Singleton.hh
@@ -33,7 +33,9 @@ private:
     struct StaticHolder {
         Instance* instance_;  // will be inited with zero (because it's static)
         ~StaticHolder() {
-            delete instance_;
+            if (instance_) {
+                delete instance_;
+            }
         }
     };
 

--- a/src/Core/StringUtilities.cc
+++ b/src/Core/StringUtilities.cc
@@ -197,3 +197,13 @@ bool Core::startsWith(const std::string& string, const std::string& search) {
     }
     return true;
 }
+
+void Core::replaceAll(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty())
+        return;
+    std::string::size_type start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length();
+    }
+}

--- a/src/Core/StringUtilities.hh
+++ b/src/Core/StringUtilities.hh
@@ -109,6 +109,11 @@ std::vector<std::string> split(const std::string& string, const std::string& sep
 bool startsWith(const std::string& string, const std::string& search);
 
 /**
+ * Replaces all occurrences of 'from' by 'to' in 'str'.
+ */
+void replaceAll(std::string& str, const std::string& from, const std::string& to);
+
+/**
  * Convinient functions to parse strings.
  *
  * returns true on successful conversion;

--- a/src/Core/Unicode.hh
+++ b/src/Core/Unicode.hh
@@ -16,6 +16,7 @@
 #define _CORE_UNICODE_HH
 
 #include <functional>
+#include <mutex>
 #include <string>
 #include <iconv.h>
 #include "Assertions.hh"
@@ -118,9 +119,10 @@ const char* const defaultEncoding = "ISO-8859-1";
 
 class CharsetConverter {
 protected:
-    iconv_t iconvHandle_;
-    size_t  nErrors_;
-    void    deactivate();
+    mutable std::mutex iconv_mutex_;
+    iconv_t            iconvHandle_;
+    size_t             nErrors_;
+    void               deactivate();
 
 public:
     CharsetConverter() {
@@ -133,6 +135,7 @@ public:
     }
 
     bool isConversionActive() const {
+        std::lock_guard<std::mutex> lock(iconv_mutex_);
         return iconvHandle_ != (iconv_t)-1;
     }
     size_t nErrors() const {

--- a/src/Core/XmlStream.cc
+++ b/src/Core/XmlStream.cc
@@ -108,12 +108,14 @@ void XmlWriter::putDeclaration(const std::string& encoding) {
 void XmlWriter::putTag(const XmlOpen& open, bool isEmpty) {
     os_ << "<" << open.element_;
     for (std::vector<XmlAttribute>::const_iterator a = open.attributes_.begin(); a != open.attributes_.end(); ++a) {
-        os_ << " ";
-        formattingHint(TextOutputStream::protect);
-        os_ << a->name_ << "=\"";
-        putEscaped(a->value_, "&<>\"'");
-        os_ << "\"";
-        formattingHint(TextOutputStream::unprotect);
+        if (!a->name_.empty()) {
+            os_ << " ";
+            formattingHint(TextOutputStream::protect);
+            os_ << a->name_ << "=\"";
+            putEscaped(a->value_, "&<>\"'");
+            os_ << "\"";
+            formattingHint(TextOutputStream::unprotect);
+        }
     }
     if (isEmpty)
         os_ << "/";
@@ -204,6 +206,14 @@ XmlOutputStream::XmlOutputStream()
 XmlOutputStream::XmlOutputStream(std::ostream* os)
         : XmlWriter(textOutputStream_),
           textOutputStream_(os) {
+    generateFormattingHints(true);
+    putDeclaration();
+}
+
+XmlOutputStream::XmlOutputStream(std::ostream* os, const std::string& encoding)
+        : XmlWriter(textOutputStream_),
+          textOutputStream_(os) {
+    setEncoding(encoding);
     generateFormattingHints(true);
     putDeclaration();
 }

--- a/src/Core/XmlStream.hh
+++ b/src/Core/XmlStream.hh
@@ -44,12 +44,30 @@ protected:
     std::string name_, value_;
 
 public:
+    using manipulator = std::ios_base& (*)(std::ios_base&);
+
     XmlAttribute(){};
     template<typename V>
     XmlAttribute(const std::string& name, const V& value) {
         name_ = name;
         std::ostringstream ss;
         ss << value;
+        value_ = ss.str();
+    }
+
+    template<typename V>
+    XmlAttribute(const std::string& name, const V& value, const int precision) {
+        name_ = name;
+        std::ostringstream ss;
+        ss << std::setprecision(precision) << value;
+        value_ = ss.str();
+    }
+
+    template<typename V>
+    XmlAttribute(const std::string& name, const V& value, const int precision, manipulator m) {
+        name_ = name;
+        std::ostringstream ss;
+        ss << m << std::setprecision(precision) << value;
         value_ = ss.str();
     }
 };
@@ -332,10 +350,14 @@ private:
 public:
     XmlOutputStream();
     XmlOutputStream(std::ostream*);
+    XmlOutputStream(std::ostream*, const std::string& encoding);
     XmlOutputStream(const std::string& filename, int mode = 0);
     void open(const std::string& filename, int mode = 0);
     void close() {
         textOutputStream_.close();
+    }
+    void flush() {
+        textOutputStream_.flush();
     }
     virtual ~XmlOutputStream();
 

--- a/src/Core/atomicops.h
+++ b/src/Core/atomicops.h
@@ -1,4 +1,4 @@
-﻿// ©2013-2016 Cameron Desrochers.
+// (c)2013-2016 Cameron Desrochers.
 // Distributed under the simplified BSD license (see the license file that
 // should have come with this header).
 // Uses Jeff Preshing's semaphore implementation (under the terms of its

--- a/src/Core/readerwriterqueue.h
+++ b/src/Core/readerwriterqueue.h
@@ -1,4 +1,4 @@
-// ©2013-2016 Cameron Desrochers.
+// (c)2013-2016 Cameron Desrochers.
 // Distributed under the simplified BSD license (see the license file that
 // should have come with this header).
 

--- a/src/Flf/Makefile
+++ b/src/Flf/Makefile
@@ -96,7 +96,7 @@ CHECK_O 	+= libSprintFlf.$(a) \
 
 # -----------------------------------------------------------------------------
 
-all: $(TARGETS)
+all: $(TARGETS) $(SUBDIRS)
 
 .PHONY: $(SUBDIRS)
 
@@ -106,7 +106,7 @@ FlfCore:
 FlfExt:
 	$(MAKE) -C FlfExt libSprintFlfExt.$(a)
 
-libSprintFlf.$(a): $(SUBDIRS) $(LIBSPRINTFLF_O)
+libSprintFlf.$(a): $(LIBSPRINTFLF_O)
 	$(MAKELIB) $@ $(LIBSPRINTFLF_O)
 
 check$(exe): $(CHECK_O)

--- a/src/Test/Core_StringUtilities.cc
+++ b/src/Test/Core_StringUtilities.cc
@@ -74,4 +74,37 @@ TEST(Core, StringUtilities, Form) {
     EXPECT_EQ(c, string("10 1.2345"));
 }
 
+TEST(Core, StringUtilities, ReplaceAll) {
+    string haystack = "abc";
+    replaceAll(haystack, "a", "x");
+    EXPECT_EQ(haystack, string("xbc"));
+
+    haystack = "abaaca";
+    replaceAll(haystack, "a", "x");
+    EXPECT_EQ(haystack, string("xbxxcx"));
+
+    haystack = "abaaca";
+    replaceAll(haystack, "a", "");
+    EXPECT_EQ(haystack, string("bc"));
+
+    haystack = "abaaca";
+    replaceAll(haystack, "a", "xx");
+    EXPECT_EQ(haystack, string("xxbxxxxcxx"));
+
+    haystack = "abaaca";
+    replaceAll(haystack, "", "xxx");
+    EXPECT_EQ(haystack, string("abaaca"));
+
+    haystack = "aa";
+    replaceAll(haystack, "aa", "");
+    EXPECT_EQ(haystack, string(""));
+
+    haystack = "aa";
+    replaceAll(haystack, "aaa", "");
+    EXPECT_EQ(haystack, string("aa"));
+
+    haystack = "aa";
+    replaceAll(haystack, "aa", "bbb");
+    EXPECT_EQ(haystack, string("bbb"));
+}
 }  // namespace Core


### PR DESCRIPTION
Many cosmetic changes / helper function. One important change is the addition of a new constructor for `XmlOutputStream`. This change is needed for https://github.com/rwth-i6/rasr/pull/31 , otherwise RASR does not compile. Fixes #33 