### PR TITLE
Fix analog tool on .gz files

### DIFF
--- a/src/Tools/Analog/analog_util/parser.py
+++ b/src/Tools/Analog/analog_util/parser.py
@@ -23,7 +23,7 @@ class SprintParser(XmlSchemaParser):
         self.setRoot(root)
 
     def parseFile(self, fname):
-        fd = zopen(fname, 'r')
+        fd = zopen(fname, 'rt')
         data = fd.read()
         zclose(fd)
         self.reset()


### PR DESCRIPTION
`gzip` [by default opens files in binary mode](https://docs.python.org/3/library/gzip.html#gzip.open)[^1], which is why the parser then breaks when processing the extracted data:

```
❯ wer --verbose-errors /long/path/redacted/for/brevity/search.log.1.gz
/u/mgunz/tools/rasr_no_tf/src/Tools/Analog/analog:14: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import glob, imp, os, sys
Can not load PyQt. Gui will not work.
failed to load plug-in "ov": No module named 'sequitur_'
                              |                   word errors                    |  time 
file/subcorpus                | seg    del    ins    sub    errors words    wer  |  rtf  
------------------------------+--------------------------------------------------+-------
/long/path/redacted/for/brevity/search.log.1.gz FAILED
Traceback (most recent call last):
  File "/work/tools/users/raissi/shared/mgunz/rasr_no_tf/src/Tools/Analog/analog_util/analog.py", line 353, in processFiles
    self.parser.parseFile(fname, segments)
  File "/work/tools/users/raissi/shared/mgunz/rasr_no_tf/src/Tools/Analog/analog_util/parser.py", line 418, in parseFile
    super(LogFileParser, self).parseFile(fname)
  File "/work/tools/users/raissi/shared/mgunz/rasr_no_tf/src/Tools/Analog/analog_util/parser.py", line 30, in parseFile
    if data.startswith('<?xml'):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
/long/path/redacted/for/brevity/search.log.1.gz
------------------------------+--------------------------------------------------+-------
```

By setting the mode to `rt` explicitly, we get the gzip module to extract text. We then get:

```
❯ wer --verbose-errors /long/path/redacted/for/brevity/search.log.1.gz
/u/mgunz/tools/rasr_no_tf/src/Tools/Analog/analog:14: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import glob, imp, os, sys
Can not load PyQt. Gui will not work.
failed to load plug-in "ov": No module named 'sequitur_'
                              |                   word errors                    |  time 
file/subcorpus                | seg    del    ins    sub    errors words    wer  |  rtf  
------------------------------+--------------------------------------------------+-------
/long/path/redacted/for/brevity/search.log.1.gz
dev-other                     |   n/a    n/a    n/a    n/a     n/a    n/a     n/a|    n/a
 - evaluator/best-in-lattice  |   144     17      0     44      61   2349    2.60|    n/a
 - evaluator/single best      |   144    263      4    158     425   2349   18.09|    n/a
 - recognizer                 |   n/a    n/a    n/a    n/a     n/a    n/a     n/a|    n/a
------------------------------+--------------------------------------------------+-------
```

Tested under python 3.10.

[^1]:  > The mode argument can be any of 'r', 'rb', 'a', 'ab', 'w', 'wb', 'x' or 'xb' for binary mode, or 'rt', 'at', 'wt', or 'xt' for text mode. The default is 'rb'.
