### PR TITLE
Basic text lexicon parser

### DIFF
--- a/src/Bliss/Lexicon.cc
+++ b/src/Bliss/Lexicon.cc
@@ -142,7 +142,7 @@ const Core::Choice Lexicon::lexiconTypeChoice(
         "xml", xmlLexicon,
         Core::Choice::endMark());
 
-const Core::ParameterChoice Lexicon::lexiconTypeParam(
+const Core::ParameterChoice Lexicon::paramLexiconType(
         "type", &Lexicon::lexiconTypeChoice, "type of the lexicon file", xmlLexicon);
 
 void Lexicon::load(const std::string& filename) {
@@ -152,20 +152,20 @@ void Lexicon::load(const std::string& filename) {
     else
         warning("could not derive md5 sum from file '%s'", filename.c_str());
     std::unique_ptr<LexiconParser> parser;
-    Core::Choice::Value lexType = Lexicon::lexiconTypeParam(config);
-    switch (Lexicon::LexiconType(lexType)) {
+    switch (paramLexiconType(config)) {
     // text-based lexicon
-    case Lexicon::LexiconType::txtLexicon:
+    case LexiconType::txtLexicon:
         parser = std::make_unique<TextLexiconParser>(this);
         break;
     // xml-based lexicon
-    case Lexicon::LexiconType::xmlLexicon:
+    case LexiconType::xmlLexicon:
         parser = std::make_unique<XmlLexiconParser>(config, this);
         break;
     }
     log("reading lexicon from file") << " \"" << filename << "\" ...";
-    if (!parser->parseFile(filename))
+    if (!parser->parseFile(filename)) {
         error("Error while reading lexicon file.");
+    }
     log("dependency value: ") << dependency_.value();
 }
 

--- a/src/Bliss/Lexicon.cc
+++ b/src/Bliss/Lexicon.cc
@@ -137,8 +137,8 @@ Lexicon::~Lexicon() {
 }
 
 const Core::Choice Lexicon::lexiconTypeChoice(
-        "txt", txtLexicon,
-        "text", txtLexicon,
+        "vocab-txt", vocabTxtLexicon,
+        "vocab-text", vocabTxtLexicon,
         "xml", xmlLexicon,
         Core::Choice::endMark());
 
@@ -147,14 +147,15 @@ const Core::ParameterChoice Lexicon::paramLexiconType(
 
 void Lexicon::load(const std::string& filename) {
     Core::MD5 md5;
-    if (md5.updateFromFile(filename))
+    if (md5.updateFromFile(filename)) {
         dependency_.setValue(md5);
-    else
+    } else {
         warning("could not derive md5 sum from file '%s'", filename.c_str());
+    }
     std::unique_ptr<LexiconParser> parser;
     switch (paramLexiconType(config)) {
     // text-based lexicon
-    case LexiconType::txtLexicon:
+    case LexiconType::vocabTxtLexicon:
         parser = std::make_unique<TextLexiconParser>(this);
         break;
     // xml-based lexicon

--- a/src/Bliss/Lexicon.cc
+++ b/src/Bliss/Lexicon.cc
@@ -142,9 +142,15 @@ void Lexicon::load(const std::string& filename) {
         dependency_.setValue(md5);
     else
         warning("could not derive md5 sum from file '%s'", filename.c_str());
-    LexiconParser parser(config, this);
+    std::unique_ptr<LexiconParser> parser;
+    // text-based lexicon
+    if (filename.compare(filename.length()-4, 4, ".txt") == 0)
+        parser = std::make_unique<TextLexiconParser>(this);
+    // xml-based lexicon
+    else
+        parser = std::make_unique<XmlLexiconParser>(config, this);
     log("reading lexicon from file") << " \"" << filename << "\" ...";
-    if (parser.parseFile(filename.c_str()) != 0)
+    if (parser->parseFile(filename) != 0)
         error("Error while reading lexicon file.");
     log("dependency value: ") << dependency_.value();
 }

--- a/src/Bliss/Lexicon.cc
+++ b/src/Bliss/Lexicon.cc
@@ -156,7 +156,7 @@ void Lexicon::load(const std::string& filename) {
     switch (paramLexiconType(config)) {
     // text-based lexicon
     case LexiconType::vocabTxtLexicon:
-        parser = std::make_unique<TextLexiconParser>(this);
+        parser = std::make_unique<VocabTextLexiconParser>(this);
         break;
     // xml-based lexicon
     case LexiconType::xmlLexicon:

--- a/src/Bliss/Lexicon.hh
+++ b/src/Bliss/Lexicon.hh
@@ -477,7 +477,7 @@ class LemmaToEvaluationTokenTransducer;
  *
  * A lemma may be assigned a symbolic name, which the system can
  * use to identify lemmas which have a special meaning to it.
- * E.g. the silence word is is identified by the symbolic name
+ * E.g. the silence word is identified by the symbolic name
  * "silence".  Such lemmas a called "special lemmas".
  */
 
@@ -607,7 +607,7 @@ public:
     void defineSpecialLemma(const std::string& name, Lemma* lemma);
 
     /**
-     * Load lexicon from XML file.
+     * Load lexicon from XML or txt file.
      */
     void load(const std::string& filename);
 

--- a/src/Bliss/Lexicon.hh
+++ b/src/Bliss/Lexicon.hh
@@ -551,6 +551,14 @@ public:
         return dependency_;
     }
 
+    /** Type of the lexicon/the lexicon file format */
+    enum LexiconType {
+        txtLexicon,
+        xmlLexicon,
+    };
+    static const Core::Choice          lexiconTypeChoice;
+    static const Core::ParameterChoice lexiconTypeParam;
+
     /** Create a new lemma. */
     Lemma* newLemma();
 

--- a/src/Bliss/Lexicon.hh
+++ b/src/Bliss/Lexicon.hh
@@ -553,11 +553,11 @@ public:
 
     /** Type of the lexicon/the lexicon file format */
     enum LexiconType {
-        txtLexicon,
+        vocabTxtLexicon,
         xmlLexicon,
     };
     static const Core::Choice          lexiconTypeChoice;
-    static const Core::ParameterChoice lexiconTypeParam;
+    static const Core::ParameterChoice paramLexiconType;
 
     /** Create a new lemma. */
     Lemma* newLemma();

--- a/src/Bliss/LexiconParser.cc
+++ b/src/Bliss/LexiconParser.cc
@@ -442,17 +442,16 @@ void TextLexiconParser::createPhoneme(const std::string line) {
     suppressTrailingBlank(symbol);
 
     // check if phoneme was already added (if one label appears more than once)
-    const Phoneme* test = phonemeInventory_->phoneme(symbol);
-    if (test != 0) {
+    if (phonemeInventory_->phoneme(symbol)) {
         return;
     }
 
     // create a new phoneme
-    Phoneme* currentPhoneme_ = phonemeInventory_->newPhoneme();
+    Phoneme* newPhoneme_ = phonemeInventory_->newPhoneme();
     // set symbol
-    phonemeInventory_->assignSymbol(currentPhoneme_, symbol);
+    phonemeInventory_->assignSymbol(newPhoneme_, symbol);
     // set variation to none
-    currentPhoneme_->setContextDependent(false);
+    newPhoneme_->setContextDependent(false);
 }
 
 // helper function to handle one label and create a corresponding lemma
@@ -462,17 +461,16 @@ void TextLexiconParser::createLemma(const std::string line) {
     suppressTrailingBlank(symbol);
 
     // check if lemma was already added (if one label appears more than once)
-    const Lemma* test = lexicon_->lemma(symbol);
-    if (test != 0) {
+    if (lexicon_->lemma(symbol)) {
         return;
     }
 
     // create a new lemma
-    Lemma* currentLemma_ = lexicon_->newLemma();
+    Lemma* newLemma_ = lexicon_->newLemma();
     // set orth
-    lexicon_->setOrthographicForms(currentLemma_, {symbol});
+    lexicon_->setOrthographicForms(newLemma_, {symbol});
     // set phon
     Pronunciation* pron = lexicon_->getPronunciation(symbol);
-    lexicon_->addPronunciation(currentLemma_, pron);
-    lexicon_->setDefaultLemmaName(currentLemma_);
+    lexicon_->addPronunciation(newLemma_, pron);
+    lexicon_->setDefaultLemmaName(newLemma_);
 }

--- a/src/Bliss/LexiconParser.cc
+++ b/src/Bliss/LexiconParser.cc
@@ -425,7 +425,7 @@ bool TextLexiconParser::parseFile(const std::string& filename) {
 }
 
 // helper function to handle one label and create a corresponding phoneme
-void TextLexiconParser::createPhoneme(const std::string line) {
+void TextLexiconParser::createPhoneme(const std::string& line) {
     std::string symbol(line);
     stripWhitespace(symbol);        // in case there are any unintentional whitespaces
     suppressTrailingBlank(symbol);

--- a/src/Bliss/LexiconParser.cc
+++ b/src/Bliss/LexiconParser.cc
@@ -257,7 +257,7 @@ void LexiconElement::addPhon(const WeightedPhonemeString& phon) {
         return;
     if (!product_->phonemeInventory()) {
         parser()->warning(
-                "No phoneme inventory defined. Ingnoring pronunciation");
+                "No phoneme inventory defined. Ignoring pronunciation");
         return;
     }
 
@@ -358,7 +358,7 @@ const Core::ParameterString paramEncoding(
         "utf-8");
 }  // namespace
 
-void LexiconParser::loadWhitelist(const Core::Configuration& config, Core::StringHashSet& whitelist) {
+void XmlLexiconParser::loadWhitelist(const Core::Configuration& config, Core::StringHashSet& whitelist) {
     std::string filename = paramFile(config);
     if (!filename.empty()) {
         Core::CompressedInputStream* cis = new Core::CompressedInputStream(filename.c_str());
@@ -379,12 +379,100 @@ void LexiconParser::loadWhitelist(const Core::Configuration& config, Core::Strin
     }
 }
 
-LexiconParser::LexiconParser(const Core::Configuration& c, Lexicon* _lexicon)
-        : Precursor(c) {
+XmlLexiconParser::XmlLexiconParser(const Core::Configuration& c, Lexicon* _lexicon)
+        : LexiconParser(),
+          Precursor(c) {
     lexicon_ = _lexicon;
 
     // build schema
     LexiconElement* lexElement = new LexiconElement(this, LexiconElement::creationHandler(&Self::pseudoCreateLexicon), c);
     loadWhitelist(select("vocab"), lexElement->whitelist_);
     setRoot(collect(lexElement));
+}
+
+// use base class parse function
+int XmlLexiconParser::parseFile(const std::string& filename) {
+    return parser()->Core::XmlSchemaParser::parseFile(filename.c_str());
+}
+
+
+TextLexiconParser::TextLexiconParser(Lexicon* _lexicon)
+        : LexiconParser() {
+    lexicon_ = _lexicon;
+    phonemeInventory_ = new PhonemeInventory();
+}
+
+// parse txt file line by line to a Bliss::Lexicon
+// two passes over the file are required
+// as we first need to complete and set the phoneme inventory
+// and afterwards the lemmata can be created
+int TextLexiconParser::parseFile(const std::string& filename) {
+    // first pass: collect all labels as phonemes in the phoneme inventory
+    std::ifstream file_first_pass(filename);
+    if (!file_first_pass.is_open()) {
+        return 1;
+    }
+    std::string line;
+    while (std::getline(file_first_pass, line)) {
+        if (line.empty()) continue;
+        createPhoneme(line);
+    }
+    file_first_pass.close();
+
+    // set the phoneme inventory
+    lexicon_->setPhonemeInventory(Core::ref(phonemeInventory_));
+
+    // second pass: create the lemmata in the lexicon
+    std::ifstream file_second_pass(filename);
+    if (!file_second_pass.is_open()) {
+        return 1;
+    }
+    while (std::getline(file_second_pass, line)) {
+        if (line.empty()) continue;
+        createLemma(line);
+    }
+    file_second_pass.close();
+    return 0;
+}
+
+// helper function to handle one label and create a corresponding phoneme
+void TextLexiconParser::createPhoneme(const std::string line) {
+    std::string symbol(line);
+    stripWhitespace(symbol);        // in case there are any unintentional whitespaces
+    suppressTrailingBlank(symbol);
+
+    // check if phoneme was already added (if one label appears more than once)
+    const Phoneme* test = phonemeInventory_->phoneme(symbol);
+    if (test != 0) {
+        return;
+    }
+
+    // create a new phoneme
+    Phoneme* currentPhoneme_ = phonemeInventory_->newPhoneme();
+    // set symbol
+    phonemeInventory_->assignSymbol(currentPhoneme_, symbol);
+    // set variation to none
+    currentPhoneme_->setContextDependent(false);
+}
+
+// helper function to handle one label and create a corresponding lemma
+void TextLexiconParser::createLemma(const std::string line) {
+    std::string symbol(line);
+    stripWhitespace(symbol);        // in case there are any unintentional whitespaces
+    suppressTrailingBlank(symbol);
+
+    // check if lemma was already added (if one label appears more than once)
+    const Lemma* test = lexicon_->lemma(symbol);
+    if (test != 0) {
+        return;
+    }
+
+    // create a new lemma
+    Lemma* currentLemma_ = lexicon_->newLemma();
+    // set orth
+    lexicon_->setOrthographicForms(currentLemma_, {symbol});
+    // set phon
+    Pronunciation* pron = lexicon_->getPronunciation(symbol);
+    lexicon_->addPronunciation(currentLemma_, pron);
+    lexicon_->setDefaultLemmaName(currentLemma_);
 }

--- a/src/Bliss/LexiconParser.cc
+++ b/src/Bliss/LexiconParser.cc
@@ -396,7 +396,7 @@ bool XmlLexiconParser::parseFile(const std::string& filename) {
 }
 
 
-TextLexiconParser::TextLexiconParser(Lexicon* _lexicon)
+VocabTextLexiconParser::VocabTextLexiconParser(Lexicon* _lexicon)
         : LexiconParser() {
     lexicon_ = _lexicon;
     phonemeInventory_ = new PhonemeInventory();
@@ -405,7 +405,7 @@ TextLexiconParser::TextLexiconParser(Lexicon* _lexicon)
 // parse txt file line by line to a Bliss::Lexicon
 // in the first step, the phonemes are created and the phoneme inventory is set
 // and afterwards the lemmata can be created from these phonemes
-bool TextLexiconParser::parseFile(const std::string& filename) {
+bool VocabTextLexiconParser::parseFile(const std::string& filename) {
     // collect all labels from the file and add them as phonemes to the phoneme inventory
     std::ifstream file(filename);
     if (!file.is_open()) {
@@ -425,7 +425,7 @@ bool TextLexiconParser::parseFile(const std::string& filename) {
 }
 
 // helper function to handle one label and create a corresponding phoneme
-void TextLexiconParser::createPhoneme(const std::string& line) {
+void VocabTextLexiconParser::createPhoneme(const std::string& line) {
     std::string symbol(line);
     stripWhitespace(symbol);        // in case there are any unintentional whitespaces
     suppressTrailingBlank(symbol);
@@ -444,7 +444,7 @@ void TextLexiconParser::createPhoneme(const std::string& line) {
 }
 
 // helper function to create the lemmata
-void TextLexiconParser::createLemmata() {
+void VocabTextLexiconParser::createLemmata() {
     // iterate over the phonemes which were assigned to the inventory previously
     auto phonemes = phonemeInventory_->phonemes();
     for (auto it = phonemes.first; it != phonemes.second; ++it) {

--- a/src/Bliss/LexiconParser.hh
+++ b/src/Bliss/LexiconParser.hh
@@ -143,7 +143,7 @@ class TextLexiconParser : public LexiconParser {
 private:
     Lexicon* lexicon_;
     PhonemeInventory* phonemeInventory_;
-    void createPhoneme(const std::string line);
+    void createPhoneme(const std::string& line);
     void createLemmata();
 
 public:

--- a/src/Bliss/LexiconParser.hh
+++ b/src/Bliss/LexiconParser.hh
@@ -105,7 +105,7 @@ public:
 class LexiconParser {
 public:
     virtual ~LexiconParser() {}
-    virtual int parseFile(const std::string& filename) = 0;
+    virtual bool parseFile(const std::string& filename) = 0;
     virtual Lexicon* lexicon() const = 0;
 };
 
@@ -117,7 +117,6 @@ public:
  * through Lexicon.
  */
 class XmlLexiconParser : public virtual LexiconParser, public Core::XmlSchemaParser {
-    typedef Core::XmlSchemaParser Precursor;
     typedef XmlLexiconParser         Self;
 
 private:
@@ -129,7 +128,7 @@ private:
 
 public:
     XmlLexiconParser(const Core::Configuration& c, Lexicon*);
-    int parseFile(const std::string& filename) override;
+    bool parseFile(const std::string& filename) override;
     Lexicon* lexicon() const override {
         return lexicon_;
      }
@@ -145,11 +144,11 @@ private:
     Lexicon* lexicon_;
     PhonemeInventory* phonemeInventory_;
     void createPhoneme(const std::string line);
-    void createLemma(const std::string line);
+    void createLemmata();
 
 public:
     TextLexiconParser(Lexicon*);
-    int parseFile(const std::string& filename) override;
+    bool parseFile(const std::string& filename) override;
     Lexicon* lexicon() const override {
         return lexicon_;
     }

--- a/src/Bliss/LexiconParser.hh
+++ b/src/Bliss/LexiconParser.hh
@@ -51,12 +51,15 @@ struct WeightedPhonemeString;
 class PronunciationElement;
 class LexiconElement;
 class LexiconParser;
+class TextLexiconParser;
+class XmlLexiconParser;
 
 class LexiconElement : public Core::XmlBuilderElement<
                                Lexicon,
                                Core::XmlRegularElement,
                                Core::CreateByContext> {
     friend class LexiconParser;
+    friend class XmlLexiconParser;
     typedef Core::XmlBuilderElement<
             Lexicon,
             Core::XmlRegularElement,
@@ -96,6 +99,16 @@ public:
     virtual void characters(const char*, int){};
 };
 
+/*
+ * Base lexicon parser class
+ */
+class LexiconParser {
+public:
+    virtual ~LexiconParser() {}
+    virtual int parseFile(const std::string& filename) = 0;
+    virtual Lexicon* lexicon() const = 0;
+};
+
 /**
  * Parser for Bliss lexicon files.
  * This class implements parsing of the lexicon XML format
@@ -103,10 +116,9 @@ public:
  * Format Reference</a>.  It is normally not used directly but
  * through Lexicon.
  */
-
-class LexiconParser : public Core::XmlSchemaParser {
+class XmlLexiconParser : public virtual LexiconParser, public Core::XmlSchemaParser {
     typedef Core::XmlSchemaParser Precursor;
-    typedef LexiconParser         Self;
+    typedef XmlLexiconParser         Self;
 
 private:
     Lexicon* lexicon_;
@@ -116,12 +128,33 @@ private:
     void loadWhitelist(const Core::Configuration&, Core::StringHashSet&);
 
 public:
-    LexiconParser(const Core::Configuration& c, Lexicon*);
-    Lexicon* lexicon() const {
+    XmlLexiconParser(const Core::Configuration& c, Lexicon*);
+    int parseFile(const std::string& filename) override;
+    Lexicon* lexicon() const override {
+        return lexicon_;
+     }
+};
+
+/**
+ * Parser for txt lexicon files.
+ * This is meant for unconstrained search
+ * The .txt-file should contain one label per line
+ */
+class TextLexiconParser : public LexiconParser {
+private:
+    Lexicon* lexicon_;
+    PhonemeInventory* phonemeInventory_;
+    void createPhoneme(const std::string line);
+    void createLemma(const std::string line);
+
+public:
+    TextLexiconParser(Lexicon*);
+    int parseFile(const std::string& filename) override;
+    Lexicon* lexicon() const override {
         return lexicon_;
     }
 };
 
-}  // namespace Bliss
+} // namespace Bliss
 
 #endif  // _BLISS_LEXICONPARSER_HH

--- a/src/Bliss/LexiconParser.hh
+++ b/src/Bliss/LexiconParser.hh
@@ -135,11 +135,11 @@ public:
 };
 
 /**
- * Parser for txt lexicon files.
+ * Parser for text lexicon files containing the vocab, so only the labels
  * This is meant for unconstrained search
  * The .txt-file should contain one label per line
  */
-class TextLexiconParser : public LexiconParser {
+class VocabTextLexiconParser : public LexiconParser {
 private:
     Lexicon* lexicon_;
     PhonemeInventory* phonemeInventory_;
@@ -147,7 +147,7 @@ private:
     void createLemmata();
 
 public:
-    TextLexiconParser(Lexicon*);
+    VocabTextLexiconParser(Lexicon*);
     bool parseFile(const std::string& filename) override;
     Lexicon* lexicon() const override {
         return lexicon_;


### PR DESCRIPTION
Support for simple text lexica instead of XML-files.
This is meant for unconstrained search for which the XML-format is unnecessarily complicated.
Instead of an XML-lexicon, one can use a txt-file containing one label per line.
For example
```
A
B
C
```
will be parsed to a Bliss Lexicon equivalent to 
```
<?xml version="1.0" ?>
<lexicon>
  <phoneme-inventory>
    <phoneme>
      <symbol>A</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
      <symbol>B</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
      <symbol>C</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
 </phoneme-inventory>
  <lemma>
    <orth>A</orth>
    <phon>A</phon>
  </lemma>
  <lemma>
    <orth>B</orth>
    <phon>B</phon>
  </lemma>
  <lemma>
    <orth>C</orth>
    <phon>C</phon>
  </lemma>
</lexicon>
```