### PR TITLE
Fix TransitionModel Applicator memory leak

### DIFF
--- a/src/Am/TransitionModel.cc
+++ b/src/Am/TransitionModel.cc
@@ -175,6 +175,8 @@ public:
     Fsa::ConstAlphabetRef alphabet_;
     Fsa::LabelId          silenceLabel_;
     bool                  applyExitTransitionToFinalStates_;
+
+    virtual ~Applicator() = default;
 };
 
 template<class AppState>


### PR DESCRIPTION
With the refactoring in #14 the `Applicator` class was introduced in `Am/TransitionModel.cc`. In the `Am::TransitionModel::apply` function, a `std::unique_ptr<Applicator> ap` is created and set with either a `new LegacyApplicator` or `new CorrectedApplicator` afterwards, depending on the configuration.

However, `Applicator` did not have a virtual destructor, so since `ap` is an `Applicator` pointer, only the `Applicator` destructor is called after the function even though the actual object pointed to by `ap` is of type `LegacyApplicator` or `CorrectedApplicator`. This leads to a memory leak. See [here](https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP52-CPP.+Do+not+delete+a+polymorphic+object+without+a+virtual+destructor).

This PR fixes that memory leak by simply adding a virtual default destructor to the `Applicator` class.