### PR TITLE
Fix word boundaries in ctm dumps of lattices with subsampling

### DIFF
--- a/src/Flf/Traceback.cc
+++ b/src/Flf/Traceback.cc
@@ -18,9 +18,7 @@
 #include <Core/Parameter.hh>
 #include <Core/StringUtilities.hh>
 #include <Core/XmlStream.hh>
-#ifndef CMAKE_DISABLE_MODULES_HH
 #include <Modules.hh>
-#endif
 #include <Search/Search.hh>
 
 #include "Best.hh"

--- a/src/Flf/Traceback.cc
+++ b/src/Flf/Traceback.cc
@@ -18,7 +18,9 @@
 #include <Core/Parameter.hh>
 #include <Core/StringUtilities.hh>
 #include <Core/XmlStream.hh>
+#ifndef CMAKE_DISABLE_MODULES_HH
 #include <Modules.hh>
+#endif
 #include <Search/Search.hh>
 
 #include "Best.hh"
@@ -60,6 +62,7 @@ public:
     static const Core::ParameterBool         paramDumpPhonemeAlignment;
     static const Core::ParameterBool         paramDumpSubwordAlignment;
     static const Core::ParameterBool         paramFillEmptySegments;
+    static const Core::ParameterFloat        paramFrameShiftTime;
 
 private:
     Core::Channel                    dump_;
@@ -82,6 +85,7 @@ private:
     bool                       dumpPhonemeAlignment_;
     bool                       dumpSubwordAlignment_;
     bool                       fillEmptySegments_;
+    float                      frameShiftTime_;
     LatticeAlignmentBuilderRef alignmentBuilder_;
 
 protected:
@@ -370,8 +374,8 @@ protected:
                     verify(sr->nArcs() == 1);
                     const Arc&      a            = *sr->begin();
                     const Boundary &leftBoundary = boundaries.get(sr->id()), &rightBoundary = boundaries.get(a.target());
-                    f32             wordBegin = f32(leftBoundary.time()) / 100.00;
-                    f32             wordEnd   = f32(rightBoundary.time()) / 100.00;
+                    f32             wordBegin = f32(leftBoundary.time()) * frameShiftTime_;
+                    f32             wordEnd   = f32(rightBoundary.time()) * frameShiftTime_;
                     if (wordBegin < wordEnd) {
                         if (lAlphabet || lpAlphabet) {
                             std::string      word;
@@ -580,6 +584,7 @@ public:
                 dumpPhonemeAlignment_               = paramDumpPhonemeAlignment(ctmConfig);
                 dumpSubwordAlignment_               = paramDumpSubwordAlignment(ctmConfig);
                 fillEmptySegments_                  = paramFillEmptySegments(ctmConfig);
+                frameShiftTime_                     = paramFrameShiftTime(ctmConfig);
                 if (dumpPhonemeAlignment_ || dumpSubwordAlignment_) {
                     createAlignmentBuilder(ctmConfig);
                 }
@@ -684,6 +689,10 @@ const Core::ParameterBool DumpTracebackNode::paramFillEmptySegments(
         "fill-empty-segments",
         "fill empty segments (can fix issues with sclite complaining about unsynchronized files if a segment is missing from the ctm file)",
         false);
+const Core::ParameterFloat DumpTracebackNode::paramFrameShiftTime(
+        "frame-shift-time",
+        "shift-time of frames of the lattice time axis in seconds. Defaults to 0.01 = 10ms. Important for correct word boundaries when subsampling is used.",
+        0.01);
 NodeRef createDumpTracebackNode(const std::string& name, const Core::Configuration& config) {
     return NodeRef(new DumpTracebackNode(name, config));
 }


### PR DESCRIPTION
When performing recognition, the traceback contains word boundaries in the form of integers that represent output time frames of the model in the case of time-synchronous decoding. These word boundaries are then written into the lattice.

Later, when dumping the lattice to a .ctm file, these boundaries are divided by 100 to form start- and end-times as well as durations of words. This assumes that a frame shift on the output time axis is 1/100 seconds (i.e. 10ms) which is wrong when subsampling is performed in the model (or if one was to use feature extraction with a different frame shift). This leads to wrong word boundaries in the .ctm file.

This PR replaces the `/ 100.0` by a multiplication with a configurable frame shift.