### PR TITLE
Backport AppTek changes to LM + LM lookahead code

### DIFF
--- a/src/Bliss/SyntacticTokenMap.hh
+++ b/src/Bliss/SyntacticTokenMap.hh
@@ -62,6 +62,16 @@ public:
         verify_(s->id() < store_.size());
         return store_[s->id()];
     }
+
+    Value& operator[](const Token::Id id) {
+        verify_(id < store_.size());
+        return store_[id];
+    }
+
+    const Value& operator[](const Token::Id id) const {
+        verify_(id < store_.size());
+        return store_[id];
+    }
 };
 
 }  // namespace Bliss

--- a/src/Lm/AbstractNNLanguageModel.cc
+++ b/src/Lm/AbstractNNLanguageModel.cc
@@ -27,7 +27,14 @@ Core::ParameterString AbstractNNLanguageModel::paramVocabUnknownWord(
         "vocab-unknown-word", "the word from the provided vocabulary file that will serve as unknown token", "");
 
 AbstractNNLanguageModel::AbstractNNLanguageModel(Core::Configuration const& c, Bliss::LexiconRef l)
-        : Core::Component(c), Precursor(c, l), collect_statistics_(paramCollectStatistics(c)), vocab_file_(paramVocabularyFile(c)), unknown_word_(paramVocabUnknownWord(config)), lexicon_(l), num_outputs_(0ul), lexicon_mapping_(), usage_histogram_() {
+        : Core::Component(c),
+          Precursor(c, l),
+          collect_statistics_(paramCollectStatistics(c)),
+          vocab_file_(paramVocabularyFile(c)),
+          unknown_word_(paramVocabUnknownWord(config)),
+          lexicon_(l),
+          num_outputs_(0ul),
+          usage_histogram_() {
     NNHistoryManager* hm = new NNHistoryManager();
     if (collect_statistics_) {
         hm->setOnReleaseHandler(std::bind(&AbstractNNLanguageModel::onRelease, this, std::placeholders::_1));
@@ -89,7 +96,7 @@ void AbstractNNLanguageModel::onRelease(HistoryHandle handle) {
     NNCacheWithStats const* c = reinterpret_cast<NNCacheWithStats const*>(handle);
     if (not c->output_used.empty()) {
         unsigned used_outputs  = std::accumulate(c->output_used.begin(), c->output_used.end(),
-                                                0u, [](unsigned sum, bool used) { return sum + (used ? 1u : 0u); });
+                                                 0u, [](unsigned sum, bool used) { return sum + (used ? 1u : 0u); });
         size_t   promille_used = static_cast<size_t>((1000.0 * used_outputs) / c->output_used.size());
         if (usage_histogram_.size() <= promille_used) {
             usage_histogram_.resize(promille_used + 1ul);

--- a/src/Lm/AbstractNNLanguageModel.hh
+++ b/src/Lm/AbstractNNLanguageModel.hh
@@ -40,10 +40,9 @@ protected:
     std::string vocab_file_;
     std::string unknown_word_;
 
-    Bliss::LexiconRef   lexicon_;
-    size_t              num_outputs_;
-    std::vector<size_t> lexicon_mapping_;
-    std::vector<u32>    usage_histogram_;
+    Bliss::LexiconRef lexicon_;
+    size_t            num_outputs_;
+    std::vector<u32>  usage_histogram_;
 
     void loadVocabulary();
     void useOutput(NNCacheWithStats const& cache, size_t idx) const;

--- a/src/Lm/BackingOff.cc
+++ b/src/Lm/BackingOff.cc
@@ -19,6 +19,7 @@
 #include <Core/Directory.hh>
 #include <Core/IoUtilities.hh>
 #include <Fsa/Sort.hh>
+#include <numeric>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -59,7 +60,7 @@ const BackingOffLm::Node* BackingOffLm::Node::findChild(TokenIndex t) const {
     return binarySearch(childrenBegin(), childrenEnd() - 1, t);
 }
 
-const BackingOffLm::WordScore* BackingOffLm::Node::findWordScore(
+const WordScore* BackingOffLm::Node::findWordScore(
         const WordScore* base, TokenIndex t) const {
     return binarySearch(scoresBegin(base), scoresEnd(base) - 1, t);
 }
@@ -121,7 +122,7 @@ void BackingOffLm::Internal::changeWordScoreCapacity(
     wordScoresEnd_  = wordScores_ + newCapacity;
 }
 
-BackingOffLm::WordScore* BackingOffLm::Internal::newWordScore() {
+WordScore* BackingOffLm::Internal::newWordScore() {
     size_t spareCapacity = wordScoresEnd_ - wordScoresTail_;
     if (spareCapacity < 1) {
         spareCapacity = nWordScores();
@@ -385,7 +386,9 @@ private:
         PositionType end;
     };
     Values values_;
-    enum { formatVersion = v };
+    enum {
+        formatVersion = v
+    };
 
 public:
     virtual u64 nTokens() const {
@@ -629,7 +632,7 @@ bool BackingOffLm::Internal::writeImage(int fd, const std::string& info) const {
 
 bool BackingOffLm::Internal::mountImage(
         int fd, std::string& info,
-        const Bliss::TokenInventory& inventory) {
+        const Bliss::TokenInventory& inventory, bool mapOovToUnk) {
     ImageHeader header(0);
     if (!header.read(fd, info))
         return false;
@@ -644,28 +647,34 @@ bool BackingOffLm::Internal::mountImage(
 
     info = std::string(mmap_ + header.size());
 
+    // lexicon and LM tokenId mapping: allow different lexicon for image building
+    verify(lexiconMapping_->size() == inventory.size());
     tokens_.resize(header.nTokens());
     char* str = mmap_ + header.tokensOffset();
     for (TokenIndex ti = 0; ti < TokenIndex(header.nTokens()); ++ti) {
         const Bliss::Token* token = 0;
         if (*str) {
             token = inventory[str];
-            if (!token) {
-                info = Core::form("undefined token \"%s\"", str);
-                munmap(mmap_, mmapSize_);
-                return false;
+            if (!token) {  // tokens not in the lexicon: never recognized (just record for later usage)
+                noUseTokens_[str] = ti;
             }
-            if (token->id() != ti) {
-                info = Core::form("wrong token index: \"%s\" has index %d, should be %d",
-                                  str, token->id(), ti);
-                munmap(mmap_, mmapSize_);
-                return false;
+            else {  // tokens in the lexicon: map id
+                lexiconMapping_->at(token->id()) = ti;
             }
-            while (*++str)
-                ;
-        }
-        tokens_[ti] = token;
+            while (*++str) {
+            }
+        }                     // ignore oov tokens of the image building lexicon
+        tokens_[ti] = token;  // reverse mapping
         ++str;
+    }
+    // map oovs to unk, otherwise max score (and probably never recognized)
+    if (mapOovToUnk) {
+        verify(lexiconMapping_->at(unkTokenId_) != Bliss::Token::invalidId);
+        for (u32 tId = 0; tId < lexiconMapping_->size(); ++tId)
+            if (lexiconMapping_->at(tId) == Bliss::Token::invalidId) {
+                lexiconMapping_->at(tId) = lexiconMapping_->at(unkTokenId_);
+                oovTokens_.insert(tId);
+            }
     }
 
     nodes_     = (Node*)(mmap_ + header.nodesOffset());
@@ -717,6 +726,8 @@ void BackingOffLm::initialize(Core::Ref<Internal> i) {
 void BackingOffLm::logInitialization() const {
     log("size: %d n-grams in %d histories",
         internal_->nWordScores(), internal_->nNodes());
+    if (!internal_->oovTokens_.empty())
+        log() << internal_->oovTokens_.size() << " out-of-vocabulary tokens from lexicon (map to unknown token)";
     log("dependency value: ") << dependency_.value();
     Core::Channel dc(config, "dot");
     if (dc.isOpen())
@@ -742,6 +753,7 @@ void BackingOffLm::load() {
     std::string image = paramImage(config);
     if (!image.size()) {
         read();
+        initTokenMapping(true);
         return;
     }
 
@@ -771,14 +783,17 @@ void BackingOffLm::load() {
         internal_ = Core::ref(new Internal);
     }
 
-    log("mounting image file \"%s\" ...", image.c_str());
+    // all token mapping built during image mounting
+    initTokenMapping();
+    std::string abs_filename = Core::realPath(image);
+    log("mounting image file \"%s\" (%s) ...", image.c_str(), abs_filename.c_str());
     int fd = open(image.c_str(), O_RDONLY);
     if (fd == -1) {
         error("Failed to open image file \"%s\" for reading", image.c_str());
         return;
     }
     std::string info;
-    if (!internal_->mountImage(fd, info, tokenInventory())) {
+    if (!internal_->mountImage(fd, info, tokenInventory(), mapOovToUnk_)) {
         error("failed to mount image file: ") << info;
         return;
     }
@@ -791,6 +806,8 @@ Score BackingOffLm::sentenceBeginScore() const {
 }
 
 const BackingOffLm::Node* BackingOffLm::Internal::startHistory(TokenIndex w) const {
+    w = lexiconMapping_->at(w);
+
     const Node* n = root()->findChild(w);
     if (!n)
         n = root();
@@ -802,6 +819,8 @@ History BackingOffLm::startHistory() const {
 }
 
 const BackingOffLm::Node* BackingOffLm::Internal::extendedHistory(const Node* old, TokenIndex w) const {
+    w = lexiconMapping_->at(w);
+
     TokenIndex hist[old->depth() + 1];
     for (const Node* n = old; n; n = n->parent())
         hist[n->depth()] = n->token();
@@ -818,24 +837,6 @@ const BackingOffLm::Node* BackingOffLm::Internal::extendedHistory(const Node* ol
     return result;
 }
 
-void BackingOffLm::historyTokens(const History& h, const Bliss::Token** target, u32& size, u32 arraySize) const {
-    size = 0;
-    for (const Node* n = descriptor<Self>(h); n; (n = n->parent()) && size < arraySize) {
-        Token tok = internal_->token(n->token());
-        if (tok) {
-            target[size] = tok;
-            ++size;
-        }
-    }
-}
-
-u32 BackingOffLm::historyLenght(const Lm::History& h) const {
-    const Node* n = descriptor<Self>(h);
-    if (!n)
-        return 0;
-    return n->depth();
-}
-
 History BackingOffLm::extendedHistory(const History& h, Token w) const {
     return history(internal_->extendedHistory(descriptor<Self>(h), w->id()));
 }
@@ -845,6 +846,15 @@ History BackingOffLm::reducedHistory(const History& h, u32 limit) const {
     while (n->depth() > limit)
         n = n->parent();
     return history(n);
+}
+
+History BackingOffLm::reduceHistoryByN(const History& h, u32 n) const {
+    const Node* node = descriptor<Self>(h);
+    while (n > 0 && node->depth() > 0) {
+        node = node->parent();
+        n -= 1;
+    }
+    return history(node);
 }
 
 std::string BackingOffLm::Internal::formatHistory(const Node* h) {
@@ -865,6 +875,8 @@ std::string BackingOffLm::formatHistory(const History& h) const {
 }
 
 Lm::Score BackingOffLm::Internal::score(const Node* h, TokenIndex w) const {
+    w = lexiconMapping_->at(w);
+
     Score backOffScore = 0.0;
     for (const Node* n = h; n; n = n->parent()) {
         const WordScore* ws = n->findWordScore(wordScores_, w);
@@ -877,38 +889,6 @@ Lm::Score BackingOffLm::Internal::score(const Node* h, TokenIndex w) const {
 
 Lm::Score BackingOffLm::score(const History& h, Token w) const {
     return internal_->score(descriptor<Self>(h), w->id());
-}
-
-Score BackingOffLm::getAccumulatedBackOffScore(const History& history, int limit) const {
-    const Node* hn  = descriptor<Self>(history);
-    Score       ret = 0;
-    for (const Node* n = hn; n; n = n->parent())
-        if (n->depth() >= limit)
-            ret += n->backOffScore();
-    return ret;
-}
-
-BackingOffLm::BackOffScores BackingOffLm::getBackOffScores(const Lm::History& history, int depth) const {
-    const Node* hn = descriptor<Self>(history);
-    const Node* nodes[hn->depth() + 1];
-    for (const Node* n = hn; n; n = n->parent()) {
-        Node::Depth d = n->depth();
-        nodes[d]      = n;
-    }
-
-    int nodeDepth = ((int)hn->depth()) - depth;
-
-    BackOffScores ret;
-
-    // Node-depth 0 is the zerogram back-off
-    verify(nodeDepth >= 0 && nodeDepth <= hn->depth());
-
-    ret.backOffScore = nodes[nodeDepth]->backOffScore();
-    verify(ret.backOffScore != Core::Type<Score>::max);
-    ret.start = internal_->scoresBegin(nodes[nodeDepth]);
-    ret.end   = internal_->scoresEnd(nodes[nodeDepth]);
-
-    return ret;
 }
 
 void BackingOffLm::getBatch(
@@ -930,10 +910,18 @@ void BackingOffLm::getBatch(
     for (Node::Depth d = 0; d <= hn->depth(); ++d) {
         const Node* n = nodes[d];
         for (const WordScore* ws = internal_->scoresBegin(n); ws != internal_->scoresEnd(n); ++ws) {
-            const Bliss::SyntacticToken* syntacticToken =
-                    static_cast<const Bliss::SyntacticToken*>(lexicon()->syntacticTokenInventory()[ws->token()]);
-            scores[syntacticToken] = ws->score() + backOffScore[d + 1];
+            Token tok = internal_->token(ws->token());
+            if (!tok) {
+                continue;
+            }
+            const Bliss::SyntacticToken* syntacticToken = static_cast<const Bliss::SyntacticToken*>(tok);
+            scores[syntacticToken]                      = ws->score() + backOffScore[d + 1];
         }
+    }
+
+    // mapOovToUnk == no, oovTokens will be empty so we never ask for InvalidId in case the unknown lemma does not have a syntactic token seq.
+    for (TokenSet::const_iterator iter = internal_->oovTokens_.begin(); iter != internal_->oovTokens_.end(); ++iter) {
+        scores[*iter] = scores[internal_->unkTokenId_];
     }
 
     const NonCompiledBatchRequest* ncbr = required_cast(const NonCompiledBatchRequest*, cbr);
@@ -960,6 +948,147 @@ void BackingOffLm::getBatch(
         if (result[r->target] > score)
             result[r->target] = score;
     }
+}
+
+bool BackingOffLm::fixedHistory(s32 limit) const {
+    return limit == 0;
+}
+
+bool BackingOffLm::isSparse(const History& h) const {
+    if (!h.isValid()) {
+        return true;
+    }
+    if (historyLength(h) == 0) {
+        return false;
+    }
+    return true;
+}
+
+HistorySuccessors BackingOffLm::getHistorySuccessors(const History& h) const {
+    BackOffScores     backoff = getBackOffScores(h, 0);
+    size_t            size    = ((size_t)backoff.end - (size_t)backoff.start) / sizeof(WordScore);
+    HistorySuccessors res;
+    res.backOffScore = backoff.backOffScore;
+    if (size == 0) {
+        return res;
+    }
+
+    // mapOovToUnk directly here: hidden from sparse lookahead
+    bool  oov2unk  = mapOovToUnk_ && !internal_->oovTokens_.empty();
+    Score unkScore = Core::Type<Score>::max;
+
+    res.reserve(size);
+    for (const WordScore* ws = backoff.start; ws != backoff.end; ++ws) {
+        Bliss::Token::Id tok = reverseMapToken(ws->token());  // lexicon token Id
+        res.emplace_back(tok, ws->score());
+        if (oov2unk && tok == internal_->unkTokenId_) {
+            unkScore = ws->score();
+        }
+    }
+
+    if (oov2unk && unkScore != Core::Type<Score>::max) {
+        size += internal_->oovTokens_.size();
+        res.reserve(size);
+        for (TokenSet::const_iterator iter = internal_->oovTokens_.begin(); iter != internal_->oovTokens_.end(); ++iter) {
+            res.emplace_back(*iter, unkScore);
+        }
+    }
+
+    return res;
+}
+
+Score BackingOffLm::getBackOffScore(const History& h) const {
+    return getBackOffScores(h, 0).backOffScore;
+}
+
+void BackingOffLm::historyTokens(const History& h, const Bliss::Token** target, u32& size, u32 arraySize) const {
+    size = 0;
+    for (const Node* n = descriptor<Self>(h); n; (n = n->parent()) && size < arraySize) {
+        Token tok = internal_->token(n->token());
+        if (tok) {
+            target[size] = tok;
+            ++size;
+        }
+    }
+}
+
+u32 BackingOffLm::historyLength(const Lm::History& h) const {
+    const Node* n = descriptor<Self>(h);
+    if (!n) {
+        return 0;
+    }
+    return n->depth();
+}
+
+BackingOffLm::BackOffScores BackingOffLm::getBackOffScores(const Lm::History& history, int depth) const {
+    const Node* hn = descriptor<Self>(history);
+    const Node* nodes[hn->depth() + 1];
+    for (const Node* n = hn; n; n = n->parent()) {
+        Node::Depth d = n->depth();
+        nodes[d]      = n;
+    }
+
+    int nodeDepth = ((int)hn->depth()) - depth;
+
+    BackOffScores ret;
+
+    // Node-depth 0 is the zerogram back-off
+    verify(nodeDepth >= 0 && nodeDepth <= hn->depth());
+
+    ret.backOffScore = nodes[nodeDepth]->backOffScore();
+    verify(ret.backOffScore != Core::Type<Score>::max);
+    ret.start = internal_->scoresBegin(nodes[nodeDepth]);
+    ret.end   = internal_->scoresEnd(nodes[nodeDepth]);
+
+    return ret;
+}
+
+Score BackingOffLm::getAccumulatedBackOffScore(const History& history, int limit) const {
+    const Node* hn  = descriptor<Self>(history);
+    Score       ret = 0;
+    for (const Node* n = hn; n; n = n->parent())
+        if (n->depth() >= limit)
+            ret += n->backOffScore();
+    return ret;
+}
+
+void BackingOffLm::initTokenMapping(bool build) {
+    verify(internal_);  // has to be initialized already
+    lexicon_mapping_.clear();
+    lexicon_mapping_.resize(tokenInventory().size(), Bliss::Token::invalidId);
+    staticSize_ = lexicon_mapping_.size();
+
+    Core::ParameterBool paramMapOovToUnk("map-oov-to-unk", "", false);
+    mapOovToUnk_ = paramMapOovToUnk(config);
+    if (!mapOovToUnk_) {
+        internal_->oovTokens_.clear();
+    }
+    auto unk_token         = getSpecialToken("unknown", mapOovToUnk_);
+    internal_->unkTokenId_ = unk_token != nullptr ? unk_token->id() : Bliss::SyntacticToken::invalidId;
+
+    // no LM image used: build token mapping directly here (just same id)
+    // Note: all LM tokens included in the lexicon based on read, thus empty noUseTokens_
+    if (build) {
+        std::iota(lexicon_mapping_.begin(), lexicon_mapping_.end(), 0);
+        internal_->noUseTokens_.clear();
+        if (mapOovToUnk_) {
+            size_t maxInVocab = internal_->tokens_.size();  // maxId + 1
+            verify(maxInVocab <= staticSize_);
+            for (u32 tId = 0; tId < staticSize_; ++tId) {
+                if (tId < maxInVocab && internal_->tokens_[tId])
+                    continue;  // in vocab
+                lexicon_mapping_[tId] = lexicon_mapping_.at(internal_->unkTokenId_);
+                internal_->oovTokens_.insert(tId);
+            }
+        }
+    }
+
+    internal_->lexiconMapping_ = &lexicon_mapping_;
+}
+
+Bliss::Token::Id BackingOffLm::reverseMapToken(Bliss::Token::Id tIdx) const {
+    Token tok = internal_->token(tIdx);
+    return tok ? tok->id() : Bliss::Token::invalidId;
 }
 
 // ===========================================================================

--- a/src/Lm/BackingOff.hh
+++ b/src/Lm/BackingOff.hh
@@ -37,14 +37,15 @@ public:
     class Internal;
     class Node;
 
-private:
+    typedef std::unordered_set<Bliss::Token::Id> TokenSet;
+
+protected:
     static const Core::ParameterString paramImage;
     friend class Internal;
     Core::Ref<Internal> internal_;
     class Automaton;
     void logInitialization() const;
 
-protected:
     BackingOffLm(const Core::Configuration&, Bliss::LexiconRef);
 
     /**
@@ -90,45 +91,36 @@ protected:
 
 public:
     typedef Node HistoryDescriptor;
-    virtual void load();
+
     virtual ~BackingOffLm();
+    virtual void                   load();
+    virtual Fsa::ConstAutomatonRef getFsa() const;
     virtual History                startHistory() const;
     virtual Lm::Score              sentenceBeginScore() const;
     virtual History                extendedHistory(const History&, Token w) const;
     virtual History                reducedHistory(const History&, u32 limit) const;
+    virtual History                reduceHistoryByN(const History&, u32 n) const;
     virtual std::string            formatHistory(const History&) const;
     virtual Lm::Score              score(const History&, Token w) const;
     virtual void                   getBatch(const History&, const CompiledBatchRequest*,
                                             std::vector<f32>& result) const;
-    virtual Fsa::ConstAutomatonRef getFsa() const;
+    virtual bool                   fixedHistory(s32 limit) const;
+    virtual bool                   isSparse(const History& h) const;
+    virtual HistorySuccessors      getHistorySuccessors(const History& h) const;
+    virtual Score                  getBackOffScore(const History& h) const;
+
     /**
      * Writes all tokens stored in the given history into the given vector
      */
     void historyTokens(const History& history, const Bliss::Token** target, u32& size, u32 arraySize) const;
 
-    u32 historyLenght(const History& history) const;
-
-    struct WordScore {
-        Bliss::Token::Id token_;
-        Lm::Score        score_;
-
-    public:
-        Bliss::Token::Id token() const {
-            return token_;
-        }
-        Lm::Score score() const {
-            return score_;
-        }
-        struct Ordering {
-            bool operator()(const WordScore& a, const WordScore& b) const {
-                return (a.token() < b.token());
-            }
-        };
-    };
+    u32 historyLength(const History& history) const;
 
     struct BackOffScores {
         BackOffScores()
-                : start(0), end(0), backOffScore(0) {
+                : start(0),
+                  end(0),
+                  backOffScore(0) {
         }
         const WordScore* start;
         const WordScore* end;
@@ -148,6 +140,14 @@ public:
      * With limit 1, returns the sum of the back-off offsets up to the _unigram_ level.
      * */
     Score getAccumulatedBackOffScore(const History& history, int limit) const;
+
+protected:
+    bool   mapOovToUnk_;
+    size_t staticSize_;
+
+    void             initTokenMapping(bool build = false);
+    Bliss::Token::Id reverseMapToken(Bliss::Token::Id tIdx) const;
+
 };
 
 }  // namespace Lm

--- a/src/Lm/CheatingSegmentLm.hh
+++ b/src/Lm/CheatingSegmentLm.hh
@@ -23,7 +23,13 @@ namespace Lm {
 
 class CheatingSegmentLm : public FsaLm {
 public:
-    using Precursor = FsaLm;
+    struct CheatingHistory : public Core::ReferenceCounted {
+        size_t             seq_idx;
+        Fsa::ConstStateRef fsa_state;
+    };
+
+    using Precursor         = FsaLm;
+    using HistoryDescriptor = CheatingHistory;
 
     static const Core::ParameterFloat paramInfinityScore;
 
@@ -33,17 +39,20 @@ public:
     virtual void load();
     virtual void setSegment(Bliss::SpeechSegment const* s);
 
+    virtual History startHistory() const;
+    virtual History extendedHistory(History const& h, Token w) const;
+    virtual Score   score(History const& h, Token w) const;
+    virtual Score   sentenceEndScore(History const& h) const;
+
+    virtual HistorySuccessors getHistorySuccessors(History const& h) const;
+
 private:
+    class HistoryManager;
+
+    size_t                                     segmentIdx_;
     Core::Ref<const Bliss::Lexicon>            lexicon_;
     Core::Ref<const Bliss::OrthographicParser> orthParser_;
 };
-
-// inline implementation
-
-inline CheatingSegmentLm::CheatingSegmentLm(Core::Configuration const& c, Bliss::LexiconRef l)
-        : Core::Component(c), Precursor(c, l), lexicon_(l), orthParser_(Core::ref(new Bliss::OrthographicParser(config, lexicon_))) {
-    infinityScore_ = paramInfinityScore(config);
-}
 
 }  // namespace Lm
 

--- a/src/Lm/FsaLm.cc
+++ b/src/Lm/FsaLm.cc
@@ -24,6 +24,16 @@ using namespace Lm;
 
 const Core::ParameterString FsaLm::paramFilename("file", "name of fsa file file to load as language model");
 
+const Core::ParameterBool FsaLm::paramGarbageLoopMode(
+        "garbage-loop-mode",
+        "accept garbage input (inf score) at any state towards the initial state, and allow looping over the fsa to accept multiple valid phrases in one utterance (final to initial)",
+        false);
+
+const Core::ParameterBool FsaLm::paramAcceptPartialRepeat(
+        "accept-partial-repeat",
+        "only under garbage-loop-mode: additionally accept repeating partial begin phrases",
+        false);
+
 Fsa::ConstStateRef FsaLm::invalidHistory(new Fsa::State(Fsa::InvalidStateId, Fsa::StateTagFinal));
 
 class FsaLm::HistoryManager : public ReferenceCountingHistoryManager {
@@ -41,29 +51,34 @@ protected:
 
     virtual std::string format(HistoryHandle hd) const {
         const Fsa::State* state = (const Fsa::State*)hd;
-        return Core::itoa(state->id());
+        return std::to_string(state->id());
     }
 };
 
-/*****************************************************************************/
 FsaLm::FsaLm(const Core::Configuration& c, Bliss::LexiconRef lexicon)
-        : Core::Component(c), LanguageModel(c, lexicon), syntacticTokens_(lexicon->syntacticTokenAlphabet()), infinityScore_(1e9)
-/*****************************************************************************/
-{
-    historyManager_ = new HistoryManager;
+        : Core::Component(c),
+          LanguageModel(c, lexicon),
+          syntacticTokens_(lexicon->syntacticTokenAlphabet()),
+          infinityScore_(1e9),
+          garbageLoopMode_(paramGarbageLoopMode(c)) {
+    historyManager_      = new HistoryManager;
+    acceptPartialRepeat_ = garbageLoopMode_ && paramAcceptPartialRepeat(c);
+    if (garbageLoopMode_) {
+        log() << "accept garbage and loop over FSA mode";
+    }
+    if (acceptPartialRepeat_) {
+        log() << "additionally accept repeating partial begin phrases";
+    }
 }
 
-/*****************************************************************************/
-FsaLm::~FsaLm()
-/*****************************************************************************/
-{
-    delete historyManager_;
+FsaLm::~FsaLm() {
+    if (historyManager_) {
+        delete historyManager_;
+        historyManager_ = nullptr;
+    }
 }
 
-/*****************************************************************************/
-void FsaLm::load()
-/*****************************************************************************/
-{
+void FsaLm::load() {
     const std::string filename(paramFilename(config));
     log("reading fsa as language model from file")
             << " \"" << filename << "\" ...";
@@ -77,34 +92,55 @@ void FsaLm::load()
     setFsa(Fsa::ConstAutomatonRef(f));
 }
 
-/*****************************************************************************/
-void FsaLm::setFsa(Fsa::ConstAutomatonRef f)
-/*****************************************************************************/
-{
+void FsaLm::setFsa(Fsa::ConstAutomatonRef f) {
     fsa_ = Fsa::cache(Fsa::sort(Fsa::determinize(Fsa::mapInput(f, syntacticTokens_)), Fsa::SortTypeByInput));
 }
 
-/*****************************************************************************/
-History FsaLm::startHistory() const
-/*****************************************************************************/
-{
-    Fsa::StateId initial = fsa_->initialStateId();
-    if (initial == Fsa::InvalidStateId)
-        error("language model fsa does not have an initial state");
-    Fsa::ConstStateRef sp = fsa_->getState(initial);
+History FsaLm::startHistory() const {
+    Fsa::ConstStateRef sp = initialState();
     sp->acquireReference();
     return history(sp.get());
 }
 
-/*****************************************************************************/
-History FsaLm::extendedHistory(const History& h, Token w) const
-/*****************************************************************************/
-{
+History FsaLm::extendedHistory(const History& h, Token w) const {
     Fsa::ConstStateRef sp(descriptor<Self>(h));
-    if (sp == invalidHistory) {
-        invalidHistory->acquireReference();
-        return history(invalidHistory.get());
+    if (sp != invalidHistory) {
+        sp = nextState(sp, w);
     }
+
+    sp->acquireReference();
+    return history(sp.get());
+}
+
+Lm::Score FsaLm::score(const History& h, Token w) const {
+    Fsa::ConstStateRef sp(descriptor<Self>(h));
+    return stateScore(sp, w);
+}
+
+Lm::Score FsaLm::sentenceEndScore(const History& h) const {
+    Fsa::ConstStateRef sp(descriptor<Self>(h));
+    return stateSentenceEndScore(sp);
+}
+
+HistorySuccessors FsaLm::getHistorySuccessors(const History& h) const {
+    Fsa::ConstStateRef sp(descriptor<Self>(h));
+    return getStateSuccessors(sp);
+}
+
+Fsa::ConstStateRef FsaLm::initialState() const {
+    Fsa::StateId initial = fsa_->initialStateId();
+    if (initial == Fsa::InvalidStateId) {
+        error("language model fsa does not have an initial state");
+    }
+    return fsa_->getState(initial);
+}
+
+Fsa::ConstStateRef FsaLm::nextState(Fsa::ConstStateRef sp, Token w) const {
+    Fsa::ConstStateRef initial = initialState();
+    bool               repeat  = acceptPartialRepeat_ && sp != initial;
+    // fsa may contain direct EPS path from initial to final
+    // reset completed path only once to avoid endless loop
+    bool resetFinal = sp != initial;
     while (sp) {
         Fsa::Arc tmp;
         tmp.input_                   = w->id();
@@ -112,63 +148,91 @@ History FsaLm::extendedHistory(const History& h, Token w) const
         if ((a == sp->end()) || (a->input() != w->id())) {
             a = sp->begin();
             if ((a == sp->end()) || (a->input() != Fsa::Epsilon)) {
-                invalidHistory->acquireReference();
-                return history(invalidHistory.get());
+                if (garbageLoopMode_) {
+                    if ((sp->isFinal() && resetFinal) || repeat) {
+                        sp         = initial;
+                        repeat     = false;
+                        resetFinal = false;
+                        continue;
+                    }
+                    else  // garbage state: initial
+                        return initial;
+                }
+                else {
+                    return invalidHistory;
+                }
             }
             sp = fsa_->getState(a->target());
         }
         else {
-            Fsa::ConstStateRef ts = fsa_->getState(a->target());
-            ts->acquireReference();
-            return history(ts.get());
+            return fsa_->getState(a->target());
         }
     }
-    return h;
+    return sp;
 }
 
-/*****************************************************************************/
-Lm::Score FsaLm::score(const History& h, Token w) const
-/*****************************************************************************/
-{
-    if (w == sentenceEndToken())
-        return sentenceEndScore(h);
-
-    Fsa::ConstStateRef sp(descriptor<Self>(h));
+Score FsaLm::stateScore(Fsa::ConstStateRef sp, Token w) const {
+    if (w == sentenceEndToken()) {
+        return stateSentenceEndScore(sp);
+    }
     if (sp == invalidHistory) {
         return infinityScore();
     }
-    Score score = 0.0;
+
+    Fsa::ConstStateRef initial    = fsa_->getState(fsa_->initialStateId());
+    bool               repeat     = acceptPartialRepeat_ && sp != initial;
+    bool               resetFinal = sp != initial;  // final to initial only once: avoid endless loop
+    Score              score      = 0.0;
     while (sp) {
         Fsa::Arc tmp;
-        tmp.input_                   = w->id();
+        tmp.input_ = w->id();
+        // search successors for input w
         Fsa::State::const_iterator a = sp->lower_bound(tmp, Fsa::byInput());
         if ((a == sp->end()) || (a->input() != w->id())) {
+            // not found: either none or still exist an EPS arc (first one)
             a = sp->begin();
             if ((a == sp->end()) || (a->input() != Fsa::Epsilon)) {
-                return infinityScore();
+                // dead end: no matching successor nor EPS arc to check further
+                if (garbageLoopMode_) {
+                    // reset to initial for final state (complete and may start over)
+                    if (sp->isFinal()) {
+                        score += Score(sp->weight_);
+                    }
+                    if ((sp->isFinal() && resetFinal) || repeat) {
+                        // either reset final or repeat partial: check again from initial
+                        sp         = initial;
+                        repeat     = false;
+                        resetFinal = false;
+                        continue;
+                    }
+                    else {  // otherwise infScore for dead end
+                        return infinityScore();
+                    }
+                }
+                else {  // infScore for dead end if not garbageLoopMode
+                    return infinityScore();
+                }
             }
+            // proceed along the EPS arc to check further
             sp = fsa_->getState(a->target());
             score += Score(a->weight());
         }
-        else {
+        else {  // found successor: return score
             return score + Score(a->weight());
         }
     }
     return infinityScore();
 }
 
-/*****************************************************************************/
-Lm::Score FsaLm::sentenceEndScore(const History& h) const
-/*****************************************************************************/
-{
-    Fsa::ConstStateRef sp(descriptor<Self>(h));
+Score FsaLm::stateSentenceEndScore(Fsa::ConstStateRef sp) const {
     if (sp == invalidHistory) {
         return infinityScore();
     }
     Score score = 0.0;
     while (sp) {
-        if (sp->isFinal())
+        if (sp->isFinal()) {
             return score + Score(sp->weight_);
+        }
         Fsa::State::const_iterator a = sp->begin();
         if ((a == sp->end()) || (a->input() != Fsa::Epsilon)) {
             return infinityScore();
@@ -179,113 +243,47 @@ Lm::Score FsaLm::sentenceEndScore(const History& h) const
     return infinityScore();
 }
 
-#if 0
-/*****************************************************************************/
-class FsaLm::CompiledBatchRequest : public Lm::CompiledBatchRequest {
-public:
-    struct Request {
-        InternalClassIndex internalClass;
-        u32 target;
-        Score offset;
-    };
-    typedef std::vector<Request> RequestList;
-    RequestList requests;
-    CompiledBatchRequest(Score scale) : Lm::CompiledBatchRequest(scale) {}
-};
+HistorySuccessors FsaLm::getStateSuccessors(Fsa::ConstStateRef sp) const {
+    HistorySuccessors res;
+    res.backOffScore = infinityScore();
 
-CompiledBatchRequest *FsaLm::compileBatchRequest(const BatchRequest &request, Score scale) const {
-    CompiledBatchRequest *result = new CompiledBatchRequest(scale);
-    CompiledBatchRequest::Request cr;
-    for (BatchRequest::const_iterator r = request.begin(); r != request.end(); ++r) {
-        cr.target = r->target;
-        cr.offset = r->offset;
-        if (r->tokens.length() == 0) {
-            cr.internalClass = nInternalClasses();
-        } else if (r->tokens.length() == 1) {
-            InternalClassIndex c = internalClassIndex(r->tokens[0]);
-            cr.internalClass = c;
-        } else if (r->tokens.length() > 1) {
-            criticalError("support for phrases not implemented in RwthLm::getBatch()");
+    Fsa::ConstStateRef initial    = fsa_->getState(fsa_->initialStateId());
+    bool               repeat     = acceptPartialRepeat_ && sp != initial;
+    bool               resetFinal = sp != initial;  // final to initial only once: avoid endless loop
+    Score              score      = 0.0;
+
+    while (sp and sp != invalidHistory) {
+        for (Fsa::State::const_iterator a = sp->begin(); a != sp->end(); ++a) {
+            if (a->input() != Fsa::Epsilon) {
+                res.emplace_back(a->input(), score + Score(a->weight()));
+            }
         }
-        result->requests.push_back(cr);
-    }
-    //  sort result ???
 
-    return result;
-}
-
-/*****************************************************************************/
-void FsaLm::getBatch(const History &h, const Lm::CompiledBatchRequest *r, std::vector<f32> &result) const
-/*****************************************************************************/
-{
-    Fsa::ConstStateRef sp(descriptor<Self>(h));
-    const CompiledBatchRequest *request = required_cast(const CompiledBatchRequest*, r);
-
-    // idea:
-    // - initialize with infinity
-    // - walk down through unigram (maintain stack of states)
-    // - fill with unigram scores
-    // - walk up and fill other scores
-
-    while (sp) {
-        Fsa::Arc tmp;
-        tmp.input_ = w->id();
-        Fsa::State::const_iterator a = sp->find(tmp, Fsa::byInput());
-        if (a == sp->end()) {
-            a = sp->begin();
-            if ((a == sp->end()) || (a->input() != Fsa::Epsilon))
-                return infinityScore();
+        Fsa::State::const_iterator a = sp->begin();
+        if ((a == sp->end()) || (a->input() != Fsa::Epsilon)) {
+            if (garbageLoopMode_) {
+                if (sp->isFinal()) {  // complete and may start over
+                    score += Score(sp->weight_);
+                }
+                if ((sp->isFinal() && resetFinal) || repeat) {
+                    sp         = initial;
+                    repeat     = false;
+                    resetFinal = false;
+                    continue;
+                }
+                else {
+                    break;
+                }
+            }
+            else {
+                break;
+            }
+        }
+        else {
             sp = fsa_->getState(a->target());
             score += Score(a->weight());
-        } else return score + Score(a->weight());
-    }
-    return infinityScore();
-
-    // copy unigram scores to scores
-    scores_ = unigram_;
-
-    // overwrite scores with bigram scores for those events observed
-    LMNodeType Node;
-    if (cd->length >= 1) {
-        LMTree_FindNode(cd->history, 1, &Node);
-        if (Node.Level == 1) {
-            for (std::vector<Score>::iterator s = scores_.begin(); s != scores_.end(); ++s)
-                *s += T->BOWeight[Node.Level][Node.Pos];
-
-            int pos1 = T->FirstChildPos[Node.Level][Node.Pos];
-            int pos2 = pos1 + T->NumChildren[Node.Level][Node.Pos];
-            for (int pos = pos1; pos < pos2; pos ++) {
-                scores_[T->Idx[Node.Level + 1][pos]] =
-                    T->Score[Node.Level + 1][pos] +
-                    classEmissionScore(T->Idx[Node.Level + 1][pos]);
-            }
         }
     }
 
-    // overwrite scores with trigram scores for those events observed
-    if (cd->length >= 2) {
-        LMTree_FindNode(cd->history, 2, &Node);
-        if (Node.Level == 2) {
-            for (std::vector<Score>::iterator s = scores_.begin(); s != scores_.end(); ++s)
-                *s += T->BOWeight[Node.Level][Node.Pos];
-
-            int pos1 = T->FirstChildPos[Node.Level][Node.Pos];
-            int pos2 = pos1 + T->NumChildren[Node.Level][Node.Pos];
-            for (int pos = pos1; pos < pos2; pos ++) {
-                scores_[T->Idx[Node.Level + 1][pos]] =
-                    T->Score[Node.Level + 1][pos] +
-                    classEmissionScore(T->Idx[Node.Level + 1][pos]);
-            }
-        }
-    }
-
-    scores_[nInternalClasses()] = 0.0;
-
-    // fill request
-    const CompiledBatchRequest::RequestList &requests(request->requests);
-    for (CompiledBatchRequest::RequestList::const_iterator r = requests.begin(); r != requests.end(); ++r) {
-        Score score = r->offset + request->scale() * scores_[r->internalClass];
-        if (result[r->target] > score) result[r->target] = score;
-    }
+    return res;
 }
-#endif

--- a/src/Lm/LanguageModel.cc
+++ b/src/Lm/LanguageModel.cc
@@ -41,7 +41,8 @@ LanguageModel::LanguageModel(const Core::Configuration& c, Bliss::LexiconRef l)
           tokenInventory_(0),
           fallbackToken_(0),
           sentenceBeginToken_(0),
-          sentenceEndToken_(0) {
+          sentenceEndToken_(0),
+          lexicon_mapping_() {
     tokenInventory_                = &l->syntacticTokenInventory();
     tokenAlphabet_                 = l->syntacticTokenAlphabet();
     requiresSentenceBoundaryToken_ = false;
@@ -68,7 +69,8 @@ private:
 
 public:
     TokenAlphabet(Core::Ref<const LanguageModel> lm)
-            : Bliss::TokenAlphabet(lm->tokenInventory()), lm_(lm) {}
+            : Bliss::TokenAlphabet(lm->tokenInventory()),
+              lm_(lm) {}
     virtual ~TokenAlphabet() {}
 };
 void LanguageModel::setTokenInventory(const TokenInventory* _tokenInventory) {
@@ -89,7 +91,7 @@ const Bliss::SyntacticToken* LanguageModel::getSpecialSyntacticToken(const std::
                   "No special lemma \"%s\" defined in lexicon.",
                   name.c_str(), name.c_str());
         }
-        return 0;
+        return nullptr;
     }
 
     if (!lemma->hasSyntacticTokenSequence()) {
@@ -98,7 +100,7 @@ const Bliss::SyntacticToken* LanguageModel::getSpecialSyntacticToken(const std::
                   "Special lemma \"%s\" does not specify a syntactic token.",
                   name.c_str(), name.c_str());
         }
-        return 0;
+        return nullptr;
     }
 
     const Bliss::SyntacticTokenSequence& tokenSequence(
@@ -110,7 +112,7 @@ const Bliss::SyntacticToken* LanguageModel::getSpecialSyntacticToken(const std::
                   "Special lemma \"%s\" specifies a syntactic token sequence of length zero.",
                   name.c_str(), name.c_str());
         }
-        return 0;
+        return nullptr;
     }
 
     const Bliss::SyntacticToken* token = tokenSequence[0];
@@ -157,6 +159,10 @@ Fsa::ConstAutomatonRef LanguageModel::getFsa() const {
 }
 
 History LanguageModel::reducedHistory(const History& h, u32) const {
+    return h;
+}
+
+History LanguageModel::reduceHistoryByN(const History& h, u32) const {
     return h;
 }
 

--- a/src/Lm/NNHistoryManager.hh
+++ b/src/Lm/NNHistoryManager.hh
@@ -95,7 +95,9 @@ private:
 // inline implementations
 
 inline NNHistoryManager::NNHistoryManager()
-        : HistoryManager(), has_on_release_handler_(false), on_release_handler_() {
+        : HistoryManager(),
+          has_on_release_handler_(false),
+          on_release_handler_() {
 }
 
 inline NNHistoryManager::~NNHistoryManager() {

--- a/src/Lm/ReverseArpaLm.cc
+++ b/src/Lm/ReverseArpaLm.cc
@@ -23,6 +23,7 @@
 #include <vector>
 #include <assert.h>
 #include <string.h>
+#include <unistd.h>
 
 // #define STANDALONE
 
@@ -203,7 +204,7 @@ float sentenceScore(const IndexedString* sentence, int len, const std::vector<NG
     return ret;
 }
 
-void reverseArpaLm(const std::string& inName, const std::string& outName, int testSamples, std::string testFile) {
+std::string reverseArpaLm(const std::string& inName, int testSamples, std::string testFile) {
 #ifdef STANDALONE
     std::ifstream infile(inName.c_str());
 #else
@@ -372,6 +373,11 @@ void reverseArpaLm(const std::string& inName, const std::string& outName, int te
     int order = ngrams.size();
 
     float offset = 0.0;
+
+    char tmpfn[] = "/tmp/reverse_lm_rasr_XXXXXX";
+    int  tmpfd   = mkstemp(tmpfn);
+    close(tmpfd);  // we only need the file name
+    std::string outName(tmpfn);
 
     std::cout << "writing " << outName << std::endl;
 
@@ -563,6 +569,7 @@ void reverseArpaLm(const std::string& inName, const std::string& outName, int te
 
         std::cout << "success" << std::endl;
     }
+    return outName;
 }
 
 }  // namespace Lm

--- a/src/Lm/ReverseArpaLm.hh
+++ b/src/Lm/ReverseArpaLm.hh
@@ -16,7 +16,7 @@
 #define REVERSE_ARPA_LM_HH
 
 namespace Lm {
-void reverseArpaLm(const std::string& sourcePath, const std::string& targetPath, int testSamples = 0, std::string testFile = std::string());
+std::string reverseArpaLm(const std::string& sourcePath, int testSamples = 0, std::string testFile = std::string());
 }
 
 #endif

--- a/src/Lm/ScaledLanguageModel.hh
+++ b/src/Lm/ScaledLanguageModel.hh
@@ -28,7 +28,9 @@ class ScaledLanguageModel : public LanguageModel,
                             public Mc::Component {
 protected:
     ScaledLanguageModel(const Core::Configuration& c, const Bliss::LexiconRef l)
-            : Core::Component(c), LanguageModel(c, l), Mc::Component(c) {}
+            : Core::Component(c),
+              LanguageModel(c, l),
+              Mc::Component(c) {}
 
 public:
     virtual ~ScaledLanguageModel() {}
@@ -75,6 +77,9 @@ public:
     virtual History reducedHistory(const History& h, u32 limit) const {
         return languageModel_->reducedHistory(h, limit);
     }
+    virtual History reduceHistoryByN(const History& h, u32 n) const {
+        return languageModel_->reduceHistoryByN(h, n);
+    }
     virtual std::string formatHistory(const History& h) const {
         return languageModel_->formatHistory(h);
     }
@@ -98,6 +103,25 @@ public:
                           std::vector<f32>&           result) const {
         return languageModel_->getBatch(h, r, result);
     }
+
+    virtual bool fixedHistory(s32 limit) const {
+        return languageModel_->fixedHistory(limit);
+    }
+    virtual bool isSparse(const History& h) const {
+        return languageModel_->isSparse(h);
+    }
+    virtual HistorySuccessors getHistorySuccessors(const History& h) const {
+        HistorySuccessors res;
+        res.backOffScore *= scale();
+        for (auto& ws : res) {
+            ws.score_ *= scale();
+        }
+        return res;
+    }
+    virtual Score getBackOffScore(const History& h) const {
+        return scale() * languageModel_->getBackOffScore(h);
+    };
+
     virtual Core::Ref<const LanguageModel> lookaheadLanguageModel() const {
         return languageModel_->lookaheadLanguageModel();
     }
@@ -106,6 +130,24 @@ public:
     }
     virtual void setSegment(Bliss::SpeechSegment const* s) {
         languageModel_->setSegment(s);
+    }
+    virtual Token sentenceBeginToken() const {
+        return languageModel_->sentenceBeginToken();
+    }
+    virtual Token sentenceEndToken() const {
+        return languageModel_->sentenceEndToken();
+    }
+    virtual Token sentenceBoundaryToken() const {
+        return languageModel_->sentenceBoundaryToken();
+    }
+    virtual Bliss::LexiconRef lexicon() const {
+        return languageModel_->lexicon();
+    }
+    virtual const TokenInventory& tokenInventory() const {
+        return languageModel_->tokenInventory();
+    }
+    virtual Fsa::ConstAlphabetRef tokenAlphabet() const {
+        return languageModel_->tokenAlphabet();
     }
 };
 

--- a/src/Lm/check.cc
+++ b/src/Lm/check.cc
@@ -32,8 +32,6 @@
 #include <Flow/Module.hh>
 #include <Lm/Module.hh>
 #include <Math/Module.hh>
-#include <Mc/Module.hh>
-#include <Me/Module.hh>
 #include <Mm/Module.hh>
 #include <Nn/Module.hh>
 #include <Signal/Module.hh>
@@ -54,14 +52,12 @@ public:
             : Core::Application() {
         INIT_MODULE(Lm);
         INIT_MODULE(Mm);
-        INIT_MODULE(Mc);
         INIT_MODULE(Flf);
         INIT_MODULE(Flow);
         INIT_MODULE(Math);
         INIT_MODULE(Signal);
         INIT_MODULE(Speech);
         INIT_MODULE(Nn);
-        INIT_MODULE(Me);
 
         setTitle("check");
     }

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -3078,7 +3078,7 @@ void SearchSpace::doStateStatistics() {
             int len = 0;
 
             if (h.isValid())
-                len = backOffLm->historyLenght(h);
+                len = backOffLm->historyLength(h);
 
             if (mt.lookahead.get())
                 statesInTreesWithLookAhead += mt.states.size();
@@ -3722,7 +3722,7 @@ Instance* SearchSpace::getBackOffInstance(Instance* instance) {
 
     Lm::History useHistory = instance->lookaheadHistory;
 
-    int length = lm->historyLenght(useHistory);
+    int length = lm->historyLength(useHistory);
 
     if (length == 0)
         return 0;
@@ -3730,7 +3730,7 @@ Instance* SearchSpace::getBackOffInstance(Instance* instance) {
     // Create a back-off network for history-length length-1
     Lm::History reduced = lm->reducedHistory(useHistory, length - 1);
 
-    verify(lm->historyLenght(reduced) == length - 1);
+    verify(lm->historyLength(reduced) == length - 1);
 
     verify(reduced.isValid());
 


### PR DESCRIPTION
Originally I wanted to only backport some fixes I made to the cheating LM, s.t. you can also do search-error experiments, but this escalated to many more changes in the LM codebase + some search related stuff. I tested that everything still compiles (in an appropriate singularity image), but it would be good if one / multiple of you could check if they get the same recognition results as before.