### PR TITLE
set c++17, add ONNX to config

### DIFF
--- a/config/cc-gcc.make
+++ b/config/cc-gcc.make
@@ -27,7 +27,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=gnu++0x
+CXXFLAGS	+= -std=gnu++17
 CXXFLAGS	+= -Wno-unknown-pragmas
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall

--- a/config/os-linux.make
+++ b/config/os-linux.make
@@ -62,6 +62,14 @@ TF_LDFLAGS += -Wl,-rpath -Wl,$(TF_COMPILE_BASE)/bazel-bin/tensorflow
 # USE_TENSORFLOW_MKL=1
 endif
 
+
+ifdef MODULE_ONNX
+LDFLAGS += -lonnxruntime
+ifndef MODULE_TENSORFLOW
+CXXFLAGS += -fexceptions
+endif
+endif
+
 # -----------------------------------------------------------------------------
 # system Libraries
 


### PR DESCRIPTION
With this changes I can directly compile at i6 with the latest images and need no other fixes except for changing the desired modules. 

I also tested that u16 with gcc 5.4 works with c++17.