### PR TITLE
Update to Tensorflow 2.12.0 and Ubuntu 22.04 and C++17

### DIFF
--- a/config/cc-gcc.make
+++ b/config/cc-gcc.make
@@ -26,7 +26,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=gnu++0x
+CXXFLAGS	+= -std=c++17
 CXXFLAGS	+= -Wno-unknown-pragmas
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall

--- a/config/os-linux.make
+++ b/config/os-linux.make
@@ -109,7 +109,7 @@ endif
 endif
 
 ifdef MODULE_CUDA
-CUDAROOT    = /usr/local/cuda-7.0
+CUDAROOT    = /usr/local/cuda-11.8
 INCLUDES    += -I$(CUDAROOT)/include/
 LDFLAGS     += -L$(CUDAROOT)/lib64/ -lcublas -lcudart -lcurand
 NVCC        = $(CUDAROOT)/bin/nvcc

--- a/config/os-linux.make
+++ b/config/os-linux.make
@@ -151,11 +151,8 @@ INCLUDES    += `${PYTHON_PATH}/bin/python3-config --includes 2>/dev/null`
 LDFLAGS     += `${PYTHON_PATH}/bin/python3-config --ldflags 2>/dev/null`
 LDFLAGS     += -Wl,-rpath -Wl,${PYTHON_PATH}/lib
 else
-INCLUDES    += `python3-config --includes 2>/dev/null`
-LDFLAGS     += `python3-config --ldflags 2>/dev/null`
-# IF you want to use Python2 for whatever reason:
-# INCLUDES    += `pkg-config --cflags python`
-# LDFLAGS     += `pkg-config --libs python`
+INCLUDES    += $(shell python3-config --includes 2>/dev/null || pkg-config --cflags python3)
+LDFLAGS     += $(shell python3-config --ldflags --embed | grep -v Usage || $(PYTHON_CONFIG) --libs 2>/dev/null || pkg-config --libs python3)
 endif
 endif
 

--- a/singularity/rasr.def
+++ b/singularity/rasr.def
@@ -6,95 +6,178 @@ Stage: tensorflow
     echo "Importing tensorflow container"
 
 Bootstrap: library
-From: ubuntu:18.04
+From: ubuntu:22.04
 Stage: rasr
 
 %files from tensorflow
-    /opt/cuda
     /opt/tensorflow/tensorflow/tensorflow
     /opt/tensorflow/tensorflow/third_party
     /opt/tensorflow/bazel_out/external/eigen_archive
     /opt/tensorflow/bazel_out/external/com_google_protobuf/src
     /opt/tensorflow/bazel_out/external/com_google_absl
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_cc.so.1.15.5
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_framework.so.1.15.5
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_cc.so.2.12.0
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/libtensorflow_framework.so.2.12.0
 
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/distribute/experimental/rpc/proto/tf_rpc_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/distribute/experimental/rpc/proto/tf_rpc_service_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/distribute/experimental/rpc/proto/tf_rpc_service.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/profile.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_output.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_log.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/protobuf/xplane.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/profiler_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service_mock.grpc.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debug_service.grpc.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/debug/debugger_event_metadata.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/example/example.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/example/example_parser_configuration.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/test_log.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/saved_tensor_slice.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/autotune_maps/conv_parameters.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/memmapped_file_system.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/event.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/quantization/uniform_quant_ops_attr.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/eager_service_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/tpu_embedding_configuration.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/optimization_parameters.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/topology.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/compile_metadata.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/dynamic_padding.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/error_codes.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saved_object_graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/control_flow.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/worker.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tensor_bundle.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/named_tensor.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/snapshot.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/rpc_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/data_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/core_platform_payloads.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/cluster.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/meta_graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/graph_debug_info.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saver.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/debug.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/composite_tensor_variant.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/autotuning.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saved_model.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/transport_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/rewriter_config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/verifier_config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tensorflow_server.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/device_filters.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/fingerprint.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/eager_service.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/service_config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/trackable_object_graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/master.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/bfc_memory_map.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/debug_event.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/eager_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/struct.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/remote_tensor_handle.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/queue_runner.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/conv_autotuning.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/device_properties.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/lib/core/error_codes.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/dispatcher_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/worker.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/export.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/common.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/worker.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/journal.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/worker_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/dispatcher.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/data/service/dispatcher.grpc.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/example/feature.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/example/example_parser_configuration.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/example/example.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/variable.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/allocation_description.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/api_def.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/attr_value.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/cost_graph.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/device_attributes.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/function.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/graph.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/graph_transfer_info.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/kernel_def.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/log_memory.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/node_def.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/op_def.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/reader_base.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/remote_fused_graph_execute_info.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/resource_handle.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/step_stats.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/summary.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor_description.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor_shape.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor_slice.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/types.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/variable.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/dataset_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/log_memory.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/versions.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/graph_transfer_info.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/step_stats.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/full_type.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/dataset_metadata.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor_slice.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/optimized_function_graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/function.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/api_def.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/attr_value.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/model.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/op_def.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/kernel_def.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/resource_handle.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/summary.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/node_def.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/dataset.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/reader_base.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/cost_graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/graph.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/device_attributes.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/framework/tensor_shape.pb.h
     /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/grappler/costs/op_performance_data.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/kernels/boosted_trees/boosted_trees.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/lib/core/error_codes.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/profile.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_log.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_options.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/profiler/tfprof_output.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/autotuning.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/cluster.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/config.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/control_flow.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/conv_autotuning.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/data/experimental/snapshot.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/debug.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/device_properties.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/eager_service.grpc.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/eager_service.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/graph_debug_info.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/master.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/meta_graph.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/named_tensor.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/queue_runner.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/rewriter_config.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saved_model.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saved_object_graph.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/saver.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/struct.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tensor_bundle.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tensorflow_server.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/optimization_parameters.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/tpu_embedding_configuration.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/tpu/tpu_embedding_output_layout.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/trace_events.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/trackable_object_graph.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/transport_options.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/verifier_config.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/protobuf/worker.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/event.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/memmapped_file_system.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/saved_tensor_slice.pb.h
-    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/core/util/test_log.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profile.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_service.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_analysis_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_analysis.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_analysis.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_service_monitor_result.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/xplane.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_service_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/profiler/protobuf/profiler_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/error_codes.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/rpc_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/test_log.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/autotuning.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/histogram.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/coordination_service.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/distributed_runtime_payloads.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/coordination_service.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/coordination_config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/coordination_service_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/bfc_memory_map.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/tsl/protobuf/dnn.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/dtensor/proto/layout.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/tf2xla/kernels/callback.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/tf2xla/tf2xla.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/tf2xla/host_compute_metadata.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/xla_data.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/xla_mock.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/xla.grpc.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/pjrt/compile_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/stream_executor/device_description.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/stream_executor/dnn.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/xla.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir/tools/mlir_replay/public/compiler_trace.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/cpu/xla_framework.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/cpu/backend_config.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/cpu/executable.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/metrics.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/gpu/backend_configs.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/gpu/executable.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/gpu/gpu_autotuning.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/hlo.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/hlo_profile_printer_data.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/hlo_execution_profile_data.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/autotune_results.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/mlir/tools/kernel_gen/compile_cache_item.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/mlir/quantization/tensorflow/exported_model.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/mlir/quantization/tensorflow/quantization_options.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/jit/xla_activity.pb.h
+    /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/jit/xla_compilation_cache.pb.h
 
 %post
     export OPENFST_VERSION=1.6.3
 
-    echo "deb http://us.archive.ubuntu.com/ubuntu bionic universe" >> /etc/apt/sources.list
+    echo "deb http://us.archive.ubuntu.com/ubuntu jammy universe" >> /etc/apt/sources.list
     apt update -y
     apt upgrade -y
 
@@ -122,7 +205,7 @@ Stage: rasr
     ln -s /opt/tensorflow/bazel_out/external/com_google_absl         bazel-tensorflow/external/com_google_absl
 
     cd /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/
-    ln -s libtensorflow_cc.so.1.15.5        libtensorflow_cc.so
-    ln -s libtensorflow_cc.so.1.15.5        libtensorflow_cc.so.1
-    ln -s libtensorflow_framework.so.1.15.5 libtensorflow_framework.so
-    ln -s libtensorflow_framework.so.1.15.5 libtensorflow_framework.so.1
+    ln -s libtensorflow_cc.so.2.12.0        libtensorflow_cc.so
+    ln -s libtensorflow_cc.so.2.12.0        libtensorflow_cc.so.1
+    ln -s libtensorflow_framework.so.2.12.0 libtensorflow_framework.so
+    ln -s libtensorflow_framework.so.2.12.0 libtensorflow_framework.so.1

--- a/singularity/rasr.def
+++ b/singularity/rasr.def
@@ -206,6 +206,6 @@ Stage: rasr
 
     cd /opt/tensorflow/bazel_out/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/
     ln -s libtensorflow_cc.so.2.12.0        libtensorflow_cc.so
-    ln -s libtensorflow_cc.so.2.12.0        libtensorflow_cc.so.1
+    ln -s libtensorflow_cc.so.2.12.0        libtensorflow_cc.so.2
     ln -s libtensorflow_framework.so.2.12.0 libtensorflow_framework.so
-    ln -s libtensorflow_framework.so.2.12.0 libtensorflow_framework.so.1
+    ln -s libtensorflow_framework.so.2.12.0 libtensorflow_framework.so.2

--- a/singularity/tensorflow.def
+++ b/singularity/tensorflow.def
@@ -11,20 +11,6 @@ Stage: tensorflow
 
     update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 
-    #CMake
-    version=3.25
-    build=1
-    cmake_dir=$(mktemp -d)
-    cd $cmake_dir
-    wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
-    tar -xzvf cmake-$version.$build.tar.gz
-    cd cmake-$version.$build/
-    ./bootstrap
-    make -j$(nproc)
-    make install
-    cd /opt
-    rm -rf $cmake_dir
-
     mkdir -p /opt/cuda/
     cd /opt/cuda
 

--- a/singularity/tensorflow.def
+++ b/singularity/tensorflow.def
@@ -81,7 +81,7 @@ EOF
 
     mkdir -p /opt/tensorflow/bazel_out/
     cd /opt/tensorflow/tensorflow
-    bazel --output_base=/opt/tensorflow/bazel_out build --local_cpu_resources=6 --config=opt --config=nogcp //tensorflow:libtensorflow_cc.so //tensorflow:libtensorflow.so
+    bazel --output_base=/opt/tensorflow/bazel_out build --config=opt --config=nogcp //tensorflow:libtensorflow_cc.so //tensorflow:libtensorflow.so
 
     #Cleanup
     rm -rf /opt/cuda

--- a/singularity/tensorflow.def
+++ b/singularity/tensorflow.def
@@ -1,59 +1,91 @@
 Bootstrap: library
-From: ubuntu:18.04
+From: ubuntu:22.04
 Stage: tensorflow
 
 %post
-    echo "deb http://us.archive.ubuntu.com/ubuntu bionic universe" >> /etc/apt/sources.list
+    echo "deb http://us.archive.ubuntu.com/ubuntu jammy universe" >> /etc/apt/sources.list
     apt update -y
     apt upgrade -y
 
-    apt install -y gcc g++ make liblapack-dev pkg-config git wget python python3 python3-dev python3-numpy 
+    apt install -y gcc g++ make liblapack-dev pkg-config git wget python2 python3 python3-dev python3-numpy libssl-dev xz-utils
+
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
+
+    #CMake
+    version=3.25
+    build=1
+    cmake_dir=$(mktemp -d)
+    cd $cmake_dir
+    wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
+    tar -xzvf cmake-$version.$build.tar.gz
+    cd cmake-$version.$build/
+    ./bootstrap
+    make -j$(nproc)
+    make install
+    cd /opt
+    rm -rf $cmake_dir
 
     mkdir -p /opt/cuda/
     cd /opt/cuda
 
-    wget http://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run
-    wget http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-x64-v7.6.5.32.tgz
+    wget https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
+    wget https://developer.download.nvidia.com/compute/redist/cudnn/v8.6.0/local_installers/11.8/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz
 
-    sh cuda_10.1.243_418.87.00_linux.run --no-drm --silent --toolkit
-    tar xzvf cudnn-10.1-linux-x64-v7.6.5.32.tgz -C /usr/local/
+    sh cuda_11.8.0_520.61.05_linux.run --no-drm --silent --toolkit
+    tar xvf cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz -C /usr/local/
 
-    wget -O /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-linux-x86_64
+    mv /usr/local/cudnn-linux-x86_64-8.6.0.163_cuda11-archive/lib /usr/local/cuda/
+    mv /usr/local/cudnn-linux-x86_64-8.6.0.163_cuda11-archive/include/* /usr/local/cuda/include/
+
+    wget -O /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel-5.3.0-linux-x86_64
     chmod +x /usr/bin/bazel
 
     mkdir -p /opt/tensorflow/
     cd /opt/tensorflow/
 
-    wget https://github.com/tensorflow/tensorflow/archive/v1.15.5.tar.gz
-    tar xzvf v1.15.5.tar.gz
-    mv tensorflow-1.15.5 tensorflow
+    wget https://github.com/tensorflow/tensorflow/archive/v2.12.0.tar.gz
+    tar xzvf v2.12.0.tar.gz
+    mv tensorflow-2.12.0 tensorflow
 
     cat << EOF > /opt/tensorflow/tensorflow/.tf_configure.bazelrc
-build --host_force_python=PY3
 build --action_env PYTHON_BIN_PATH="/usr/bin/python3"
-build --action_env PYTHON_LIB_PATH="/usr/local/lib/python3.6/dist-packages"
 build --python_path="/usr/bin/python3"
-build:xla --define with_xla_support=true
-build --config=xla
-build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda"
+build --action_env USE_DEFAULT_PYTHON_LIB_PATH=1
+build --define with_xla_support=true
+build --define no_aws_support=true
+build --define no_hdfs_support=true
+build --define framework_shared_object=true
+build --action_env TF_NEED_OPENCL_SYCL="0"
+build --action_env TF_NEED_ROCM="0"
+build --action_env TF_NEED_MKL="1"
+build --action_env TF_DOWNLOAD_CLANG="0"
+build:v2 --define=tf_api_version=2
+build --action_env TF_NEED_CUDA="1"
+build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
 build --action_env TF_CUDA_COMPUTE_CAPABILITIES="3.5,7.0"
 build --action_env LD_LIBRARY_PATH="/.singularity.d/libs"
-build --action_env GCC_HOST_COMPILER_PATH="/usr/bin/gcc"
+build --action_env GCC_HOST_COMPILER_PATH="/usr/bin/x86_64-linux-gnu-gcc-11"
 build --config=cuda
-build:opt --copt=-march=native
 build:opt --copt=-Wno-sign-compare
-build:opt --host_copt=-march=native
+build:opt --host_copt=-Wno-sign-compare
+build:opt --host_copt=-march=core-avx2
 build:opt --define with_default_optimizations=true
-build:v2 --define=tf_api_version=2
 test --flaky_test_attempts=3
 test --test_size_filters=small,medium
-test --test_tag_filters=-benchmark-test,-no_oss,-oss_serial
-test --build_tag_filters=-benchmark-test,-no_oss
-test --test_tag_filters=-gpu
-test --build_tag_filters=-gpu
-build --action_env TF_CONFIGURE_IOS="0"
+test --test_env=LD_LIBRARY_PATH
+test:v1 --test_tag_filters=-benchmark-test,-no_oss,-no_gpu,-oss_serial
+test:v1 --build_tag_filters=-benchmark-test,-no_oss,-no_gpu
+test:v2 --test_tag_filters=-benchmark-test,-no_oss,-no_gpu,-oss_serial,-v1only
+test:v2 --build_tag_filters=-benchmark-test,-no_oss,-no_gpu,-v1only
 EOF
 
     mkdir -p /opt/tensorflow/bazel_out/
     cd /opt/tensorflow/tensorflow
-    bazel --output_base=/opt/tensorflow/bazel_out build --define framework_shared_object=true --config=opt --config=noaws --config=nogcp --config=noignite --config=nokafka //tensorflow:libtensorflow_cc.so //tensorflow:libtensorflow.so
+    bazel --output_base=/opt/tensorflow/bazel_out build --local_cpu_resources=6 --config=opt --config=nogcp //tensorflow:libtensorflow_cc.so //tensorflow:libtensorflow.so
+
+    #Cleanup
+    rm -rf /opt/cuda
+    rm -rf /opt/tensorflow/v2.12.0.tar.gz
+    find /opt/tensorflow/tensorflow/bazel-out/ -name "*.o" -exec rm {} \;
+    find /opt/tensorflow/tensorflow/bazel-out/ -name "*.lo" -exec rm {} \;
+    find /opt/tensorflow/tensorflow/bazel-out/ -name "*.a" -exec rm {} \;

--- a/singularity/tensorflow.def
+++ b/singularity/tensorflow.def
@@ -54,6 +54,9 @@ build --action_env GCC_HOST_COMPILER_PATH="/usr/bin/x86_64-linux-gnu-gcc-11"
 build --config=cuda
 build:opt --copt=-Wno-sign-compare
 build:opt --host_copt=-Wno-sign-compare
+build:opt --copt=-march=native
+build:opt --host_copt=-march=native
+build:opt --cxxopt=-march=native
 build:opt --host_copt=-march=core-avx2
 build:opt --define with_default_optimizations=true
 test --flaky_test_attempts=3

--- a/src/Mm/FeatureScorer.hh
+++ b/src/Mm/FeatureScorer.hh
@@ -27,25 +27,24 @@ namespace Mm {
 /** Abstract feature scorer interface. */
 class FeatureScorer : public virtual Core::Component,
                       public Core::ReferenceCounted {
-protected:
-    /** Implement emission independent precalculations for feature vector */
-    class ContextScorer : public Core::ReferenceCounted {
-    protected:
-        ContextScorer() {}
-
-    public:
-        virtual ~ContextScorer() {}
-
-        virtual EmissionIndex nEmissions() const           = 0;
-        virtual Score         score(EmissionIndex e) const = 0;
-        virtual Score         score(EmissionIndex e, u32 modelIndex) {
-            return 0.0;
-        }
-    };
-    friend class ContextScorer;
-
 public:
-    FeatureScorer(const Core::Configuration& c)
+    /** Implement emission independent precalculations for feature vector */
+   class ContextScorer : public Core::ReferenceCounted {
+   protected:
+       ContextScorer() {}
+
+   public:
+       virtual ~ContextScorer() {}
+
+       virtual EmissionIndex nEmissions() const           = 0;
+       virtual Score         score(EmissionIndex e) const = 0;
+       virtual Score         score(EmissionIndex e, u32 modelIndex) {
+           return 0.0;
+       }
+   };
+   friend class ContextScorer;
+
+   FeatureScorer(const Core::Configuration& c)
             : Core::Component(c) {}
     virtual ~FeatureScorer() {}
 


### PR DESCRIPTION
Version updates in the singularity containers:
- Ubuntu to 22.04
- Tensorflow to 2.12.0
- Cuda to 11.8
- Cudnn to 8.6

Updates in the config files:
- C++ updated to C++17. `src/Mm/FeatureScorer.hh` updated accordingly.
- Include and library directories for python 3 updated