### PR TITLE
Bugfix: ONNX value creation based on transposed FastMatrix

### DIFF
--- a/src/Onnx/Value.cc
+++ b/src/Onnx/Value.cc
@@ -725,7 +725,7 @@ void Value::set(Math::FastMatrix<T> const& mat, bool transpose) {
         // if we transpose we can iterate over both matrices linearly
         for (u32 c = 0u; c < mat.nColumns(); c++) {
             for (u32 r = 0u; r < mat.nRows(); r++) {
-                data[c * mat.nColumns() + r] = mat.at(r, c);
+                data[c * mat.nRows() + r] = mat.at(r, c);
             }
         }
     }


### PR DESCRIPTION
The `set` function of `Onnx::Value` with a transposed FastMatrix is wrong. The assign logic is

```
        for (u32 c = 0u; c < mat.nColumns(); c++) {
            for (u32 r = 0u; r < mat.nRows(); r++) {
                data[c * mat.nColumns() + r] = mat.at(r, c);
            }
        }
```
but it should be `data[c * mat.nRows() + r] = mat.at(r, c);`.

For example if `mat` is a FastMatrix of shape 1 x 3 then the current logic works like this:

1. `c = 0`, `r = 0`: `data[0] = mat.at(0, 0)`
2. `c = 1`, `r = 0`: `data[3] = mat.at(0, 1)`
3. `c = 2`, `r = 0`: `data[6] = mat.at(0, 2)`

With the fix it works properly like this:
1. `c = 0`, `r = 0`: `data[0] = mat.at(0, 0)`
2. `c = 1`, `r = 0`: `data[1] = mat.at(0, 1)`
3. `c = 2`, `r = 0`: `data[2] = mat.at(0, 2)`