### PR TITLE
Connect word ends to initial state for context-independent allophones

### DIFF
--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -155,10 +155,12 @@ ClassicTransducerBuilder::ClassicTransducerBuilder(Core::Ref<
     fixAllophoneContextAtWordBoundaries_    = paramFixAllophoneContextAtWordBoundaries(model_->getConfiguration());
     statistics_                             = new Statistics;
 
-    if ( model_->phonology()->maximumHistoryLength() == 0 && model_->phonology()->maximumFutureLength() == 0 )
-      linkWordEndStart_ = true;
-    else
-      linkWordEndStart_ = false;
+    if (model_->phonology()->maximumHistoryLength() == 0 && model_->phonology()->maximumFutureLength() == 0) {
+        linkWordEndStart_ = true;
+    }
+    else {
+        linkWordEndStart_ = false;
+    }
 }
 
 ClassicTransducerBuilder::~ClassicTransducerBuilder() {

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -155,7 +155,6 @@ ClassicTransducerBuilder::ClassicTransducerBuilder(Core::Ref<
     fixAllophoneContextAtWordBoundaries_    = paramFixAllophoneContextAtWordBoundaries(model_->getConfiguration());
     statistics_                             = new Statistics;
 
-    // TODO make unique endState (including [SILENCE] ...)
     if ( model_->phonology()->maximumHistoryLength() == 0 && model_->phonology()->maximumFutureLength() == 0 )
       linkWordEndStart_ = true;
     else

--- a/src/Am/ClassicTransducerBuilder.cc
+++ b/src/Am/ClassicTransducerBuilder.cc
@@ -154,6 +154,12 @@ ClassicTransducerBuilder::ClassicTransducerBuilder(Core::Ref<
     filterOutInvalidAllophones_             = paramFilterOutInvalidAllophones(model->getConfiguration());
     fixAllophoneContextAtWordBoundaries_    = paramFixAllophoneContextAtWordBoundaries(model_->getConfiguration());
     statistics_                             = new Statistics;
+
+    // TODO make unique endState (including [SILENCE] ...)
+    if ( model_->phonology()->maximumHistoryLength() == 0 && model_->phonology()->maximumFutureLength() == 0 )
+      linkWordEndStart_ = true;
+    else
+      linkWordEndStart_ = false;
 }
 
 ClassicTransducerBuilder::~ClassicTransducerBuilder() {
@@ -244,11 +250,16 @@ void ClassicTransducerBuilder::setupWordStart(Fsa::State* s, const PhoneBoundary
 }
 
 void ClassicTransducerBuilder::setupWordEnd(Fsa::State* s, const PhoneBoundaryStateDescriptor& pbsd) {
-    if (acceptCoarticulatedSinglePronunciation_) {
+    if ( linkWordEndStart_ ) {
+        Fsa::StateId initialId = product_->initialStateId();
+        if ( initialId != Fsa::InvalidStateId ) {
+            Fsa::State* initial = product_->fastState(initialId);
+            buildWordBoundaryLinks(s, initial);
+        }
+    } else if (acceptCoarticulatedSinglePronunciation_) {
         s->addTags(Fsa::StateTagFinal);
         s->weight_ = product_->semiring()->one();
-    }
-    else {
+    } else {
         PhoneBoundaryStateDescriptor pbsd2(pbsd);
         pbsd2.flag &= ~wordEnd;
         pbsd2.flag |= wordStart;

--- a/src/Am/ClassicTransducerBuilder.hh
+++ b/src/Am/ClassicTransducerBuilder.hh
@@ -34,6 +34,9 @@ protected:  // configurable options
     bool filterOutInvalidAllophones_;
     bool fixAllophoneContextAtWordBoundaries_;
 
+    // for context-independent allophones
+    bool linkWordEndStart_;
+
 public:  // configurable options
     virtual void setDisambiguators(u32);
 


### PR DESCRIPTION
For context-independent allophones (i.e. history_length = future_length = 0) the word-end states were not connected to the initial state in the `ClassicTransducerBuilder` which results in a broken automaton and a crash during training with `fast_bw` loss (e. g. CTC).
A fix for this behaviour had already been implemented in the original `label_sync_decoding` branch of @ZhouW321 but was missed when porting to github RASR. This PR re-applies the original fix.