### PR TITLE
Enable back LM util

### DIFF
--- a/Modules.make
+++ b/Modules.make
@@ -120,6 +120,7 @@ TOOLS += CorpusStatistics
 TOOLS += FeatureExtraction
 TOOLS += FeatureStatistics
 TOOLS += Fsa
+TOOLS += Lm
 TOOLS += SpeechRecognizer
 TOOLS += Xml
 

--- a/src/Tools/Lm/LmUtilityTool.cc
+++ b/src/Tools/Lm/LmUtilityTool.cc
@@ -21,8 +21,6 @@
 #include <Flow/Module.hh>
 #include <Lm/Module.hh>
 #include <Math/Module.hh>
-#include <Mc/Module.hh>
-#include <Me/Module.hh>
 #include <Mm/Module.hh>
 #include <Nn/Module.hh>
 #include <Signal/Module.hh>
@@ -102,14 +100,12 @@ LmUtilityTool::LmUtilityTool()
         : Core::Application() {
     INIT_MODULE(Lm);
     INIT_MODULE(Mm);
-    INIT_MODULE(Mc);
     INIT_MODULE(Flf);
     INIT_MODULE(Flow);
     INIT_MODULE(Math);
     INIT_MODULE(Signal);
     INIT_MODULE(Speech);
     INIT_MODULE(Nn);
-    INIT_MODULE(Me);
 #ifdef MODULE_TENSORFLOW
     INIT_MODULE(Tensorflow);
 #endif

--- a/src/Tools/Lm/Makefile
+++ b/src/Tools/Lm/Makefile
@@ -17,9 +17,7 @@ LM_UTIL_TOOL_O = $(OBJDIR)/LmUtilityTool.o \
 		 ../../Mc/libSprintMc.$(a) \
 		 ../../Bliss/libSprintBliss.$(a) \
 		 ../../Nn/libSprintNn.$(a) \
-		 ../../Me/libSprintMe.$(a) \
 		 ../../Mm/libSprintMm.$(a) \
-		 ../../Legacy/libSprintLegacy.$(a) \
 		 ../../Signal/libSprintSignal.$(a) \
 		 ../../Flow/libSprintFlow.$(a) \
 		 ../../Math/libSprintMath.$(a) \


### PR DESCRIPTION
Enable LM util tool again and remove some legacy imports so that it compiles again with the current version. Addresses issue #62.