### PR TITLE
Allow dense state tying of multiple HMM states into one

### DIFF
--- a/src/Am/ClassicStateTying.cc
+++ b/src/Am/ClassicStateTying.cc
@@ -272,16 +272,17 @@ Mm::MixtureIndex NoStateTyingDense::nClasses() const {
 Mm::MixtureIndex NoStateTyingDense::classify(const AllophoneState& a) const {
     require_lt(a.allophone()->boundary, numBoundaryClasses_);
     require_le(0, a.state());
-    require_lt(u32(a.state()), numStates_);
     u32 result = 0;
 
     u32 phoneIdx = a.allophone()->phoneme(0);
     require_lt(phoneIdx, numPhoneClasses_);
     result += phoneIdx;
 
-    result *= numStates_;
-    result += u32(a.state());
-
+    if (numStates_ > 1) {
+        require_lt(u32(a.state()), numStates_);
+        result *= numStates_;
+        result += u32(a.state());
+    }
     if (useBoundaryClasses_) {
         result *= numBoundaryClasses_;
         result += a.allophone()->boundary;
@@ -335,7 +336,6 @@ DiphoneDense::DiphoneDense(const Core::Configuration& config, ClassicStateModelR
 Mm::MixtureIndex DiphoneDense::classify(const AllophoneState& a) const {
     require_lt(a.allophone()->boundary, numBoundaryClasses_);
     require_le(0, a.state());
-    require_lt(u32(a.state()), numStates_);
     require_eq(contextLength_, 1);
     u32 result = 0;
 
@@ -343,9 +343,11 @@ Mm::MixtureIndex DiphoneDense::classify(const AllophoneState& a) const {
     require_lt(phoneIdx, numPhoneClasses_);
     result += phoneIdx;
 
-    result *= numStates_;
-    result += u32(a.state());
-
+    if (numStates_ > 1) {
+        require_lt(u32(a.state()), numStates_);
+        result *= numStates_;
+        result += u32(a.state());
+    }
     if (useBoundaryClasses_) {
         result *= numBoundaryClasses_;
         result += a.allophone()->boundary;
@@ -390,7 +392,6 @@ MonophoneDense::MonophoneDense(const Core::Configuration& config, ClassicStateMo
 Mm::MixtureIndex MonophoneDense::classify(const AllophoneState& a) const {
     require_lt(a.allophone()->boundary, numBoundaryClasses_);
     require_le(0, a.state());
-    require_lt(u32(a.state()), numStates_);
     require_eq(contextLength_, 1);
     u32 result = 0;
 
@@ -398,9 +399,11 @@ Mm::MixtureIndex MonophoneDense::classify(const AllophoneState& a) const {
     require_lt(phoneIdx, numPhoneClasses_);
     result += phoneIdx;
 
-    result *= numStates_;
-    result += u32(a.state());
-
+    if (numStates_ > 1) {
+        require_lt(u32(a.state()), numStates_);
+        result *= numStates_;
+        result += u32(a.state());
+    }
     if (useBoundaryClasses_) {
         result *= numBoundaryClasses_;
         result += a.allophone()->boundary;


### PR DESCRIPTION
I am training a model with 1 state per phone from an alignment from a model with three states per phoneme.

The training fails w/ the following error, because during alignment extraction, the code attempts to classify/tie the allophones with `n = 3` and runs into an assertion:

```
<?xml version="1.0" encoding="UTF-8"?>
<sprint>


  PROGRAM DEFECTIVE:
  assertion u32(a.state()) < numStates_ violated
  in virtual Mm::MixtureIndex Am::NoStateTyingDense::classify(const Am::AllophoneState&) const file ClassicStateTying.cc line 275
  1 < 1
  Creating stack trace (innermost first):
  #2  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard() [0xc51289]
  #3  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZNK2Am17NoStateTyingDense8classifyERKNS_14AllophoneStateE+0x205) [0xc52605]
  #4  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZNK2Am17NoStateTyingDense13classifyIndexEi+0x3a) [0xc50f5a]
  #5  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN17AlignmentToPython23extractViterbiAlignmentERKN6Speech9AlignmentERN6Python6ObjRefE+0x290) [0x947b50]
  #6  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN2Nn28PythonControlCorpusProcessorIN6Speech16FeatureExtractorELb1EE14processSegmentEPN5Bliss7SegmentE+0x58d) [0x94a62d]
  #7  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN6Speech13CorpusVisitor18visitSpeechSegmentEPN5Bliss13SpeechSegmentE+0xb0) [0xa92330]
  #8  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss17CorpusDescription32ProgressIndicationVisitorAdaptor18visitSpeechSegmentEPNS_13SpeechSegmentE+0xe) [0x73a0ae]
  #9  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss31ProgressReportingVisitorAdaptor18visitSpeechSegmentEPNS_13SpeechSegmentE+0xabb) [0x73769b]
  #10  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss17CorpusDescription30SegmentPartitionVisitorAdaptor18visitSpeechSegmentEPNS_13SpeechSegmentE+0xbc) [0x73a9bc]
  #11  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss22SegmentOrderingVisitor17CustomCorpusGuide17showSegmentByNameERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x41) [0x742561]
  #12  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss28PythonSegmentOrderingVisitor11leaveCorpusEPNS_6CorpusE+0x16f) [0x748b6f]
  #13  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss23CorpusDescriptionParser9endCorpusEv+0x68) [0x73bee8]
  #14  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN4Core15XmlSchemaParser10endElementEPKc+0xd7) [0x797397]
  #15  /usr/lib/x86_64-linux-gnu/libxml2.so.2(+0x4c88d) [0x7fc05135888d]
  #16  /usr/lib/x86_64-linux-gnu/libxml2.so.2(xmlParseElement+0x58b) [0x7fc05135f07b]
  #17  /usr/lib/x86_64-linux-gnu/libxml2.so.2(xmlParseDocument+0x3ea) [0x7fc05135f6fa]
  #18  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN4Core9XmlParser5parseEv+0x33) [0x7981b3]
  #19  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN4Core9XmlParser9parseFileEPKc+0x38) [0x798478]
  #20  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss23CorpusDescriptionParser6acceptERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS_13CorpusVisitorE+0x135) [0x73ceb5]
  #21  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN5Bliss17CorpusDescription6acceptEPNS_13CorpusVisitorE+0x9f) [0x738fff]
  #22  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard() [0x944a7b]
  #23  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN9NnTrainer13pythonControlEv+0x10b) [0x71614b]
  #24  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN9NnTrainer4mainERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EE+0x2e5) [0x6f30e5]
  #25  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN4Core11Application3runERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE+0x20) [0x7524e0]
  #26  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_ZN4Core11Application4mainEiPPc+0x65f) [0x6f479f]
  #27  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(main+0x38) [0x6f2898]
  #28  /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0) [0x7fc0283bd840]
  #29  /work/tools/users/raissi/shared/mgunz/rasr_apptainer_tf2.3_u16/arch/linux-x86_64-standard/nn-trainer.linux-x86_64-standard(_start+0x29) [0x7157b9]

<?xml version="1.0" encoding="UTF-8"?>
<sprint>
```

The assertion is correct for cases where there is no trivial tying of the phonemes (e.g. when training with `n = 2` from an `n = 3` alignment), but for the case `n = 1` the assertion can be removed.