### PR TITLE
Refactor tree construction in AdvancedTreeSearch to allow multiple TreeBuilder types

### DIFF
--- a/src/Search/AdvancedTreeSearch/PersistentStateTree.cc
+++ b/src/Search/AdvancedTreeSearch/PersistentStateTree.cc
@@ -41,7 +41,7 @@ struct ConvertTree {
     TreeIndex                                                            masterTreeIndex;
     StateId                                                              rootSubTree;
     StateId                                                              ciRootNode;
-    std::map<StateTree::Exit, u32>                                       exits;  //Maps exits to label-indices @todo Make this a hash_map
+    std::map<StateTree::Exit, u32>                                       exits;  // Maps exits to label-indices @todo Make this a hash_map
     std::vector<PersistentStateTree::Exit>                               exitVector;
     Core::HashMap<StateId, StateTree::StateId>                           statesForNodes;
     Core::HashMap<StateTree::StateId, StateId>                           nodesForStates;
@@ -73,7 +73,7 @@ struct ConvertTree {
             }
         }
 
-        ///Make sure a node is created for every single state, so that also the coarticulated roots are respected
+        /// Make sure a node is created for every single state, so that also the coarticulated roots are respected
 
         for (std::set<StateTree::StateId>::iterator stateIt = coarticulatedRootStates.begin(); stateIt != coarticulatedRootStates.end(); ++stateIt) {
             StateTree::StateId state = *stateIt;
@@ -121,7 +121,7 @@ struct ConvertTree {
                 exitIndices.insert(exitEntry->second);
             }
 
-            //Add connections to the attached outputs/exits
+            // Add connections to the attached outputs/exits
             for (std::set<u32>::iterator it = exitIndices.begin(); it != exitIndices.end(); ++it)
                 subtrees.addOutputToEdge(subtrees.state(node).successors, *it);
         }
@@ -150,10 +150,10 @@ private:
 
         subtrees.state(node).stateDesc = state;
 
-        //Build successor structure
+        // Build successor structure
         std::pair<StateTree::SuccessorIterator, StateTree::SuccessorIterator> successors = tree->successors(stateId);
 
-        StateId current = node;  //Just to verify the order
+        StateId current = node;  // Just to verify the order
 
         for (; successors.first != successors.second; ++successors.first) {
             std::unordered_map<StateTree::StateId, StateId>::iterator nodeIt = nodesForStates.find(*successors.first);
@@ -437,7 +437,7 @@ HMMStateNetwork::CleanupResult PersistentStateTree::cleanup(bool cleanupExits) {
 
     Core::HashMap<StateId, StateId>::const_iterator targetNodeIt;
     if (rootState) {
-        verify(cleanupResult.nodeMap.find(rootState) != cleanupResult.nodeMap.end());  //Root-node must stay unchanged
+        verify(cleanupResult.nodeMap.find(rootState) != cleanupResult.nodeMap.end());  // Root-node must stay unchanged
         verify(cleanupResult.nodeMap.find(rootState)->second == rootState);
         targetNodeIt = cleanupResult.nodeMap.find(rootState);
         verify(targetNodeIt != cleanupResult.nodeMap.end());

--- a/src/Search/AdvancedTreeSearch/PersistentStateTree.hh
+++ b/src/Search/AdvancedTreeSearch/PersistentStateTree.hh
@@ -44,25 +44,25 @@ public:
     ///@param lexicon This must be given if the resulting exits are supposed to be functional
     PersistentStateTree(Core::Configuration config, Core::Ref<const Am::AcousticModel> acousticModel, Bliss::LexiconRef lexicon, TreeBuilderFactory treeBuilderFactory);
 
-    ///Builds this state tree.
+    /// Builds this state tree.
     void build();
 
-    ///Writes the current state of the state tree into the file,
-    ///Returns whether writing was successful
+    /// Writes the current state of the state tree into the file,
+    /// Returns whether writing was successful
     bool write(int transformation = 0);
 
-    ///Reads the state tree from the file.
+    /// Reads the state tree from the file.
     ///@return Whether the reading was successful.
     bool read(int transformation = 0);
 
-    ///Cleans up the structure, saving memory and allowing a more efficient iteration.
-    ///Node and tree IDs may be changed.
+    /// Cleans up the structure, saving memory and allowing a more efficient iteration.
+    /// Node and tree IDs may be changed.
     ///@return An object that contains a mapping representing the index changes.
     HMMStateNetwork::CleanupResult cleanup(bool cleanupExits = true);
 
-    ///Removes all outputs from the network
-    ///Also performs a cleanup, so the search network must already be clean
-    ///for indices to stay equal
+    /// Removes all outputs from the network
+    /// Also performs a cleanup, so the search network must already be clean
+    /// for indices to stay equal
     void removeOutputs();
 
     u32 getChecksum() const;
@@ -134,10 +134,10 @@ private:
     Core::Configuration                config_;
     TreeBuilderFactory                 treeBuilderFactory_;
 
-    //Writes the whole state network into the given stream
+    // Writes the whole state network into the given stream
     void write(Core::MappedArchiveWriter writer);
 
-    //Reads the state network from the given stream.
+    // Reads the state network from the given stream.
     //@return Whether the reading was successful.
     bool read(Core::MappedArchiveReader reader);
 };

--- a/src/Search/AdvancedTreeSearch/PersistentStateTree.hh
+++ b/src/Search/AdvancedTreeSearch/PersistentStateTree.hh
@@ -31,14 +31,18 @@ struct MyStandardValueHash {
     }
 };
 
+class AbstractTreeBuilder;
+
 namespace Search {
 class HMMStateNetwork;
 class StateTree;
 
 class PersistentStateTree {
 public:
+    using TreeBuilderFactory = std::function<std::unique_ptr<AbstractTreeBuilder>(Core::Configuration, const Bliss::Lexicon&, const Am::AcousticModel&, PersistentStateTree&, bool)>;
+
     ///@param lexicon This must be given if the resulting exits are supposed to be functional
-    PersistentStateTree(Core::Configuration config, Core::Ref<const Am::AcousticModel> acousticModel, Bliss::LexiconRef lexicon);
+    PersistentStateTree(Core::Configuration config, Core::Ref<const Am::AcousticModel> acousticModel, Bliss::LexiconRef lexicon, TreeBuilderFactory treeBuilderFactory);
 
     ///Builds this state tree.
     void build();
@@ -128,6 +132,7 @@ private:
     Core::Ref<const Am::AcousticModel> acousticModel_;
     Bliss::LexiconRef                  lexicon_;
     Core::Configuration                config_;
+    TreeBuilderFactory                 treeBuilderFactory_;
 
     //Writes the whole state network into the given stream
     void write(Core::MappedArchiveWriter writer);

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -3108,7 +3108,7 @@ void SearchSpace::doStateStatistics() {
             int len = 0;
 
             if (h.isValid())
-                len = backOffLm->historyLenght(h);
+                len = backOffLm->historyLength(h);
 
             if (mt.lookahead.get())
                 statesInTreesWithLookAhead += mt.states.size();
@@ -3240,10 +3240,10 @@ void SearchSpace::recombineWordEndsInternal(bool shallCreateLattice) {
         ReducedContextRecombinationMap wordEndHypothesisMap;
 
         for (in = out = wordEndHypotheses.begin(); in != wordEndHypotheses.end(); ++in) {
-            auto                                     key = std::make_pair(recombinationLm_->reducedHistory(in->recombinationHistory,
-                                                                                                           reducedContextWordRecombinationLimit_),
-                                                                          in->transitState);
-            ReducedContextRecombinationMap::iterator i   = wordEndHypothesisMap.find(key);
+            auto key = std::make_pair(recombinationLm_->reducedHistory(in->recombinationHistory, reducedContextWordRecombinationLimit_),
+                                      in->transitState);
+
+            ReducedContextRecombinationMap::iterator i = wordEndHypothesisMap.find(key);
             if (i != wordEndHypothesisMap.end()) {
                 WordEndHypothesis& a(*in);
                 WordEndHypothesis& b(*(i->second));
@@ -3752,7 +3752,7 @@ Instance* SearchSpace::getBackOffInstance(Instance* instance) {
 
     Lm::History useHistory = instance->lookaheadHistory;
 
-    int length = lm->historyLenght(useHistory);
+    int length = lm->historyLength(useHistory);
 
     if (length == 0)
         return 0;
@@ -3760,7 +3760,7 @@ Instance* SearchSpace::getBackOffInstance(Instance* instance) {
     // Create a back-off network for history-length length-1
     Lm::History reduced = lm->reducedHistory(useHistory, length - 1);
 
-    verify(lm->historyLenght(reduced) == length - 1);
+    verify(lm->historyLength(reduced) == length - 1);
 
     verify(reduced.isValid());
 

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -230,7 +230,7 @@ const Core::ParameterBool paramReducedContextTreeKey(
 
 const Core::ParameterBool paramOnTheFlyRescoring(
         "on-the-fly-rescoring",
-        "keep track of recombined histories and use those aswell when searching for word ends",
+        "keep track of recombined histories and use those as well when searching for word ends",
         false);
 
 const Core::ParameterInt paramOnTheFlyRescoringMaxHistories(
@@ -391,7 +391,6 @@ StaticSearchAutomaton::StaticSearchAutomaton(Core::Configuration config, Core::R
           treeBuilderType_(static_cast<TreeBuilderType>(paramTreeBuilderType(config))),
           acousticModel_(acousticModel),
           lexicon_(lexicon) {
-
     if (treeBuilderType_ == TreeBuilderType::previousBehavior) {
         treeBuilderType_ = minimized ? TreeBuilderType::minimizedHmm : TreeBuilderType::classicHmm;
     }
@@ -405,7 +404,7 @@ StaticSearchAutomaton::~StaticSearchAutomaton() {
 
 void StaticSearchAutomaton::buildNetwork() {
     /// @todo Track the TreeBuilder configuration in transformation if minimizedTree
-    int  transformation = minimized ? 32 : 0;
+    int transformation = minimized ? 32 : 0;
     if (!network.read(transformation)) {
         log() << "persistent network image could not be loaded, building it";
 
@@ -1165,7 +1164,7 @@ inline bool SearchSpace::eventuallyDeactivateTree(Instance* at, bool increaseIna
 
 void SearchSpace::activateOrUpdateStateHypothesisLoop(const Search::StateHypothesis& hyp, Score score) {
     StateHypothesisIndex& recombination = stateHypothesisRecombinationArray[hyp.state];  // Look-up at node index, contains positions in newStateHypotheses.
-    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);                  //We may be referencing a not allocated position, so we use data()
+    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);                  // We may be referencing a not allocated position, so we use data()
     // Check if present in current tree (starting at currentTreeFirstNewStateHypothesis).
     if (recombination < currentTreeFirstNewStateHypothesis || recombination >= newStateHypotheses.size() || sh.state != hyp.state) {
         recombination = newStateHypotheses.size();
@@ -1173,7 +1172,7 @@ void SearchSpace::activateOrUpdateStateHypothesisLoop(const Search::StateHypothe
         newStateHypotheses.back().score = score;
     }
     else {
-        //Update existing hypothesis
+        // Update existing hypothesis
         if (sh.score >= score) {
             sh.score = score;
             sh.trace = hyp.trace;
@@ -1183,7 +1182,7 @@ void SearchSpace::activateOrUpdateStateHypothesisLoop(const Search::StateHypothe
 
 void SearchSpace::activateOrUpdateStateHypothesisTransition(const Search::StateHypothesis& hyp, Score score, StateId successorState) {
     StateHypothesisIndex& recombination = stateHypothesisRecombinationArray[successorState];
-    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);  //We may be referencing a not allocated position, so we use data()
+    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);  // We may be referencing a not allocated position, so we use data()
     // Check if present in current tree (starting at currentTreeFirstNewStateHypothesis).
     if (recombination < currentTreeFirstNewStateHypothesis || recombination >= newStateHypotheses.size() || sh.state != successorState) {
         recombination = newStateHypotheses.size();
@@ -1192,7 +1191,7 @@ void SearchSpace::activateOrUpdateStateHypothesisTransition(const Search::StateH
         newStateHypotheses.back().state = successorState;
     }
     else {
-        //Update existing hypothesis
+        // Update existing hypothesis
         if (sh.score >= score) {
             sh.score = score;
             sh.trace = hyp.trace;
@@ -1202,14 +1201,14 @@ void SearchSpace::activateOrUpdateStateHypothesisTransition(const Search::StateH
 
 void SearchSpace::activateOrUpdateStateHypothesisDirectly(const Search::StateHypothesis& hyp) {
     StateHypothesisIndex& recombination = stateHypothesisRecombinationArray[hyp.state];
-    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);  //We may be referencing a not allocated position, so we use data()
+    StateHypothesis&      sh(newStateHypotheses.data()[recombination]);  // We may be referencing a not allocated position, so we use data()
 
     if (recombination < currentTreeFirstNewStateHypothesis || recombination >= newStateHypotheses.size() || sh.state != hyp.state) {
         recombination = newStateHypotheses.size();
         addNewStateHypothesis(hyp);
     }
     else {
-        //Update existing hypothesis
+        // Update existing hypothesis
         if (sh.score >= hyp.score) {
             sh.score = hyp.score;
             sh.trace = hyp.trace;
@@ -1245,7 +1244,7 @@ void SearchSpace::expandStateSlow(const Search::StateHypothesis& hyp) {
     if (forwardScore < Core::Type<Score>::max) {
         std::pair<int, int> successors = net.structure.batchSuccessorsSimple<true>(state.successors);
         if (successors.first != -1) {
-            //Fast iteration
+            // Fast iteration
             for (StateId successor = successors.first; successor != successors.second; ++successor) {
                 if (expandForward)
                     activateOrUpdateStateHypothesisTransition(hyp, forwardScore, successor);  // Already covered by expandState?
@@ -1254,7 +1253,7 @@ void SearchSpace::expandStateSlow(const Search::StateHypothesis& hyp) {
                 {                          // Second order expansion (successors of successor).
                     std::pair<int, int> skipSuccessors = net.structure.batchSuccessorsSimple<true>(net.structure.state(successor).successors);
                     if (skipSuccessors.first != -1) {
-                        //Fast iteration
+                        // Fast iteration
                         for (StateId skipSuccessor = skipSuccessors.first; skipSuccessor != skipSuccessors.second; ++skipSuccessor)
                             activateOrUpdateStateHypothesisTransition(hyp, skipScore, skipSuccessor);
                     }
@@ -1346,7 +1345,7 @@ inline void SearchSpace::expandState(const Search::StateHypothesis& hyp) {
                     activateOrUpdateStateHypothesisTransition(hyp, skipScore, successor2);
         }
         else if (secondStart == 0) {
-            //The secondOrderEdgeSuccessorBatches_ structure can not hold the successors, so use slow expansion to expand the second-order followers
+            // The secondOrderEdgeSuccessorBatches_ structure can not hold the successors, so use slow expansion to expand the second-order followers
             expandStateSlow<false, true>(hyp);
         }
     }
@@ -1561,7 +1560,7 @@ void SearchSpace::applyLookaheadInInstanceInternal(Instance* _instance, Acoustic
             fail = !la->getScoreForLookAheadHashSparse(ids.first, lmScore);
 
             if (fail) {
-                //This state needs to transfer into the back-off network
+                // This state needs to transfer into the back-off network
 
                 // Set the prospect to max, so this state will be pruned away from this network
                 sh->prospect = F32_MAX;
@@ -1654,7 +1653,7 @@ void SearchSpace::addAcousticScoresInternal(Instance const& instance, Pruning& p
         // Omit overhead of a virtual function-call for cached scores by calling the score function directly with qualification
         for (; sh != sh_end; ++sh) {
             if (sh->prospect == F32_MAX)
-                continue;  //This state will be pruned
+                continue;  // This state will be pruned
 
             const HMMState&  state = network().structure.state(sh->state);
             Mm::MixtureIndex mix   = state.stateDesc.acousticModel;
@@ -1672,7 +1671,7 @@ void SearchSpace::addAcousticScoresInternal(Instance const& instance, Pruning& p
     else {
         for (; sh != sh_end; ++sh) {
             if (sh->prospect == F32_MAX)
-                continue;  //This state will be pruned
+                continue;  // This state will be pruned
 
             const HMMState&  state = network().structure.state(sh->state);
             Mm::MixtureIndex mix   = state.stateDesc.acousticModel;
@@ -1904,7 +1903,6 @@ void SearchSpace::pruneStates(Pruning& pruning) {
 
     activeInstances.resize(instOut);
 }
-
 
 void SearchSpace::updateSsaLm() {
     if (!ssaLm_) {
@@ -3011,7 +3009,7 @@ void SearchSpace::doStateStatisticsBeforePruning() {
 
     for (InstanceList::reverse_iterator it = activeInstances.rbegin(); it != activeInstances.rend(); ++it) {
         if (backOffLm) {
-            //Do statistics over the count of states in back-off instances
+            // Do statistics over the count of states in back-off instances
             Instance& mt = dynamic_cast<Instance&>(**it);
 
             if (mt.lookahead.get())
@@ -3102,7 +3100,7 @@ void SearchSpace::doStateStatistics() {
 
     for (InstanceList::reverse_iterator it = activeInstances.rbegin(); it != activeInstances.rend(); ++it) {
         if (backOffLm) {
-            //Do statistics over the count of states in back-off instances
+            // Do statistics over the count of states in back-off instances
             Instance& mt = dynamic_cast<Instance&>(**it);
 
             Lm::History h = mt.lookaheadHistory;
@@ -3243,8 +3241,8 @@ void SearchSpace::recombineWordEndsInternal(bool shallCreateLattice) {
 
         for (in = out = wordEndHypotheses.begin(); in != wordEndHypotheses.end(); ++in) {
             auto                                     key = std::make_pair(recombinationLm_->reducedHistory(in->recombinationHistory,
-                                                                       reducedContextWordRecombinationLimit_),
-                                      in->transitState);
+                                                                                                           reducedContextWordRecombinationLimit_),
+                                                                          in->transitState);
             ReducedContextRecombinationMap::iterator i   = wordEndHypothesisMap.find(key);
             if (i != wordEndHypothesisMap.end()) {
                 WordEndHypothesis& a(*in);
@@ -3600,7 +3598,7 @@ Instance* SearchSpace::activateOrUpdateTree(const Core::Ref<Trace>& trace,
                                             Score                   score) {
     /// TODO (Nolden): getLastSyntacticToken is inefficient for long sequences. A simple rule would be better: Stay in same instance, or follow most recent pron.
     InstanceKey key(recombinationHistory, conditionPredecessorWord_ ? getLastSyntacticToken(trace) : Bliss::LemmaPronunciation::invalidId);
-    Instance* instance = instanceForKey(true, key, lookaheadHistory, scoreHistory);
+    Instance*   instance = instanceForKey(true, key, lookaheadHistory, scoreHistory);
 
     if (!instance)
         return 0;
@@ -3619,7 +3617,7 @@ void SearchSpace::processOneWordEnd(Instance const& at, StateHypothesis const& h
     PersistentStateTree::Exit const* we   = &network().exits[exit];
     TraceItem const&                 item = trace_manager_.traceItem(hyp.trace);
 
-    //We can do a more efficient word end handling if there is only one item in the trace, which is the standard case
+    // We can do a more efficient word end handling if there is only one item in the trace, which is the standard case
     verify_(item.scoreHistory.isValid());
 
     EarlyWordEndHypothesis weh(hyp.trace,
@@ -3697,10 +3695,10 @@ void SearchSpace::findWordEndsInternal() {
             Score           exitPenalty = (*transitionModel(state.stateDesc))[Am::StateTransitionModel::exit];
 
             if (earlyWordEndPruning && hyp.score + exitPenalty + earlyWordEndPruningAnticipatedLmScore_ > bestWordEndPruning) {
-                continue;  //Apply early word-end pruning (If the best score can not be reached, do not even try)
+                continue;  // Apply early word-end pruning (If the best score can not be reached, do not even try)
             }
 
-            ///With pushing, ca. 80% of all label-lists are single-labels, so optimize for this case
+            /// With pushing, ca. 80% of all label-lists are single-labels, so optimize for this case
             if (exit >= 0) {
                 // There is 1 label
                 processOneWordEnd<earlyWordEndPruning, onTheFlyRescoring>(*inst, hyp, exit, exitPenalty, relativePruning, bestWordEndPruning);
@@ -3726,7 +3724,7 @@ void SearchSpace::findWordEndsInternal() {
 }
 
 void SearchSpace::findWordEnds() {
-    //std::cerr << "best hyp: " << bestScore() << std::endl;
+    // std::cerr << "best hyp: " << bestScore() << std::endl;
     if (earlyWordEndPruning_) {
         if (onTheFlyRescoring_) {
             findWordEndsInternal<true, true>();

--- a/src/Search/AdvancedTreeSearch/SearchSpace.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.hh
@@ -132,7 +132,6 @@ private:
     Bliss::LexiconRef                  lexicon_;
 };
 
-
 class SearchSpace : public Core::Component {
 public:
     /// Statistics:
@@ -338,7 +337,9 @@ public:
     void rescale(Score offset, bool ignoreWordEnds = false);
 
     // Returns the info from trace manager about whether it needs cleanup
-    inline bool needCleanup() const { return trace_manager_.needCleanup();}
+    inline bool needCleanup() const {
+        return trace_manager_.needCleanup();
+    }
 
     // Needs to be called once in a while, but not every timeframe,
     // deletes all traces that did not survive in stateHypotheses and rootStateHypotheses of activeTrees
@@ -370,18 +371,18 @@ public:
     void                                        setLookAhead(const std::deque<Core::Ref<const Speech::Feature>>&);
     Search::SearchAlgorithm::RecognitionContext setContext(Search::SearchAlgorithm::RecognitionContext);
 
-    ///Returns the best prospect, eg. the score of the best state hypothesis including the look-ahead score
+    /// Returns the best prospect, eg. the score of the best state hypothesis including the look-ahead score
     Score bestProspect() const;
     ///@warning: Expensive, without caching
     StateHypothesesList::const_iterator bestProspectStateHypothesis() const;
-    ///Returns the best score (the look-ahead score is not included)
+    /// Returns the best score (the look-ahead score is not included)
     ///@warning: Expensive, but with caching
     Score bestScore() const;
     ///@warning: Expensive, without caching
     StateHypothesesList::const_iterator bestScoreStateHypothesis() const;
     Score                               quantileStateScore(Score min, Score max, u32 nHyp) const;
-    ///Returns the lowest word end score (without look-ahead)
-    ///Always valid after findWordEnds was called
+    /// Returns the lowest word end score (without look-ahead)
+    /// Always valid after findWordEnds was called
     Score minimumWordEndScore() const;
     Score quantileWordEndScore(Score min, Score max, u32 nHyp) const;
 

--- a/src/Search/AdvancedTreeSearch/SearchSpace.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.hh
@@ -50,6 +50,13 @@ class StaticSearchAutomaton : public Core::Component {
 public:
     using Precursor = Core::Component;
 
+    enum class TreeBuilderType {
+        previousBehavior = 0,
+        classicHmm       = 1,
+        minimizedHmm     = 2,
+        ctc              = 3,
+    };
+
     /// HMM length of a common phoneme
     const u32 hmmLength;
     bool      minimized;
@@ -68,7 +75,7 @@ public:
     std::vector<int> singleLabels;
     // LM- and acoustic look-ahead ids together, for quicker access
     std::vector<std::pair<u32, u32>> lookAheadIds;
-    // Sparse LM lookahead hash and acoustic lookahead id paired togeter
+    // Sparse LM lookahead hash and acoustic lookahead id paired together
     std::vector<std::pair<u32, u32>> lookAheadIdAndHash;
 
     std::vector<int> stateDepths;
@@ -79,7 +86,7 @@ public:
     std::vector<unsigned char> truncatedInvertedStateDepths;
     std::vector<unsigned char> truncatedStateDepths;
 
-    // number of transitions needed untill the next word end (that is not silence)
+    // number of transitions needed until the next word end (that is not silence)
     std::vector<unsigned> labelDistance;
 
     /// Optional filter which allows limiting the search space to a certain word sequence prefix
@@ -114,6 +121,11 @@ public:
 
     // Creates fast look-up structures like singleOutputs_, quickOutputBatches_ and secondOrderEdgeTargetBatches_.
     void buildBatches();
+
+protected:
+    TreeBuilderType treeBuilderType_;
+
+    std::unique_ptr<AbstractTreeBuilder> createTreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true);
 
 private:
     Core::Ref<const Am::AcousticModel> acousticModel_;
@@ -299,7 +311,7 @@ public:
     // Creates early word end hypotheses from the active state hypotheses
     void findWordEnds();
 
-    // Prunes early word end hypotheses, and expands them to normal word end hypothses
+    // Prunes early word end hypotheses, and expands them to normal word end hypotheses
     void pruneEarlyWordEnds();
 
     // Applies time-, score- and transit-modification to the given trace-id, and returns the corrected trace item (as successor of the original trace item)
@@ -332,7 +344,7 @@ public:
     // deletes all traces that did not survive in stateHypotheses and rootStateHypotheses of activeTrees
     void cleanup();
 
-    // Optimize the lattice, removing redundant silence occurances
+    // Optimize the lattice, removing redundant silence occurrences
     void optimizeSilenceInWordLattice(const Bliss::Lemma* silence);
 
     Core::Ref<Trace> getSentenceEnd(TimeframeIndex time, bool shallCreateLattice);

--- a/src/Search/AdvancedTreeSearch/TreeBuilder.cc
+++ b/src/Search/AdvancedTreeSearch/TreeBuilder.cc
@@ -20,69 +20,75 @@
 #include <algorithm>
 #include "PersistentStateTree.hh"
 
+using namespace Search;
+
+// -------------------- AbstractTreeBuilder --------------------
+
+AbstractTreeBuilder::AbstractTreeBuilder(Core::Configuration          config,
+                                         const Bliss::Lexicon&        lexicon,
+                                         const Am::AcousticModel&     acousticModel,
+                                         Search::PersistentStateTree& network)
+        : Core::Component(config),
+          lexicon_(lexicon),
+          acousticModel_(acousticModel),
+          network_(network) {
+}
+
+// -------------------- MinimizedTreeBuilder --------------------
+
 // TODO: Verify that pushed word-ends have the same transition penalty as the corresponding unpushed word-ends
 
-const Core::ParameterBool paramAddCiTransitions(
-        "add-ci-transitions",
-        "whether context-independent acoustic transitions should be inserted between words. Useful for non-fluid speech, specifically when the training data consistent of fluid speech",
-        false);  // if this is false, then an additional special-root is used, which is followed only by non-words. it is labeled #|[sil] (where [sil] is the first special-phone)
-
-const Core::ParameterBool paramUseRootForCiExits(
-        "use-root-for-ci-exits",
-        "whether the root-node should be used as target for exits behind context-independent phones",
-        true);
-
-const Core::ParameterInt paramMinPhones(
+const Core::ParameterInt MinimizedTreeBuilder::paramMinPhones(
         "min-phones",
         "minimum number of phones which are expanded without pushing the word ends",
         1);
 
-const Core::ParameterInt paramMinimizeIterations(
-        "minimization-iterations",
-        "usually only the first 2 iterations show an effect",
-        2);
+const Core::ParameterBool MinimizedTreeBuilder::paramAddCiTransitions(
+        "add-ci-transitions",
+        "whether context-independent acoustic transitions should be inserted between words. Useful for non-fluid speech, specifically when the training data consistent of fluid speech",
+        false);  // if this is false, then an additional special-root is used, which is followed only by non-words. it is labeled #|[sil] (where [sil] is the first special-phone)
 
-const Core::ParameterBool paramForceExactWordEnds(
+const Core::ParameterBool MinimizedTreeBuilder::paramUseRootForCiExits(
+        "use-root-for-ci-exits",
+        "whether the root-node should be used as target for exits behind context-independent phones",
+        true);
+
+const Core::ParameterBool MinimizedTreeBuilder::paramForceExactWordEnds(
         "force-exact-word-ends",
         "",
         false);
 
-const Core::ParameterBool paramKeepRoots(
+const Core::ParameterBool MinimizedTreeBuilder::paramKeepRoots(
         "keep-roots",
         "keep roots as they were after initial building (i.e. don't minimize them). might become useful to insert new words on-the-fly in the future, or to have correct boundary-information right after decoding.",
         false);
 
-const Core::ParameterBool paramAllowCrossWordSkips(
+const Core::ParameterBool MinimizedTreeBuilder::paramAllowCrossWordSkips(
         "allow-cross-word-skips",
         "add additional word labels to allow skips over word boundaries; equal skip penalties for all states are recommended",
         false);
 
-const Core::ParameterBool paramRepeatSilence(
+const Core::ParameterBool MinimizedTreeBuilder::paramRepeatSilence(
         "repeat-silence",
         "repeat silence. this makes cross-word skipping consistent in forward/backward case, given that all forward/skip penalties are the same",
         false);
 
-using namespace Search;
+const Core::ParameterInt MinimizedTreeBuilder::paramMinimizeIterations(
+        "minimization-iterations",
+        "usually only the first 2 iterations show an effect",
+        2);
 
-typedef std::set<Bliss::Phoneme::Id> PhonemeList;
-
-TreeBuilder::TreeBuilder(Core::Configuration          config,
-                         const Bliss::Lexicon&        lexicon,
-                         const Am::AcousticModel&     acousticModel,
-                         Search::PersistentStateTree& network,
-                         bool                         initialize,
-                         bool                         arcBased)
-        : lexicon_(lexicon),
-          acousticModel_(acousticModel),
-          network_(network),
-          config_(config),
+MinimizedTreeBuilder::MinimizedTreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize)
+        : AbstractTreeBuilder(config, lexicon, acousticModel, network),
           minPhones_(paramMinPhones(config)),
+          addCiTransitions_(paramAddCiTransitions(config)),
+          useRootForCiExits_(paramUseRootForCiExits(config)),
           forceExactWordEnds_(paramForceExactWordEnds(config)),
           keepRoots_(paramKeepRoots(config)),
           allowCrossWordSkips_(paramAllowCrossWordSkips(config)),
           repeatSilence_(paramRepeatSilence(config)),
-          reverse_(isBackwardRecognition(config)),
-          arcBased_(arcBased) {
+          minimizeIterations_(paramMinimizeIterations(config)),
+          reverse_(isBackwardRecognition(config)) {
     if (allowCrossWordSkips_) {
         Score skipPenalty    = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::skip);
         Score forwardPenalty = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::forward);
@@ -100,10 +106,12 @@ TreeBuilder::TreeBuilder(Core::Configuration          config,
         }
     }
 
-    if (reverse_)
+    if (reverse_) {
         log() << "building backward network";
-    else
+    }
+    else {
         log() << "building forward network";
+    }
 
     if (initialize) {
         verify(!network_.rootState);
@@ -114,48 +122,477 @@ TreeBuilder::TreeBuilder(Core::Configuration          config,
     }
 }
 
-TreeBuilder::HMMSequence TreeBuilder::arcSequence(u32 acousticModelIndex) const {
-    verify(acousticModelIndex < arcSequences_.size());
-    return arcSequences_[acousticModelIndex];
+std::unique_ptr<AbstractTreeBuilder> MinimizedTreeBuilder::newInstance(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize) {
+    return std::unique_ptr<AbstractTreeBuilder>(new MinimizedTreeBuilder(config, lexicon, acousticModel, network, initialize));
 }
 
-std::string TreeBuilder::arcDesc(u32 acousticModelIndex) const {
-    verify(acousticModelIndex < arcSequences_.size());
-    ArcDesc            desc = arcDescs_[acousticModelIndex];
+void MinimizedTreeBuilder::build() {
+    buildBody();
+
+    buildFanInOutStructure();
+
+    skipRootTransitions();
+
+    for (u32 i = 0; i < minimizeIterations_; ++i) {
+        minimize();
+    }
+
+    if (allowCrossWordSkips_) {
+        addCrossWordSkips();
+    }
+
+    log() << "building ready";
+}
+
+void MinimizedTreeBuilder::printStats(std::string occasion) {
+    log() << "stats " << occasion << ":";
+    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size();
+    log() << "coarticulated roots: " << network_.coarticulatedRootStates.size() << " unpushed: " << network_.unpushedCoarticulatedRootStates.size();
+    u32 roots = 0;
+    for (std::set<StateId>::iterator it = network_.uncoarticulatedWordEndStates.begin(); it != network_.uncoarticulatedWordEndStates.end(); ++it) {
+        if (network_.coarticulatedRootStates.count(*it)) {
+            ++roots;
+        }
+    }
+    log() << "number of uncoarticulated pushed word-end nodes: " << network_.uncoarticulatedWordEndStates.size() << " out of those are roots: " << roots;
+}
+
+std::string MinimizedTreeBuilder::describe(std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id> desc) {
     std::ostringstream os;
-    if (desc.central == Core::Type<Bliss::Phoneme::Id>::max) {
-        os << "*";
+
+    if (desc.first == Bliss::Phoneme::term) {
+        os << "#";
     }
     else {
-        if (isContextDependent(desc.central)) {
-            if (desc.left == Core::Type<Bliss::Phoneme::Id>::max)
-                os << "*";
-            else if (desc.left == Bliss::Phoneme::term || !isContextDependent(desc.left))
-                os << "#";
-            else
-                os << acousticModel_.phonemeInventory()->phoneme(desc.left)->symbol();
-            os << "/";
-        }
-        os << acousticModel_.phonemeInventory()->phoneme(desc.central)->symbol();
-        if (isContextDependent(desc.central)) {
-            os << "/";
-            if (desc.right == Core::Type<Bliss::Phoneme::Id>::max)
-                os << "*";
-            else if (desc.right == Bliss::Phoneme::term || !isContextDependent(desc.right))
-                os << "#";
-            else
-                os << acousticModel_.phonemeInventory()->phoneme(desc.right)->symbol();
-        }
+        os << lexicon_.phonemeInventory()->phoneme(desc.first)->symbol();
     }
+
+    os << "<->";
+
+    if (desc.second == Bliss::Phoneme::term) {
+        os << "#";
+    }
+    else {
+        os << lexicon_.phonemeInventory()->phoneme(desc.second)->symbol();
+    }
+
     return os.str();
 }
 
-void TreeBuilder::hmmFromAllophone(TreeBuilder::HMMSequence& ret,
-                                   Bliss::Phoneme::Id        left,
-                                   Bliss::Phoneme::Id        central,
-                                   Bliss::Phoneme::Id        right,
-                                   u32                       boundary,
-                                   bool                      allowNonStandard) {
+bool MinimizedTreeBuilder::isContextDependent(Bliss::Phoneme::Id phone) const {
+    return acousticModel_.phonemeInventory()->phoneme(phone)->isContextDependent();
+}
+
+void MinimizedTreeBuilder::buildBody() {
+    std::pair<Bliss::Lexicon::PronunciationIterator, Bliss::Lexicon::PronunciationIterator> prons = lexicon_.pronunciations();
+
+    u32 coarticulatedInitial = 0, uncoarticulatedInitial = 0, coarticulatedFinal = 0, uncoarticulatedFinal = 0;
+
+    // Collect initial/final phonemes
+    for (Bliss::Lexicon::PronunciationIterator pronIt = prons.first; pronIt != prons.second; ++pronIt) {
+        const Bliss::Pronunciation& pron(**pronIt);
+        if (pron.length()) {
+            Bliss::Phoneme::Id initial = pron[0], fin = pron[pron.length() - 1];
+            if (reverse_) {
+                std::swap(initial, fin);
+            }
+
+            if (!initialPhonemes_.count(initial)) {
+                initialPhonemes_.insert(initial);
+                if (isContextDependent(initial)) {
+                    coarticulatedInitial += 1;
+                } else {
+                    uncoarticulatedInitial += 1;
+                }
+            }
+
+            if (!finalPhonemes_.count(fin)) {
+                if (isContextDependent(fin)) {
+                    coarticulatedFinal += 1;
+                } else {
+                    uncoarticulatedFinal += 1;
+                }
+                finalPhonemes_.insert(fin);
+            }
+        }
+        else {
+            log() << "Ignoring 0-length pronunciation in state-network: '" << pron.format(acousticModel_.phonemeInventory()) << "'";
+        }
+    }
+
+    if ((uncoarticulatedFinal == 0 || uncoarticulatedInitial == 0) && !addCiTransitions_) {
+        Core::Application::us()->error() << "There are no context-independent initial or final phonemes in the lexicon, word-end detection will not work properly. Consider adding context-independent phonemes, or setting add-ci-transitions=true";
+    }
+
+    log() << "coarticulated initial phones: " << coarticulatedInitial
+          << " uncoarticulated: " << uncoarticulatedInitial
+          << ", coarticulated final phones: " << uncoarticulatedFinal
+          << " uncoarticulated: " << uncoarticulatedFinal;
+
+    bool useRootForCiExits = useRootForCiExits_ && !addCiTransitions_;
+
+    // Build the network-like non-coarticulated portion starting at the context-independent root
+    log() << "building";
+    for (Bliss::Lexicon::PronunciationIterator pronIt = prons.first; pronIt != prons.second; ++pronIt) {
+        const Bliss::Pronunciation& pron(**pronIt);
+        u32                         pronLength = pron.length();
+        if (pronLength == 0) {
+            continue;
+        }
+
+        std::pair<StateId, StateId> currentState(0, network_.rootState);
+
+        std::vector<Bliss::Phoneme::Id> phones;
+        for (u32 phoneIndex = 0; phoneIndex < pronLength; ++phoneIndex) {
+            phones.push_back(pron[phoneIndex]);
+        }
+
+        if (reverse_) {
+            std::reverse(phones.begin(), phones.end());
+        }
+
+        for (u32 phoneIndex = 0; phoneIndex < pronLength - 1; ++phoneIndex) {
+            currentState = extendPhone(currentState.second, phoneIndex, phones);
+        }
+
+        std::pair<Bliss::Pronunciation::LemmaIterator, Bliss::Pronunciation::LemmaIterator> lemmaProns = pron.lemmas();
+
+        if (pronLength - 1 < minPhones_ || !isContextDependent(phones[pronLength - 1])) {
+            // Statically expand the fan-out.
+            for (std::set<Bliss::Phoneme::Id>::iterator initialIt = initialPhonemes_.begin(); initialIt != initialPhonemes_.end(); ++initialIt) {
+                std::pair<StateId, StateId> tail = extendPhone(currentState.second, pronLength - 1, phones, Bliss::Phoneme::term, *initialIt);
+                for (Bliss::Pronunciation::LemmaIterator lemmaPron = lemmaProns.first; lemmaPron != lemmaProns.second; ++lemmaPron) {
+                    u32 exit;
+                    if (!isContextDependent(phones[pronLength - 1]) && useRootForCiExits) {
+                        exit = addExit(tail.second, Bliss::Phoneme::term, Bliss::Phoneme::term, 0, lemmaPron->id());  // Use the non-coarticulated root node
+                    } else {
+                        exit = addExit(tail.second, phones[pronLength - 1], *initialIt, 0, lemmaPron->id());
+                    }
+                    if (pronLength == 1) {
+                        initialFinalPhoneSuffix_[RootKey(phones[0], *initialIt, 1)].insert(ID_FROM_LABEL(exit));
+                    }
+                }
+            }
+        } else {
+            // Minimize the remaining phoneme, insert corresponding word-ends.
+            for (Bliss::Pronunciation::LemmaIterator lemmaPron = lemmaProns.first; lemmaPron != lemmaProns.second; ++lemmaPron) {
+                if (pronLength == 1) {
+                    addExit(currentState.second, Bliss::Phoneme::term, phones[0], -1, lemmaPron->id());
+
+                    for (std::set<Bliss::Phoneme::Id>::const_iterator finalIt = finalPhonemes_.begin(); finalIt != finalPhonemes_.end(); ++finalIt) {
+                        Search::PersistentStateTree::Exit exit;
+                        exit.transitState  = createRoot(*finalIt, phones[0], -1);
+                        exit.pronunciation = lemmaPron->id();
+                        addSuccessor(createRoot(*finalIt, phones[0], 0), ID_FROM_LABEL(createExit(exit)));
+                    }
+                } else {
+                    u32 exit = addExit(currentState.second, phones[pronLength - 2], phones[pronLength - 1], -1, lemmaPron->id());
+                    if (pronLength == 2) {
+                        initialPhoneSuffix_[RootKey(phones[0], phones[1], 1)].insert(ID_FROM_LABEL(exit));
+                    }
+                }
+            }
+        }
+    }
+
+    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size() << " roots: " << roots_.size();
+}
+
+void MinimizedTreeBuilder::buildFanInOutStructure() {
+    // Create temporary coarticulated roots
+    for (std::set<Bliss::Phoneme::Id>::const_iterator finalIt = finalPhonemes_.begin(); finalIt != finalPhonemes_.end(); ++finalIt) {
+        for (std::set<Bliss::Phoneme::Id>::const_iterator initialIt = initialPhonemes_.begin(); initialIt != initialPhonemes_.end(); ++initialIt) {
+            createRoot(*finalIt, *initialIt, 0);
+        }
+    }
+
+    log() << "building fan-in";
+    // Build the fan-in structure (e.g. the HMM structure representing the initial word phonemes, behind roots, up to the joints)
+    for (RootHash::const_iterator rootIt = roots_.begin(); rootIt != roots_.end(); ++rootIt) {
+        if (rootIt->first.depth != 0 || rootIt->second == network_.rootState) {
+            continue;
+        }
+        Bliss::Phoneme::Id initial = rootIt->first.right;
+        verify(initialPhonemes_.count(initial));
+        verify(initial != Bliss::Phoneme::term);
+        u32 paths = 0;
+
+        for (CoarticulationJointHash::const_iterator initialSuffixIt = initialPhoneSuffix_.begin(); initialSuffixIt != initialPhoneSuffix_.end(); ++initialSuffixIt) {
+            if (initialSuffixIt->first.left != initial) {
+                continue;
+            }
+            ++paths;
+            HMMSequence hmm;
+            hmmFromAllophone(hmm, rootIt->first.left, initial, initialSuffixIt->first.right, Am::Allophone::isInitialPhone);
+            verify(hmm.length > 0);
+            StateId currentNode = extendFanIn(initialSuffixIt->second, hmm[hmm.length - 1]);
+            for (s32 s = hmm.length - 2; s >= 0; --s) {
+                currentNode = extendFanIn(currentNode, hmm[s]);
+            }
+
+            addSuccessor(rootIt->second, currentNode);
+        }
+
+        for (CoarticulationJointHash::const_iterator initialSuffixIt = initialFinalPhoneSuffix_.begin(); initialSuffixIt != initialFinalPhoneSuffix_.end(); ++initialSuffixIt) {
+            if (initialSuffixIt->first.left != initial) {
+                continue;
+            }
+            ++paths;
+            HMMSequence hmm;
+            hmmFromAllophone(hmm, rootIt->first.left, initial, initialSuffixIt->first.right, Am::Allophone::isInitialPhone | Am::Allophone::isFinalPhone);
+            verify(hmm.length > 0);
+            StateId currentNode = extendFanIn(initialSuffixIt->second, hmm[hmm.length - 1]);
+            for (s32 s = hmm.length - 2; s >= 0; --s) {
+                currentNode = extendFanIn(currentNode, hmm[s]);
+            }
+
+            addSuccessor(rootIt->second, currentNode);
+        }
+    }
+
+    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size() << " roots: " << roots_.size();
+    log() << "building fan-out";
+
+    // Build the fan-out structure (e.g. the HMM structure representing the final word phonemes, behind special roots)
+    // On the left side delimited by the roots of depth -1, and on the right side by the roots of depth 0
+    for (RootHash::const_iterator leftRootIt = roots_.begin(); leftRootIt != roots_.end(); ++leftRootIt) {
+        if (leftRootIt->first.depth != -1) {
+            continue;
+        }
+        Bliss::Phoneme::Id fin = leftRootIt->first.right;
+        verify(finalPhonemes_.count(fin));
+
+        u32 paths = 0;
+        for (RootHash::const_iterator rightRootIt = roots_.begin(); rightRootIt != roots_.end(); ++rightRootIt) {
+            if (rightRootIt->first.depth != 0 || (rightRootIt->first.left != fin && (!addCiTransitions_ || rightRootIt->first.left != Bliss::Phoneme::term))) {
+                continue;
+            }
+            ++paths;
+            HMMSequence hmm;
+            hmmFromAllophone(hmm, leftRootIt->first.left, fin, rightRootIt->first.right, Am::Allophone::isFinalPhone);
+            verify(hmm.length > 0);
+
+            // The last state in the pushed fan-in is equivalent with the corresponding root state
+
+            StateId lastNode = extendFanIn(network_.structure.targetSet(rightRootIt->second), hmm[hmm.length - 1]);
+
+            StateId currentNode = lastNode;
+            for (s32 s = hmm.length - 2; s >= 0; --s) {
+                currentNode = extendFanIn(currentNode, hmm[s]);
+            }
+
+            if (rightRootIt->first.right == Bliss::Phoneme::term || !isContextDependent(rightRootIt->first.right)) {
+                network_.uncoarticulatedWordEndStates.insert(lastNode);
+            }
+
+            addSuccessor(leftRootIt->second, currentNode);
+        }
+        verify(paths);
+    }
+
+    printStats("after fan-in/out structure");
+}
+
+void MinimizedTreeBuilder::addCrossWordSkips() {
+    log() << "adding cross-word skips";
+    u32 oldNodes = network_.structure.stateCount();
+
+    for (StateId node = 1; node < oldNodes; ++node) {
+        {
+            bool hasWordEnd   = false;
+            bool hasSuccessor = false;
+            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
+                if (!target.isLabel()) {
+                    hasSuccessor = true;
+                }
+                if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2) {
+                    hasWordEnd = true;
+                }
+            }
+            verify(hasSuccessor || hasWordEnd);
+        }
+
+        std::set<PersistentStateTree::Exit> skipRoots;
+
+        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
+            if (target.isLabel()) {
+                continue;
+            }
+            for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(*target); target2; ++target2) {
+                if (target2.isLabel()) {
+                    skipRoots.insert(network_.exits[target2.label()]);
+                }
+            }
+        }
+
+        if (skipRoots.size()) {
+            for (std::set<PersistentStateTree::Exit>::iterator it = skipRoots.begin(); it != skipRoots.end(); ++it) {
+                PersistentStateTree::Exit e(*it);
+                verify(e.pronunciation != Bliss::LemmaPronunciation::invalidId);
+                if (network_.structure.state(e.transitState).stateDesc.transitionModelIndex == Am::TransitionModel::entryM2) {
+                    continue;
+                }
+                e.transitState = createSkipRoot(e.transitState);
+                network_.structure.addOutputToNode(node, createExit(e));
+            }
+        }
+
+        {
+            bool hasWordEnd   = false;
+            bool hasSuccessor = false;
+            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
+                if (!target.isLabel()) {
+                    hasSuccessor = true;
+                }
+                if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2) {
+                    hasWordEnd = true;
+                }
+            }
+            verify(hasSuccessor || hasWordEnd);
+        }
+    }
+
+    for (StateId node = 1; node < oldNodes; ++node) {
+        bool hasWordEnd   = false;
+        bool hasSuccessor = false;
+        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
+            if (!target.isLabel()) {
+                hasSuccessor = true;
+            }
+            if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2) {
+                hasWordEnd = true;
+            }
+        }
+        verify(hasSuccessor || hasWordEnd);
+    }
+
+    log() << "added " << network_.structure.stateCount() - oldNodes << " skip-roots";
+
+    network_.cleanup();
+}
+
+void MinimizedTreeBuilder::skipRootTransitions(StateId start) {
+    for (StateId node = start; node < network_.structure.stateCount(); ++node) {
+        if (network_.structure.state(node).stateDesc.acousticModel == Search::StateTree::invalidAcousticModel) {
+            continue;
+        }
+
+        HMMStateNetwork::ChangePlan change = network_.structure.change(node);
+        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
+            if (target.isLabel()) {
+                continue;
+            }
+
+            if (network_.structure.state(*target).stateDesc.acousticModel == Search::StateTree::invalidAcousticModel) {
+                change.removeSuccessor(*target);
+                for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(*target); target2; ++target2) {
+                    change.addSuccessor(*target2);
+                }
+            }
+        }
+        change.apply();
+    }
+}
+
+StateTree::StateDesc MinimizedTreeBuilder::rootDesc() const {
+    StateTree::StateDesc desc;
+    desc.acousticModel        = Search::StateTree::invalidAcousticModel;
+    desc.transitionModelIndex = Am::TransitionModel::entryM1;
+    return desc;
+}
+
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::createSkipRoot(StateId baseRoot) {
+    SkipRootsHash::const_iterator it = skipRoots_.find(baseRoot);
+    if (it != skipRoots_.end()) {
+        return it->second;
+    }
+    StateTree::StateDesc desc = rootDesc();
+    desc.transitionModelIndex = Am::TransitionModel::entryM2;
+    StateId ret               = createState(desc);
+
+    skipRoots_.insert(std::make_pair(baseRoot, ret));
+    network_.structure.addTargetToNode(ret, baseRoot);
+    skipRootSet_.insert(ret);
+    network_.coarticulatedRootStates.insert(ret);
+    verify(network_.rootTransitDescriptions.count(baseRoot));
+    network_.rootTransitDescriptions.insert(std::make_pair(ret, network_.rootTransitDescriptions[baseRoot]));
+    return ret;
+}
+
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::createRoot(Bliss::Phoneme::Id left, Bliss::Phoneme::Id right, int depth) {
+    RootKey                  key(left, right, depth);
+    RootHash::const_iterator it = roots_.find(key);
+    if (it != roots_.end()) {
+        return it->second;
+    }
+
+    // record newly inserted RootStates to reset network_ later
+    StateId ret = createState(rootDesc());
+
+    if (depth == 0 && (left != Bliss::Phoneme::term || right != Bliss::Phoneme::term)) {
+        network_.unpushedCoarticulatedRootStates.insert(ret);
+    }
+
+    if (right == Bliss::Phoneme::term || !acousticModel_.phonemeInventory()->phoneme(right)->isContextDependent()) {
+        network_.uncoarticulatedWordEndStates.insert(ret);
+    }
+
+    if (left != Bliss::Phoneme::term || right != Bliss::Phoneme::term) {
+        network_.coarticulatedRootStates.insert(ret);
+    }
+
+    roots_.insert(std::make_pair(key, ret));
+
+    network_.rootTransitDescriptions.insert(std::make_pair(ret, std::make_pair(left, right)));
+
+    return ret;
+}
+
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::createState(StateTree::StateDesc desc) {
+    StateId ret                             = network_.structure.allocateTreeNode(network_.masterTree);
+    network_.structure.state(ret).stateDesc = desc;
+    return ret;
+}
+
+u32 MinimizedTreeBuilder::createExit(PersistentStateTree::Exit exit) {
+    ExitHash::iterator exitHashIt = exitHash_.find(exit);
+    if (exitHashIt != exitHash_.end()) {
+        return exitHashIt->second;
+    } else {
+        // Exit does not exist yet, add it
+        network_.exits.push_back(exit);
+        u32 exitIndex = network_.exits.size() - 1;
+        exitHash_.insert(std::make_pair(exit, exitIndex));
+        return exitIndex;
+    }
+}
+
+u32 MinimizedTreeBuilder::addExit(StateId                       predecessor,
+                                  Bliss::Phoneme::Id            leftPhoneme,
+                                  Bliss::Phoneme::Id            rightPhoneme,
+                                  int                           depth,
+                                  Bliss::LemmaPronunciation::Id pron) {
+    PersistentStateTree::Exit exit;
+    exit.transitState  = createRoot(leftPhoneme, rightPhoneme, depth);
+    exit.pronunciation = pron;
+
+    u32 exitIndex = createExit(exit);
+
+    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target) {
+        if (target.isLabel() && target.label() == exitIndex) {
+            return exitIndex;
+        }
+    }
+
+    network_.structure.addOutputToNode(predecessor, ID_FROM_LABEL(exitIndex));
+    return exitIndex;
+}
+
+void MinimizedTreeBuilder::hmmFromAllophone(HMMSequence&       ret,
+                                            Bliss::Phoneme::Id left,
+                                            Bliss::Phoneme::Id central,
+                                            Bliss::Phoneme::Id right,
+                                            u32                boundary) {
     verify(ret.length == 0);
     verify(central != Bliss::Phoneme::term);
     verify(acousticModel_.phonemeInventory()->isValidPhonemeId(central));
@@ -163,17 +600,20 @@ void TreeBuilder::hmmFromAllophone(TreeBuilder::HMMSequence& ret,
 
     if (reverse_) {
         std::swap(left, right);
-        if (boundary == Am::Allophone::isFinalPhone)
+        if (boundary == Am::Allophone::isFinalPhone) {
             boundary = Am::Allophone::isInitialPhone;
-        else if (boundary == Am::Allophone::isInitialPhone)
+        } else if (boundary == Am::Allophone::isInitialPhone) {
             boundary = Am::Allophone::isFinalPhone;
+        }
     }
 
     if (isContextDependent(central)) {
-        if (acousticModel_.phonemeInventory()->isValidPhonemeId(left) && isContextDependent(left))
+        if (acousticModel_.phonemeInventory()->isValidPhonemeId(left) && isContextDependent(left)) {
             history.append(1, left);
-        if (acousticModel_.phonemeInventory()->isValidPhonemeId(right) && isContextDependent(right))
+        }
+        if (acousticModel_.phonemeInventory()->isValidPhonemeId(right) && isContextDependent(right)) {
             future.append(1, right);
+        }
     }
 
     const Am::Allophone* allophone = acousticModel_.allophoneAlphabet()->allophone(Am::Allophone(Bliss::ContextPhonology::PhonemeInContext(central, history, future), boundary));
@@ -195,36 +635,9 @@ void TreeBuilder::hmmFromAllophone(TreeBuilder::HMMSequence& ret,
         }
     }
 
-    if (arcBased_) {
-        HMMSequence newRet;
-        newRet.length                      = 1;
-        newRet.hmm[0].transitionModelIndex = boundary;
-
-        ArcSequenceHash::const_iterator it = arcSequencesHash_.find(ret);
-        if (it != arcSequencesHash_.end()) {
-            newRet.hmm[0].acousticModel = it->second;
-            if (arcDescs_[it->second].central != central)
-                arcDescs_[it->second].central = Core::Type<Bliss::Phoneme::Id>::max;
-            if (arcDescs_[it->second].left != left)
-                arcDescs_[it->second].left = Core::Type<Bliss::Phoneme::Id>::max;
-            if (arcDescs_[it->second].right != right)
-                arcDescs_[it->second].right = Core::Type<Bliss::Phoneme::Id>::max;
-        }
-        else {
-            newRet.hmm[0].acousticModel = arcSequences_.size();
-            verify(newRet.hmm[0].acousticModel == arcSequences_.size());
-            arcSequencesHash_[ret] = arcSequences_.size();
-            arcSequences_.push_back(ret);
-            ArcDesc desc;
-            desc.left    = left;
-            desc.central = central;
-            desc.right   = right;
-            arcDescs_.push_back(desc);
-        }
-        ret = newRet;
-    }
-    if (reverse_)
+    if (reverse_) {
         ret.reverse();
+    }
 
     if (repeatSilence_ && ret.length == 1 && central == acousticModel_.silence()) {
         ret.hmm[1] = ret.hmm[0];
@@ -232,222 +645,119 @@ void TreeBuilder::hmmFromAllophone(TreeBuilder::HMMSequence& ret,
     }
 }
 
-void TreeBuilder::build() {
-    std::pair<Bliss::Lexicon::PronunciationIterator, Bliss::Lexicon::PronunciationIterator> prons = lexicon_.pronunciations();
-
-    u32 coarticulatedInitial = 0, uncoarticulatedInitial = 0, coarticulatedFinal = 0, uncoarticulatedFinal = 0;
-
-    // Collect initial/final phonemes
-    for (Bliss::Lexicon::PronunciationIterator pronIt = prons.first; pronIt != prons.second; ++pronIt) {
-        const Bliss::Pronunciation& pron(**pronIt);
-        if (pron.length()) {
-            Bliss::Phoneme::Id initial = pron[0], fin = pron[pron.length() - 1];
-            if (reverse_)
-                std::swap(initial, fin);
-
-            if (!initialPhonemes_.count(initial)) {
-                initialPhonemes_.insert(initial);
-                if (isContextDependent(initial))
-                    coarticulatedInitial += 1;
-                else
-                    uncoarticulatedInitial += 1;
-            }
-
-            if (!finalPhonemes_.count(fin)) {
-                if (isContextDependent(fin))
-                    coarticulatedFinal += 1;
-                else
-                    uncoarticulatedFinal += 1;
-
-                finalPhonemes_.insert(fin);
-            }
-        }
-        else {
-            log() << "Ignoring 0-length pronunciation in state-network: '" << pron.format(acousticModel_.phonemeInventory()) << "'";
+bool MinimizedTreeBuilder::addSuccessor(StateId predecessor, StateId successor) {
+    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target) {
+        if (*target == successor) {
+            return false;
         }
     }
 
-    if ((uncoarticulatedFinal == 0 || uncoarticulatedInitial == 0) && !paramAddCiTransitions(config_))
-        Core::Application::us()->error() << "There are no context-independent initial or final phonemes in the lexicon, word-end detection will not work properly. Consider adding context-independent phonemes, or setting add-ci-transitions=true";
-
-    log() << "coarticulated initial phones: " << coarticulatedInitial
-          << " uncoarticulated: " << uncoarticulatedInitial
-          << ", coarticulated final phones: " << uncoarticulatedFinal
-          << " uncoarticulated: " << uncoarticulatedFinal;
-
-    bool useRootForCiExits = paramUseRootForCiExits(config_) && !paramAddCiTransitions(config_);
-
-    // Build the network-like non-coarticulated portion starting at the context-independent root
-    log() << "building";
-    for (Bliss::Lexicon::PronunciationIterator pronIt = prons.first; pronIt != prons.second; ++pronIt) {
-        const Bliss::Pronunciation& pron(**pronIt);
-        u32                         pronLength = pron.length();
-        if (pronLength == 0)
-            continue;
-
-        std::pair<StateId, StateId> currentState(0, network_.rootState);
-
-        std::vector<Bliss::Phoneme::Id> phones;
-        for (u32 phoneIndex = 0; phoneIndex < pronLength; ++phoneIndex)
-            phones.push_back(pron[phoneIndex]);
-
-        if (reverse_)
-            std::reverse(phones.begin(), phones.end());
-
-        for (u32 phoneIndex = 0; phoneIndex < pronLength - 1; ++phoneIndex)
-            currentState = extendPhone(currentState.second, phoneIndex, phones);
-
-        std::pair<Bliss::Pronunciation::LemmaIterator, Bliss::Pronunciation::LemmaIterator> lemmaProns = pron.lemmas();
-
-        if (pronLength - 1 < minPhones_ || !isContextDependent(phones[pronLength - 1])) {
-            // Statically expand the fan-out.
-            for (std::set<Bliss::Phoneme::Id>::iterator initialIt = initialPhonemes_.begin(); initialIt != initialPhonemes_.end(); ++initialIt) {
-                std::pair<StateId, StateId> tail = extendPhone(currentState.second, pronLength - 1, phones, Bliss::Phoneme::term, *initialIt);
-                for (Bliss::Pronunciation::LemmaIterator lemmaPron = lemmaProns.first; lemmaPron != lemmaProns.second; ++lemmaPron) {
-                    u32 exit;
-                    if (!isContextDependent(phones[pronLength - 1]) && useRootForCiExits)
-                        exit = addExit(tail.first, tail.second, Bliss::Phoneme::term, Bliss::Phoneme::term, 0, lemmaPron->id());  // Use the non-coarticulated root node
-                    else
-                        exit = addExit(tail.first, tail.second, phones[pronLength - 1], *initialIt, 0, lemmaPron->id());
-                    if (pronLength == 1)
-                        initialFinalPhoneSuffix_[RootKey(phones[0], *initialIt, 1)].insert(ID_FROM_LABEL(exit));
-                }
-            }
-        }
-        else {
-            // Minimize the remaining phoneme, insert corresponding word-ends.
-            for (Bliss::Pronunciation::LemmaIterator lemmaPron = lemmaProns.first; lemmaPron != lemmaProns.second; ++lemmaPron) {
-                if (pronLength == 1) {
-                    addExit(currentState.first, currentState.second, Bliss::Phoneme::term, phones[0], -1, lemmaPron->id());
-
-                    for (std::set<Bliss::Phoneme::Id>::const_iterator finalIt = finalPhonemes_.begin(); finalIt != finalPhonemes_.end(); ++finalIt) {
-                        Search::PersistentStateTree::Exit exit;
-                        exit.transitState  = createRoot(*finalIt, phones[0], -1);
-                        exit.pronunciation = lemmaPron->id();
-                        addSuccessor(createRoot(*finalIt, phones[0], 0), ID_FROM_LABEL(createExit(exit)));
-                    }
-                }
-                else {
-                    u32 exit = addExit(currentState.first, currentState.second, phones[pronLength - 2], phones[pronLength - 1], -1, lemmaPron->id());
-                    if (pronLength == 2)
-                        initialPhoneSuffix_[RootKey(phones[0], phones[1], 1)].insert(ID_FROM_LABEL(exit));
-                }
-            }
-        }
-    }
-
-    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size() << " roots: " << roots_.size();
-
-    buildFanInOutStructure();
-
-    skipRootTransitions();
-
-    u32 it = paramMinimizeIterations(config_);
-    for (u32 i = 0; i < it; ++i)
-        minimize();
-
-    if (allowCrossWordSkips_)
-        addCrossWordSkips();
-
-    log() << "building ready";
+    network_.structure.addTargetToNode(predecessor, successor);
+    return true;
 }
 
-void TreeBuilder::addCrossWordSkips() {
-    log() << "adding cross-word skips";
-    u32 oldNodes = network_.structure.stateCount();
+std::pair<AbstractTreeBuilder::StateId, AbstractTreeBuilder::StateId> MinimizedTreeBuilder::extendPhone(StateId                                currentState,
+                                                                                                        u32                                    phoneIndex,
+                                                                                                        const std::vector<Bliss::Phoneme::Id>& phones,
+                                                                                                        Bliss::Phoneme::Id                     left,
+                                                                                                        Bliss::Phoneme::Id                     right) {
+    u8 boundary = 0;
+    if (phoneIndex != 0) {
+        left = phones[phoneIndex - 1];
+    } else {
+        boundary |= Am::Allophone::isInitialPhone;
+    }
 
-    for (StateId node = 1; node < oldNodes; ++node) {
-        {
-            bool hasWordEnd   = false;
-            bool hasSuccessor = false;
-            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
-                if (!target.isLabel())
-                    hasSuccessor = true;
-                if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2)
-                    hasWordEnd = true;
-            }
-            verify(hasSuccessor || hasWordEnd);
-        }
+    if (phoneIndex != phones.size() - 1) {
+        right = phones[phoneIndex + 1];
+    } else {
+        boundary |= Am::Allophone::isFinalPhone;
+    }
 
-        std::set<PersistentStateTree::Exit> skipRoots;
+    HMMSequence hmm;
+    hmmFromAllophone(hmm, left, phones[phoneIndex], right, boundary);
 
-        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
-            if (target.isLabel())
-                continue;
-            for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(*target); target2; ++target2)
-                if (target2.isLabel())
-                    skipRoots.insert(network_.exits[target2.label()]);
-        }
+    verify(hmm.length >= 1);
 
-        if (skipRoots.size()) {
-            for (std::set<PersistentStateTree::Exit>::iterator it = skipRoots.begin(); it != skipRoots.end(); ++it) {
-                PersistentStateTree::Exit e(*it);
-                verify(e.pronunciation != Bliss::LemmaPronunciation::invalidId);
-                if (network_.structure.state(e.transitState).stateDesc.transitionModelIndex == Am::TransitionModel::entryM2)
+    u32     hmmState      = 0;
+    StateId previousState = 0;
+
+    if (phoneIndex == 1 && hmmState == 0) {
+        currentState = extendBodyState(currentState, left, phones[phoneIndex], hmm[hmmState++]);
+    }
+
+    for (; hmmState < hmm.length; ++hmmState) {
+        previousState = currentState;
+        currentState  = extendState(currentState, hmm[hmmState]);
+    }
+
+    return std::make_pair(previousState, currentState);
+}
+
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::extendState(StateId predecessor, StateTree::StateDesc desc, MinimizedTreeBuilder::RootKey uniqueKey) {
+    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target) {
+        if (!target.isLabel() && network_.structure.state(*target).stateDesc == desc) {
+            if (uniqueKey.isValid()) {
+                Core::HashMap<StateId, RootKey>::const_iterator it = stateUniqueKeys_.find(*target);
+                verify(it != stateUniqueKeys_.end());
+                if (!(it->second == uniqueKey)) {
                     continue;
-                e.transitState = createSkipRoot(e.transitState);
-                network_.structure.addOutputToNode(node, createExit(e));
+                }
             }
-        }
-
-        {
-            bool hasWordEnd   = false;
-            bool hasSuccessor = false;
-            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
-                if (!target.isLabel())
-                    hasSuccessor = true;
-                if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2)
-                    hasWordEnd = true;
-            }
-            verify(hasSuccessor || hasWordEnd);
+            return *target;
         }
     }
 
-    for (StateId node = 1; node < oldNodes; ++node) {
-        bool hasWordEnd   = false;
-        bool hasSuccessor = false;
-        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
-            if (!target.isLabel())
-                hasSuccessor = true;
-            if (target.isLabel() && network_.structure.state(network_.exits[target.label()].transitState).stateDesc.transitionModelIndex != Am::TransitionModel::entryM2)
-                hasWordEnd = true;
-        }
-        verify(hasSuccessor || hasWordEnd);
+    // No matching successor found, extend
+    StateId ret = createState(desc);
+    if (uniqueKey.isValid()) {
+        stateUniqueKeys_.insert(std::make_pair(ret, uniqueKey));
     }
-
-    log() << "added " << network_.structure.stateCount() - oldNodes << " skip-roots";
-
-    network_.cleanup();
+    network_.structure.addTargetToNode(predecessor, ret);
+    return ret;
 }
 
-void TreeBuilder::skipRootTransitions() {
-    for (StateId node = 1; node < network_.structure.stateCount(); ++node) {
-        if (network_.structure.state(node).stateDesc.acousticModel == Search::StateTree::invalidAcousticModel)
-            continue;
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::extendBodyState(StateId                      state,
+                                                                   Bliss::Phoneme::Id           first,
+                                                                   Bliss::Phoneme::Id           second,
+                                                                   Search::StateTree::StateDesc desc) {
+    RootKey key(first, second, 1);
+    StateId ret = extendState(state, desc, key);
+    initialPhoneSuffix_[key].insert(ret);
 
-        HMMStateNetwork::ChangePlan change = network_.structure.change(node);
-        for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(node); target; ++target) {
-            if (target.isLabel())
-                continue;
-
-            if (network_.structure.state(*target).stateDesc.acousticModel == Search::StateTree::invalidAcousticModel) {
-                change.removeSuccessor(*target);
-                for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(*target); target2; ++target2)
-                    change.addSuccessor(*target2);
-            }
-        }
-        change.apply();
-    }
+    return ret;
 }
 
-std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminization, bool onlyMinimizeBackwards, bool allowLost) {
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::extendFanIn(StateId successorOrExit, StateTree::StateDesc desc) {
+    std::set<StateId> successors;
+    successors.insert(successorOrExit);
+    return extendFanIn(successors, desc);
+}
+
+AbstractTreeBuilder::StateId MinimizedTreeBuilder::extendFanIn(const std::set<StateId>& successorsOrExits, Search::StateTree::StateDesc desc) {
+    StatePredecessor           pred(successorsOrExits, desc);
+    PredecessorsHash::iterator it = predecessors_.find(pred);
+    if (it != predecessors_.end()) {
+        return it->second;
+    }
+    StateId ret = createState(desc);
+    for (std::set<StateId>::const_iterator it = successorsOrExits.begin(); it != successorsOrExits.end(); ++it) {
+        network_.structure.addTargetToNode(ret, *it);
+    }
+    predecessors_.insert(std::make_pair(pred, ret));
+    return ret;
+}
+
+std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool forceDeterminization, bool onlyMinimizeBackwards, bool allowLost) {
     log() << "minimizing";
 
-    if (forceExactWordEnds_)
+    if (forceExactWordEnds_) {
         log() << "forcing exact word-ends";
+    }
 
-    for (std::set<StateId>::iterator it = network_.unpushedCoarticulatedRootStates.begin(); it != network_.unpushedCoarticulatedRootStates.end(); ++it)
+    for (std::set<StateId>::iterator it = network_.unpushedCoarticulatedRootStates.begin(); it != network_.unpushedCoarticulatedRootStates.end(); ++it) {
         verify(network_.coarticulatedRootStates.count(*it));
+    }
 
     std::set<StateId>   usedRoots;
     std::deque<StateId> active;
@@ -493,10 +803,10 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
 
     if (onlyMinimizeBackwards) {
         log() << "skipping determinization";
-        for (StateId node = 1; node < network_.structure.stateCount(); ++node)
+        for (StateId node = 1; node < network_.structure.stateCount(); ++node) {
             determinizeMap[node] = node;
-    }
-    else {
+        }
+    } else {
         // Determinize states: Join successor states with the same state-desc
         while (!active.empty()) {
             StateId state = active.front();
@@ -504,9 +814,11 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
             HMMStateNetwork::ChangePlan                                                                change = network_.structure.change(state);
             typedef std::unordered_multimap<StateTree::StateDesc, StateId, StateTree::StateDesc::Hash> SuccessorHash;
             SuccessorHash                                                                              successors;
-            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(state); target; ++target)
-                if (!target.isLabel() && (forceDeterminization || fanIn[*target] == 1))
+            for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(state); target; ++target) {
+                if (!target.isLabel() && (forceDeterminization || fanIn[*target] == 1)) {
                     successors.insert(std::make_pair(network_.structure.state(*target).stateDesc, *target));
+                }
+            }
 
             while (!successors.empty()) {
                 std::pair<SuccessorHash::iterator, SuccessorHash::iterator> items = successors.equal_range(successors.begin()->first);
@@ -514,22 +826,27 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
                 SuccessorHash::iterator it = items.first;
                 if (++it != items.second) {
                     StateId newNode = network_.structure.allocateTreeNode(network_.masterTree);
-                    if (newNode >= determinizeMap.size())
+                    if (newNode >= determinizeMap.size()) {
                         determinizeMap.resize(newNode + 1, 0);
+                    }
                     network_.structure.state(newNode).stateDesc = items.first->first;
-                    if (network_.uncoarticulatedWordEndStates.count(items.first->second))
+                    if (network_.uncoarticulatedWordEndStates.count(items.first->second)) {
                         network_.uncoarticulatedWordEndStates.insert(newNode);
+                    }
                     HMMStateNetwork::ChangePlan newChange = network_.structure.change(newNode);
                     // There are multiple successors with the same state-desc, join them
                     for (it = items.first; it != items.second; ++it) {
                         verify(it->second < determinizeMap.size());
-                        if (forceExactWordEnds_ && network_.uncoarticulatedWordEndStates.count(it->second))
+                        if (forceExactWordEnds_ && network_.uncoarticulatedWordEndStates.count(it->second)) {
                             network_.uncoarticulatedWordEndStates.insert(newNode);
-                        if (determinizeMap[it->second])
+                        }
+                        if (determinizeMap[it->second]) {
                             ++determinizeClashes;
+                        }
                         determinizeMap[it->second] = newNode;
-                        for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(it->second); target2; ++target2)
+                        for (HMMStateNetwork::SuccessorIterator target2 = network_.structure.successors(it->second); target2; ++target2) {
                             newChange.addSuccessor(*target2);
+                        }
                         change.removeSuccessor(it->second);
                     }
                     newChange.apply();
@@ -552,16 +869,19 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
     std::vector<StateId> minimizeMap(network_.structure.stateCount(), 0);
 
     minimizeState(network_.rootState, minimizeMap);
-    for (std::set<StateId>::iterator it = network_.coarticulatedRootStates.begin(); it != network_.coarticulatedRootStates.end(); ++it)
+    for (std::set<StateId>::iterator it = network_.coarticulatedRootStates.begin(); it != network_.coarticulatedRootStates.end(); ++it) {
         minimizeState(*it, minimizeMap);
-    for (std::set<StateId>::iterator it = skipRootSet_.begin(); it != skipRootSet_.end(); ++it)
+    }
+    for (std::set<StateId>::iterator it = skipRootSet_.begin(); it != skipRootSet_.end(); ++it) {
         minimizeState(*it, minimizeMap);
+    }
 
     // loop over 0-depth roots to make sure they are mapped and connected with updated successors
     for (std::set<StateId>::iterator it = usefulRoots.begin(); it != usefulRoots.end(); ++it) {
         if (determinizeMap[*it]) {
             minimizeState(determinizeMap[*it], minimizeMap);
-        } else {
+        }
+        else {
             minimizeState(*it, minimizeMap);
         }
     }
@@ -587,11 +907,13 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
 
         log() << "joining exits, coarticulated roots before: " << network_.coarticulatedRootStates.size();
         u32 oldNodeCount = network_.structure.stateCount();  // New nodes may be added during this procedure
+        // joint transitRoot is individual state specific, thus not update roots_ for general key
         for (StateId state = 1; state < oldNodeCount; ++state) {
-            if (minimizeMap[state] == state)
+            if (minimizeMap[state] == state) {
                 minimizeExits(state, minimizeExitsMap);
-            else
+            } else {
                 network_.structure.clearOutputEdges(state);
+            }
         }
     }
 
@@ -611,10 +933,10 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
         for (std::map<StateId, std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id>>::iterator it = oldTransitDescs.begin(); it != oldTransitDescs.end(); ++it) {
             StateId orig = it->first;
             if (orig == network_.rootState || orig >= minimizeMap.size()) {
-                if (orig == network_.rootState || network_.coarticulatedRootStates.count(orig))
+                if (orig == network_.rootState || network_.coarticulatedRootStates.count(orig)) {
                     network_.rootTransitDescriptions.insert(*it);
-            }
-            else {
+                }
+            } else {
                 StateId mapped = minimizeMap[it->first];
                 verify(mapped);
                 verify(network_.coarticulatedRootStates.count(mapped));
@@ -632,13 +954,15 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
     log() << "cleaning";
     u32 lost = 0, kept = 0;
     for (StateId state = 1; state < determinizeMap.size(); ++state) {
-        if (determinizeMap[state])
+        if (determinizeMap[state]) {
             determinizeMap[state] = minimizeMap[determinizeMap[state]];
-        else
+        } else {
             determinizeMap[state] = minimizeMap[state];
+        }
     }
     minimizeMap = determinizeMap;
 
+    // cleanup also changes structure, need to update map accordingly
     HMMStateNetwork::CleanupResult cleanupResult = network_.cleanup();
     for (std::vector<StateId>::iterator it = minimizeMap.begin(); it != minimizeMap.end(); ++it) {
         if (*it) {
@@ -646,8 +970,7 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
                 *it = cleanupResult.nodeMap[*it];
                 kept += 1;
                 verify(*it);
-            }
-            else {
+            } else {
                 lost += 1;
                 *it = 0;
             }
@@ -664,25 +987,11 @@ std::vector<TreeBuilder::StateId> TreeBuilder::minimize(bool forceDeterminizatio
     return minimizeMap;
 }
 
-void TreeBuilder::mapSet(std::set<StateId>& set, const std::vector<StateId>& minimizeMap, bool force) {
-    std::set<StateId> oldSet;
-    oldSet.swap(set);
-    for (std::set<StateId>::iterator it = oldSet.begin(); it != oldSet.end(); ++it) {
-        if (*it >= minimizeMap.size())
-            set.insert(*it);
-        else if (!minimizeMap[*it]) {
-            verify(!force);
-        }
-        else {
-            set.insert(minimizeMap[*it]);
-        }
-    }
-}
-
-void TreeBuilder::minimizeState(StateId state, std::vector<StateId>& minimizeMap) {
+void MinimizedTreeBuilder::minimizeState(StateId state, std::vector<StateId>& minimizeMap) {
     verify(state < minimizeMap.size());
-    if (minimizeMap[state])
+    if (minimizeMap[state]) {
         return;
+    }
 
     minimizeMap[state] = Core::Type<u32>::max;
 
@@ -699,8 +1008,7 @@ void TreeBuilder::minimizeState(StateId state, std::vector<StateId>& minimizeMap
         if (minimizeMap[*target] == Core::Type<u32>::max) {
             //       std::cout << "detected recursion while minimization on " << *target << std::endl;
             successors.insert(*target);
-        }
-        else {
+        }else {
             successors.insert(minimizeMap[*target]);
         }
     }
@@ -711,8 +1019,7 @@ void TreeBuilder::minimizeState(StateId state, std::vector<StateId>& minimizeMap
     std::unordered_map<StatePredecessor, StateId, StatePredecessor::Hash>::iterator it = predecessors_.find(pred);
     if (it != predecessors_.end()) {
         minimizeMap[state] = it->second;
-    }
-    else {
+    } else {
         minimizeMap[state] = state;
         predecessors_.insert(std::make_pair(pred, state));
         for (std::set<StateId>::iterator succIt = successors.begin(); succIt != successors.end(); ++succIt)
@@ -720,7 +1027,7 @@ void TreeBuilder::minimizeState(StateId state, std::vector<StateId>& minimizeMap
     }
 }
 
-void TreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeExitsMap) {
+void MinimizedTreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeExitsMap) {
     typedef std::multimap<Bliss::LemmaPronunciation::Id, u32> ExitMap;
     ExitMap                                                   successorExits;
 
@@ -734,12 +1041,14 @@ void TreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeE
             successorStates.insert(*target);
         }
 
-        if (successorExits.empty())
+        if (successorExits.empty()) {
             return;
+        }
 
         network_.structure.clearOutputEdges(state);
-        for (std::set<StateId>::iterator it = successorStates.begin(); it != successorStates.end(); ++it)
+        for (std::set<StateId>::iterator it = successorStates.begin(); it != successorStates.end(); ++it) {
             network_.structure.addTargetToNode(state, *it);
+        }
     }
 
     // Join multiple exits for the same pronunciation to one
@@ -748,14 +1057,14 @@ void TreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeE
         ExitMap::iterator                               i     = range.first;
         if (++i == range.second) {
             network_.structure.addOutputToNode(state, range.first->second);
-        }
-        else {
+        } else {
             // Join
             std::set<StateId>            newRootSuccessors;
             std::set<Bliss::Phoneme::Id> left, right;
             for (i = range.first; i != range.second; ++i) {
-                for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(network_.exits[i->second].transitState); target; ++target)
+                for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(network_.exits[i->second].transitState); target; ++target) {
                     newRootSuccessors.insert(*target);
+                }
                 left.insert(network_.rootTransitDescriptions[network_.exits[i->second].transitState].first);
                 right.insert(network_.rootTransitDescriptions[network_.exits[i->second].transitState].second);
             }
@@ -770,10 +1079,12 @@ void TreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeE
                 network_.rootTransitDescriptions.insert(std::make_pair(exit.transitState, std::make_pair(left.size() == 1 ? *left.begin() : Bliss::Phoneme::term, right.size() == 1 ? *right.begin() : Bliss::Phoneme::term)));
                 for (i = range.first; i != range.second; ++i) {
                     verify(i->second < network_.exits.size());
-                    if (network_.unpushedCoarticulatedRootStates.count(network_.exits[i->second].transitState))
+                    if (network_.unpushedCoarticulatedRootStates.count(network_.exits[i->second].transitState)) {
                         network_.unpushedCoarticulatedRootStates.insert(exit.transitState);
-                    if (network_.uncoarticulatedWordEndStates.count(network_.exits[i->second].transitState))
+                    }
+                    if (network_.uncoarticulatedWordEndStates.count(network_.exits[i->second].transitState)) {
                         network_.uncoarticulatedWordEndStates.insert(exit.transitState);
+                    }
                 }
             }
         }
@@ -781,335 +1092,55 @@ void TreeBuilder::minimizeExits(StateId state, const std::vector<u32>& minimizeE
     }
 }
 
-void TreeBuilder::buildFanInOutStructure() {
-    bool ciTransitions = paramAddCiTransitions(config_);
-
-    // Create temporary coarticulated roots
-    for (std::set<Bliss::Phoneme::Id>::const_iterator finalIt = finalPhonemes_.begin(); finalIt != finalPhonemes_.end(); ++finalIt)
-        for (std::set<Bliss::Phoneme::Id>::const_iterator initialIt = initialPhonemes_.begin(); initialIt != initialPhonemes_.end(); ++initialIt)
-            createRoot(*finalIt, *initialIt, 0);
-
-    log() << "building fan-in";
-    // Build the fan-in structure (eg. the HMM structure representing the initial word phonemes, behind roots, up to the joints)
-    for (RootHash::const_iterator rootIt = roots_.begin(); rootIt != roots_.end(); ++rootIt) {
-        if (rootIt->first.depth != 0 || rootIt->second == network_.rootState)
-            continue;
-        Bliss::Phoneme::Id initial = rootIt->first.right;
-        verify(initialPhonemes_.count(initial));
-        verify(initial != Bliss::Phoneme::term);
-        u32 paths = 0;
-
-        for (CoarticulationJointHash::const_iterator initialSuffixIt = initialPhoneSuffix_.begin(); initialSuffixIt != initialPhoneSuffix_.end(); ++initialSuffixIt) {
-            if (initialSuffixIt->first.left != initial)
-                continue;
-            ++paths;
-            HMMSequence hmm;
-            hmmFromAllophone(hmm, rootIt->first.left, initial, initialSuffixIt->first.right, Am::Allophone::isInitialPhone);
-            verify(hmm.length > 0);
-            StateId currentNode = extendFanIn(initialSuffixIt->second, hmm[hmm.length - 1]);
-            for (s32 s = hmm.length - 2; s >= 0; --s)
-                currentNode = extendFanIn(currentNode, hmm[s]);
-
-            addSuccessor(rootIt->second, currentNode);
-        }
-
-        for (CoarticulationJointHash::const_iterator initialSuffixIt = initialFinalPhoneSuffix_.begin(); initialSuffixIt != initialFinalPhoneSuffix_.end(); ++initialSuffixIt) {
-            if (initialSuffixIt->first.left != initial)
-                continue;
-            ++paths;
-            HMMSequence hmm;
-            hmmFromAllophone(hmm, rootIt->first.left, initial, initialSuffixIt->first.right, Am::Allophone::isInitialPhone | Am::Allophone::isFinalPhone);
-            verify(hmm.length > 0);
-            StateId currentNode = extendFanIn(initialSuffixIt->second, hmm[hmm.length - 1]);
-            for (s32 s = hmm.length - 2; s >= 0; --s)
-                currentNode = extendFanIn(currentNode, hmm[s]);
-
-            addSuccessor(rootIt->second, currentNode);
+void MinimizedTreeBuilder::mapSet(std::set<StateId>& set, const std::vector<StateId>& minimizeMap, bool force) {
+    std::set<StateId> oldSet;
+    oldSet.swap(set);
+    for (std::set<StateId>::iterator it = oldSet.begin(); it != oldSet.end(); ++it) {
+        if (*it >= minimizeMap.size()) {
+            set.insert(*it);
+        } else if (!minimizeMap[*it]) {
+            verify(!force);
+        } else {
+            set.insert(minimizeMap[*it]);
         }
     }
-
-    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size() << " roots: " << roots_.size();
-
-    log() << "building fan-out";
-
-    // Build the fan-out structure (eg. the HMM structure representing the final word phonemes, behind special roots)
-    // At the left side delimited by the roots of depth -1, and at the right side by the roots of depth 0
-    for (RootHash::const_iterator leftRootIt = roots_.begin(); leftRootIt != roots_.end(); ++leftRootIt) {
-        if (leftRootIt->first.depth != -1)
-            continue;
-        Bliss::Phoneme::Id fin = leftRootIt->first.right;
-        verify(finalPhonemes_.count(fin));
-
-        u32 paths = 0;
-        for (RootHash::const_iterator rightRootIt = roots_.begin(); rightRootIt != roots_.end(); ++rightRootIt) {
-            if (rightRootIt->first.depth != 0 || (rightRootIt->first.left != fin && (!ciTransitions || rightRootIt->first.left != Bliss::Phoneme::term)))
-                continue;
-            ++paths;
-            HMMSequence hmm;
-            hmmFromAllophone(hmm, leftRootIt->first.left, fin, rightRootIt->first.right, Am::Allophone::isFinalPhone, false);
-            verify(hmm.length > 0);
-
-            // The last state in the pushed fan-in is equivalent with the corresponding root state
-
-            StateId lastNode    = extendFanIn(network_.structure.targetSet(rightRootIt->second), hmm[hmm.length - 1]);
-            StateId currentNode = lastNode;
-            for (s32 s = hmm.length - 2; s >= 0; --s)
-                currentNode = extendFanIn(currentNode, hmm[s]);
-
-            if (rightRootIt->first.right == Bliss::Phoneme::term || !isContextDependent(rightRootIt->first.right))
-                network_.uncoarticulatedWordEndStates.insert(lastNode);
-
-            addSuccessor(leftRootIt->second, currentNode);
-        }
-        verify(paths);
-    }
-
-    printStats("after fan-in/out structure");
-}
-
-void TreeBuilder::printStats(std::string occasion) {
-    log() << "stats " << occasion << ":";
-    log() << "states: " << network_.structure.stateCount() << " exits: " << network_.exits.size();
-    log() << "coarticulated roots: " << network_.coarticulatedRootStates.size() << " unpushed: " << network_.unpushedCoarticulatedRootStates.size();
-    u32 roots = 0;
-    for (std::set<StateId>::iterator it = network_.uncoarticulatedWordEndStates.begin(); it != network_.uncoarticulatedWordEndStates.end(); ++it)
-        if (network_.coarticulatedRootStates.count(*it))
-            ++roots;
-    log() << "number of uncoarticulated pushed word-end nodes: " << network_.uncoarticulatedWordEndStates.size() << " out of those are roots: " << roots;
-}
-
-TreeBuilder::StateId TreeBuilder::createSkipRoot(StateId baseRoot) {
-    SkipRootsHash::const_iterator it = skipRoots_.find(baseRoot);
-    if (it != skipRoots_.end())
-        return it->second;
-    StateTree::StateDesc desc = rootDesc();
-    desc.transitionModelIndex = Am::TransitionModel::entryM2;
-    StateId ret               = createState(desc);
-
-    skipRoots_.insert(std::make_pair(baseRoot, ret));
-    network_.structure.addTargetToNode(ret, baseRoot);
-    skipRootSet_.insert(ret);
-    network_.coarticulatedRootStates.insert(ret);
-    verify(network_.rootTransitDescriptions.count(baseRoot));
-    network_.rootTransitDescriptions.insert(std::make_pair(ret, network_.rootTransitDescriptions[baseRoot]));
-    return ret;
-}
-
-TreeBuilder::StateId TreeBuilder::createRoot(Bliss::Phoneme::Id left, Bliss::Phoneme::Id right, int depth) {
-    RootKey                  key(left, right, depth);
-    RootHash::const_iterator it = roots_.find(key);
-    if (it != roots_.end())
-        return it->second;
-    StateId ret = createState(rootDesc());
-    if (depth == 0 && (left != Bliss::Phoneme::term || right != Bliss::Phoneme::term))
-        network_.unpushedCoarticulatedRootStates.insert(ret);
-
-    if (right == Bliss::Phoneme::term || !acousticModel_.phonemeInventory()->phoneme(right)->isContextDependent())
-        network_.uncoarticulatedWordEndStates.insert(ret);
-
-    if (left != Bliss::Phoneme::term || right != Bliss::Phoneme::term)
-        network_.coarticulatedRootStates.insert(ret);
-    roots_.insert(std::make_pair(key, ret));
-
-    network_.rootTransitDescriptions.insert(std::make_pair(ret, std::make_pair(left, right)));
-
-    return ret;
-}
-
-TreeBuilder::StateId TreeBuilder::createState(StateTree::StateDesc desc) {
-    StateId ret                             = network_.structure.allocateTreeNode(network_.masterTree);
-    network_.structure.state(ret).stateDesc = desc;
-    return ret;
-}
-
-TreeBuilder::StateId TreeBuilder::extendFanIn(StateId successorOrExit, StateTree::StateDesc desc) {
-    std::set<StateId> successors;
-    successors.insert(successorOrExit);
-    return extendFanIn(successors, desc);
-}
-
-TreeBuilder::StateId TreeBuilder::extendFanIn(const std::set<StateId>& successorsOrExits, Search::StateTree::StateDesc desc) {
-    StatePredecessor           pred(successorsOrExits, desc);
-    PredecessorsHash::iterator it = predecessors_.find(pred);
-    if (it != predecessors_.end())
-        return it->second;
-    StateId ret = createState(desc);
-    for (std::set<StateId>::const_iterator it = successorsOrExits.begin(); it != successorsOrExits.end(); ++it)
-        network_.structure.addTargetToNode(ret, *it);
-    predecessors_.insert(std::make_pair(pred, ret));
-    return ret;
-}
-
-bool TreeBuilder::addSuccessor(StateId predecessor, StateId successor) {
-    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target)
-        if (*target == successor)
-            return false;
-
-    network_.structure.addTargetToNode(predecessor, successor);
-    return true;
-}
-
-std::pair<TreeBuilder::StateId, TreeBuilder::StateId> TreeBuilder::extendPhone(StateId                                currentState,
-                                                                               u32                                    phoneIndex,
-                                                                               const std::vector<Bliss::Phoneme::Id>& phones,
-                                                                               Bliss::Phoneme::Id                     left,
-                                                                               Bliss::Phoneme::Id                     right) {
-    u8 boundary = 0;
-    if (phoneIndex != 0)
-        left = phones[phoneIndex - 1];
-    else
-        boundary |= Am::Allophone::isInitialPhone;
-
-    if (phoneIndex != phones.size() - 1)
-        right = phones[phoneIndex + 1];
-    else
-        boundary |= Am::Allophone::isFinalPhone;
-
-    HMMSequence hmm;
-    hmmFromAllophone(hmm, left, phones[phoneIndex], right, boundary, phoneIndex == 0);
-
-    verify(hmm.length >= 1);
-
-    u32     hmmState      = 0;
-    StateId previousState = 0;
-
-    if (phoneIndex == 1 && hmmState == 0)
-        currentState = extendBodyState(currentState, left, phones[phoneIndex], hmm[hmmState++]);
-
-    for (; hmmState < hmm.length; ++hmmState) {
-        previousState = currentState;
-        currentState  = extendState(currentState, hmm[hmmState]);
-    }
-
-    return std::make_pair(previousState, currentState);
-}
-
-TreeBuilder::StateId TreeBuilder::extendState(StateId predecessor, StateTree::StateDesc desc, TreeBuilder::RootKey uniqueKey) {
-    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target)
-        if (!target.isLabel() && network_.structure.state(*target).stateDesc == desc) {
-            if (uniqueKey.isValid()) {
-                Core::HashMap<StateId, RootKey>::const_iterator it = stateUniqueKeys_.find(*target);
-                verify(it != stateUniqueKeys_.end());
-                if (!(it->second == uniqueKey))
-                    continue;
-            }
-            return *target;
-        }
-
-    // No matching successor found, extend
-    StateId ret = createState(desc);
-    if (uniqueKey.isValid())
-        stateUniqueKeys_.insert(std::make_pair(ret, uniqueKey));
-    network_.structure.addTargetToNode(predecessor, ret);
-    return ret;
-}
-
-u32 TreeBuilder::createExit(PersistentStateTree::Exit exit) {
-    ExitHash::iterator exitHashIt = exitHash_.find(exit);
-    if (exitHashIt != exitHash_.end()) {
-        return exitHashIt->second;
-    }
-    else {
-        // Exit does not exist yet, add it
-        network_.exits.push_back(exit);
-        u32 exitIndex = network_.exits.size() - 1;
-        exitHash_.insert(std::make_pair(exit, exitIndex));
-        return exitIndex;
-    }
-}
-
-u32 TreeBuilder::addExit(StateId                       prePredecessor,
-                         StateId                       predecessor,
-                         Bliss::Phoneme::Id            leftPhoneme,
-                         Bliss::Phoneme::Id            rightPhoneme,
-                         int                           depth,
-                         Bliss::LemmaPronunciation::Id pron) {
-    PersistentStateTree::Exit exit;
-    exit.transitState  = createRoot(leftPhoneme, rightPhoneme, depth);
-    exit.pronunciation = pron;
-
-    u32 exitIndex = createExit(exit);
-
-    for (HMMStateNetwork::SuccessorIterator target = network_.structure.successors(predecessor); target; ++target)
-        if (target.isLabel() && target.label() == exitIndex)
-            return exitIndex;
-
-    network_.structure.addOutputToNode(predecessor, ID_FROM_LABEL(exitIndex));
-    return exitIndex;
-}
-
-TreeBuilder::StateId TreeBuilder::extendBodyState(StateId                      state,
-                                                  Bliss::Phoneme::Id           first,
-                                                  Bliss::Phoneme::Id           second,
-                                                  Search::StateTree::StateDesc desc) {
-    RootKey key(first, second, 1);
-    StateId ret = extendState(state, desc, key);
-    initialPhoneSuffix_[key].insert(ret);
-    return ret;
-}
-
-bool TreeBuilder::isContextDependent(Bliss::Phoneme::Id phone) const {
-    return acousticModel_.phonemeInventory()->phoneme(phone)->isContextDependent();
-}
-
-StateTree::StateDesc TreeBuilder::rootDesc() const {
-    StateTree::StateDesc desc;
-    desc.acousticModel        = Search::StateTree::invalidAcousticModel;
-    desc.transitionModelIndex = Am::TransitionModel::entryM1;
-    return desc;
-}
-
-std::string TreeBuilder::describe(std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id> desc) {
-    std::ostringstream os;
-
-    if (desc.first == Bliss::Phoneme::term)
-        os << "#";
-    else
-        os << lexicon_.phonemeInventory()->phoneme(desc.first)->symbol();
-
-    os << "<->";
-
-    if (desc.second == Bliss::Phoneme::term)
-        os << "#";
-    else
-        os << lexicon_.phonemeInventory()->phoneme(desc.second)->symbol();
-
-    return os.str();
-}
-
-Core::Component::Message TreeBuilder::log() const {
-    return Core::Application::us()->log("TreeBuilder: ");
 }
 
 
 // update hash structures according to minimizeMap (invalid ones are removed)
 // should be ok for any number of minimize iterations
-void TreeBuilder::updateHashFromMap(const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
+void MinimizedTreeBuilder::updateHashFromMap(const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
     Core::HashMap<StateId, RootKey> tmpKeyHash;
-    for (Core::HashMap<StateId, RootKey>::iterator iter = stateUniqueKeys_.begin(); iter != stateUniqueKeys_.end(); ++iter)
-        if (iter->first < map.size() && map[iter->first])
+    for (Core::HashMap<StateId, RootKey>::iterator iter = stateUniqueKeys_.begin(); iter != stateUniqueKeys_.end(); ++iter) {
+        if (iter->first < map.size() && map[iter->first]) {
             tmpKeyHash.insert(std::make_pair(map[iter->first], iter->second));
+        }
+    }
     stateUniqueKeys_.swap(tmpKeyHash);
 
     mapCoarticulationJointHash(initialPhoneSuffix_, map, exitMap);
     mapCoarticulationJointHash(initialFinalPhoneSuffix_, map, exitMap);
 
     RootHash tmpRootHash;
-    for (RootHash::const_iterator rootIt = roots_.begin(); rootIt != roots_.end(); ++rootIt)
-        if (rootIt->second < map.size() && map[rootIt->second])
+    for (RootHash::const_iterator rootIt = roots_.begin(); rootIt != roots_.end(); ++rootIt) {
+        if (rootIt->second < map.size() && map[rootIt->second]) {
             tmpRootHash.insert(std::make_pair(rootIt->first, map[rootIt->second]));
+        }
+    }
     roots_.swap(tmpRootHash);
 
     // exits are changed in cleanup
     exitHash_.clear();
-    for (u32 idx = 0; idx != network_.exits.size(); ++idx)
+    for (u32 idx = 0; idx != network_.exits.size(); ++idx) {
         exitHash_.insert(std::make_pair(network_.exits[idx], idx));
+    }
 
     // PredecessorsHash still the FanIn/Out ones at this point (recorded in minimize())
     PredecessorsHash tmpPredHash;
     for (PredecessorsHash::iterator pIt = predecessors_.begin(); pIt != predecessors_.end(); ++pIt) {
-        if (pIt->second >= map.size() || !map[pIt->second])
+        if (pIt->second >= map.size() || !map[pIt->second]) {
             continue;
+        }
         const StatePredecessor& sp = pIt->first;
         std::set<StateId>       tmpSet;
         mapSuccessors(sp.successors, tmpSet, map, exitMap);
@@ -1121,26 +1152,29 @@ void TreeBuilder::updateHashFromMap(const std::vector<StateId>& map, const std::
     predecessors_.swap(tmpPredHash);
 }
 
-inline void TreeBuilder::mapCoarticulationJointHash(CoarticulationJointHash& hash, const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
+inline void MinimizedTreeBuilder::mapCoarticulationJointHash(CoarticulationJointHash& hash, const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
     CoarticulationJointHash tmpHash;
     for (CoarticulationJointHash::iterator iter = hash.begin(); iter != hash.end(); ++iter) {
         std::set<StateId> tmpSet;
         mapSuccessors(iter->second, tmpSet, map, exitMap);
-        if (!tmpSet.empty())
+        if (!tmpSet.empty()) {
             tmpHash.insert(std::make_pair(iter->first, tmpSet));
+        }
     }
     hash.swap(tmpHash);
 }
 
-inline void TreeBuilder::mapSuccessors(const std::set<StateId>& successors, std::set<StateId>& tmpSet, const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
-    for (std::set<StateId>::const_iterator sIt = successors.cbegin(); sIt != successors.cend(); ++sIt)
+inline void MinimizedTreeBuilder::mapSuccessors(const std::set<StateId>& successors, std::set<StateId>& tmpSet, const std::vector<StateId>& map, const std::vector<u32>& exitMap) {
+    for (std::set<StateId>::const_iterator sIt = successors.cbegin(); sIt != successors.cend(); ++sIt) {
         if (IS_LABEL(*sIt)) {
             u32 eIdx = LABEL_FROM_ID(*sIt);
-            if (exitMap.empty() || eIdx >= exitMap.size())
+            if (exitMap.empty() || eIdx >= exitMap.size()) {
                 tmpSet.insert(*sIt);
-            else
+            } else {
                 tmpSet.insert(ID_FROM_LABEL(exitMap[eIdx]));
-        }
-        else if (*sIt < map.size() && map[*sIt])
+            }
+        } else if (*sIt < map.size() && map[*sIt]) {
             tmpSet.insert(map[*sIt]);
+        }
+    }
 }

--- a/src/Search/AdvancedTreeSearch/TreeBuilder.cc
+++ b/src/Search/AdvancedTreeSearch/TreeBuilder.cc
@@ -201,7 +201,8 @@ void MinimizedTreeBuilder::buildBody() {
                 initialPhonemes_.insert(initial);
                 if (isContextDependent(initial)) {
                     coarticulatedInitial += 1;
-                } else {
+                }
+                else {
                     uncoarticulatedInitial += 1;
                 }
             }
@@ -209,7 +210,8 @@ void MinimizedTreeBuilder::buildBody() {
             if (!finalPhonemes_.count(fin)) {
                 if (isContextDependent(fin)) {
                     coarticulatedFinal += 1;
-                } else {
+                }
+                else {
                     uncoarticulatedFinal += 1;
                 }
                 finalPhonemes_.insert(fin);
@@ -265,7 +267,8 @@ void MinimizedTreeBuilder::buildBody() {
                     u32 exit;
                     if (!isContextDependent(phones[pronLength - 1]) && useRootForCiExits) {
                         exit = addExit(tail.second, Bliss::Phoneme::term, Bliss::Phoneme::term, 0, lemmaPron->id());  // Use the non-coarticulated root node
-                    } else {
+                    }
+                    else {
                         exit = addExit(tail.second, phones[pronLength - 1], *initialIt, 0, lemmaPron->id());
                     }
                     if (pronLength == 1) {
@@ -273,7 +276,8 @@ void MinimizedTreeBuilder::buildBody() {
                     }
                 }
             }
-        } else {
+        }
+        else {
             // Minimize the remaining phoneme, insert corresponding word-ends.
             for (Bliss::Pronunciation::LemmaIterator lemmaPron = lemmaProns.first; lemmaPron != lemmaProns.second; ++lemmaPron) {
                 if (pronLength == 1) {
@@ -285,7 +289,8 @@ void MinimizedTreeBuilder::buildBody() {
                         exit.pronunciation = lemmaPron->id();
                         addSuccessor(createRoot(*finalIt, phones[0], 0), ID_FROM_LABEL(createExit(exit)));
                     }
-                } else {
+                }
+                else {
                     u32 exit = addExit(currentState.second, phones[pronLength - 2], phones[pronLength - 1], -1, lemmaPron->id());
                     if (pronLength == 2) {
                         initialPhoneSuffix_[RootKey(phones[0], phones[1], 1)].insert(ID_FROM_LABEL(exit));
@@ -558,7 +563,8 @@ u32 MinimizedTreeBuilder::createExit(PersistentStateTree::Exit exit) {
     ExitHash::iterator exitHashIt = exitHash_.find(exit);
     if (exitHashIt != exitHash_.end()) {
         return exitHashIt->second;
-    } else {
+    }
+    else {
         // Exit does not exist yet, add it
         network_.exits.push_back(exit);
         u32 exitIndex = network_.exits.size() - 1;
@@ -602,7 +608,8 @@ void MinimizedTreeBuilder::hmmFromAllophone(HMMSequence&       ret,
         std::swap(left, right);
         if (boundary == Am::Allophone::isFinalPhone) {
             boundary = Am::Allophone::isInitialPhone;
-        } else if (boundary == Am::Allophone::isInitialPhone) {
+        }
+        else if (boundary == Am::Allophone::isInitialPhone) {
             boundary = Am::Allophone::isFinalPhone;
         }
     }
@@ -664,13 +671,15 @@ std::pair<AbstractTreeBuilder::StateId, AbstractTreeBuilder::StateId> MinimizedT
     u8 boundary = 0;
     if (phoneIndex != 0) {
         left = phones[phoneIndex - 1];
-    } else {
+    }
+    else {
         boundary |= Am::Allophone::isInitialPhone;
     }
 
     if (phoneIndex != phones.size() - 1) {
         right = phones[phoneIndex + 1];
-    } else {
+    }
+    else {
         boundary |= Am::Allophone::isFinalPhone;
     }
 
@@ -806,7 +815,8 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
         for (StateId node = 1; node < network_.structure.stateCount(); ++node) {
             determinizeMap[node] = node;
         }
-    } else {
+    }
+    else {
         // Determinize states: Join successor states with the same state-desc
         while (!active.empty()) {
             StateId state = active.front();
@@ -911,7 +921,8 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
         for (StateId state = 1; state < oldNodeCount; ++state) {
             if (minimizeMap[state] == state) {
                 minimizeExits(state, minimizeExitsMap);
-            } else {
+            }
+            else {
                 network_.structure.clearOutputEdges(state);
             }
         }
@@ -936,7 +947,8 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
                 if (orig == network_.rootState || network_.coarticulatedRootStates.count(orig)) {
                     network_.rootTransitDescriptions.insert(*it);
                 }
-            } else {
+            }
+            else {
                 StateId mapped = minimizeMap[it->first];
                 verify(mapped);
                 verify(network_.coarticulatedRootStates.count(mapped));
@@ -956,7 +968,8 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
     for (StateId state = 1; state < determinizeMap.size(); ++state) {
         if (determinizeMap[state]) {
             determinizeMap[state] = minimizeMap[determinizeMap[state]];
-        } else {
+        }
+        else {
             determinizeMap[state] = minimizeMap[state];
         }
     }
@@ -970,7 +983,8 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
                 *it = cleanupResult.nodeMap[*it];
                 kept += 1;
                 verify(*it);
-            } else {
+            }
+            else {
                 lost += 1;
                 *it = 0;
             }
@@ -979,7 +993,7 @@ std::vector<AbstractTreeBuilder::StateId> MinimizedTreeBuilder::minimize(bool fo
     log() << "transformed states: " << kept << " lost: " << lost;
     //   verify( allowLost || !lost );
 
-    // update necessary hashs w.r.t. minimizeMap
+    // update necessary hashes w.r.t. minimizeMap
     predecessors_.swap(oldPredecessors);
     updateHashFromMap(minimizeMap, minimizeExitsMap);
 
@@ -1008,7 +1022,8 @@ void MinimizedTreeBuilder::minimizeState(StateId state, std::vector<StateId>& mi
         if (minimizeMap[*target] == Core::Type<u32>::max) {
             //       std::cout << "detected recursion while minimization on " << *target << std::endl;
             successors.insert(*target);
-        }else {
+        }
+        else {
             successors.insert(minimizeMap[*target]);
         }
     }
@@ -1019,7 +1034,8 @@ void MinimizedTreeBuilder::minimizeState(StateId state, std::vector<StateId>& mi
     std::unordered_map<StatePredecessor, StateId, StatePredecessor::Hash>::iterator it = predecessors_.find(pred);
     if (it != predecessors_.end()) {
         minimizeMap[state] = it->second;
-    } else {
+    }
+    else {
         minimizeMap[state] = state;
         predecessors_.insert(std::make_pair(pred, state));
         for (std::set<StateId>::iterator succIt = successors.begin(); succIt != successors.end(); ++succIt)
@@ -1057,7 +1073,8 @@ void MinimizedTreeBuilder::minimizeExits(StateId state, const std::vector<u32>& 
         ExitMap::iterator                               i     = range.first;
         if (++i == range.second) {
             network_.structure.addOutputToNode(state, range.first->second);
-        } else {
+        }
+        else {
             // Join
             std::set<StateId>            newRootSuccessors;
             std::set<Bliss::Phoneme::Id> left, right;
@@ -1098,14 +1115,15 @@ void MinimizedTreeBuilder::mapSet(std::set<StateId>& set, const std::vector<Stat
     for (std::set<StateId>::iterator it = oldSet.begin(); it != oldSet.end(); ++it) {
         if (*it >= minimizeMap.size()) {
             set.insert(*it);
-        } else if (!minimizeMap[*it]) {
+        }
+        else if (!minimizeMap[*it]) {
             verify(!force);
-        } else {
+        }
+        else {
             set.insert(minimizeMap[*it]);
         }
     }
 }
-
 
 // update hash structures according to minimizeMap (invalid ones are removed)
 // should be ok for any number of minimize iterations
@@ -1170,10 +1188,12 @@ inline void MinimizedTreeBuilder::mapSuccessors(const std::set<StateId>& success
             u32 eIdx = LABEL_FROM_ID(*sIt);
             if (exitMap.empty() || eIdx >= exitMap.size()) {
                 tmpSet.insert(*sIt);
-            } else {
+            }
+            else {
                 tmpSet.insert(ID_FROM_LABEL(exitMap[eIdx]));
             }
-        } else if (*sIt < map.size() && map[*sIt]) {
+        }
+        else if (*sIt < map.size() && map[*sIt]) {
             tmpSet.insert(map[*sIt]);
         }
     }

--- a/src/Search/AdvancedTreeSearch/TreeBuilder.hh
+++ b/src/Search/AdvancedTreeSearch/TreeBuilder.hh
@@ -61,7 +61,7 @@ public:
     static const Core::ParameterBool paramAllowCrossWordSkips;
     static const Core::ParameterBool paramRepeatSilence;
     static const Core::ParameterInt  paramMinimizeIterations;
-    typedef u32 StateId;
+    typedef u32                      StateId;
 
     MinimizedTreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true);
     virtual ~MinimizedTreeBuilder() = default;

--- a/src/Search/AdvancedTreeSearch/TreeBuilder.hh
+++ b/src/Search/AdvancedTreeSearch/TreeBuilder.hh
@@ -33,29 +33,57 @@ namespace Core {
 class Configuration;
 }
 
-class TreeBuilder {
+class AbstractTreeBuilder : public Core::Component {
 public:
     typedef u32 StateId;
 
-    TreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true, bool arcBased = false);
-    // Build a new persistent state network.
-    void build();
-    // Returns a mapping of state-indices. Zero means 'invalid'.
-    // If onlyMinimizeBackwards is true, then no forward determinization is performed, but rather only backwards minimization.
-    // If allowLost is true, losing states is allowed. Happens if there are unreachable garbage states.
-    std::vector<StateId> minimize(bool forceDeterminization = true, bool onlyMinimizeBackwards = false, bool allowLost = false);
+    AbstractTreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network);
+    virtual ~AbstractTreeBuilder() = default;
 
+    virtual std::unique_ptr<AbstractTreeBuilder> newInstance(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true) = 0;
+
+    // Build a new persistent state network.
+    virtual void build() = 0;
+
+protected:
+    const Bliss::Lexicon&        lexicon_;
+    const Am::AcousticModel&     acousticModel_;
+    Search::PersistentStateTree& network_;
+};
+
+class MinimizedTreeBuilder : public AbstractTreeBuilder {
+public:
+    static const Core::ParameterInt  paramMinPhones;
+    static const Core::ParameterBool paramAddCiTransitions;
+    static const Core::ParameterBool paramUseRootForCiExits;
+    static const Core::ParameterBool paramForceExactWordEnds;
+    static const Core::ParameterBool paramKeepRoots;
+    static const Core::ParameterBool paramAllowCrossWordSkips;
+    static const Core::ParameterBool paramRepeatSilence;
+    static const Core::ParameterInt  paramMinimizeIterations;
+    typedef u32 StateId;
+
+    MinimizedTreeBuilder(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true);
+    virtual ~MinimizedTreeBuilder() = default;
+
+    virtual std::unique_ptr<AbstractTreeBuilder> newInstance(Core::Configuration config, const Bliss::Lexicon& lexicon, const Am::AcousticModel& acousticModel, Search::PersistentStateTree& network, bool initialize = true);
+
+    virtual void build();
+
+protected:
     struct HMMSequence {
         HMMSequence()
                 : length(0) {}
         enum {
             MaxLength = 12
         };
-        s32                                        length;
+
+        s32                          length;
+        Search::StateTree::StateDesc hmm[MaxLength];
+
         inline const Search::StateTree::StateDesc& operator[](u32 index) const {
             return hmm[index];
         }
-        Search::StateTree::StateDesc hmm[MaxLength];
 
         bool operator==(const HMMSequence& rhs) const {
             verify(length < MaxLength);
@@ -79,18 +107,6 @@ public:
             }
         };
     };
-
-    HMMSequence arcSequence(u32 acousticModelIndex) const;
-    std::string arcDesc(u32 acousticModelIndex) const;
-
-    // If this function returns true, then the hmm states are placeholders for hmm sequences which
-    // can be acquired through arcSequence(...). The transition model index then contains word boundary information.
-    bool arcBased() const {
-        return arcBased_;
-    }
-
-protected:
-    Core::Component::Message log() const;
 
     struct RootKey {
     public:
@@ -127,15 +143,15 @@ protected:
                   isWordEnd(_isWordEnd),
                   hash(StandardValueHash<Bliss::Phoneme::Id>()(SetHash<StateId>()(successors) + Search::StateTree::StateDesc::Hash()(desc) + (isWordEnd ? 1312 : 0))) {}
 
+        bool operator==(const StatePredecessor& rhs) const {
+            return successors == rhs.successors && desc == rhs.desc && isWordEnd == rhs.isWordEnd;
+        }
+
         struct Hash {
             u32 operator()(const StatePredecessor& pred) const {
                 return pred.hash;
             }
         };
-
-        bool operator==(const StatePredecessor& rhs) const {
-            return successors == rhs.successors && desc == rhs.desc && isWordEnd == rhs.isWordEnd;
-        }
 
         const std::set<StateId>            successors;
         const Search::StateTree::StateDesc desc;
@@ -143,12 +159,47 @@ protected:
         const u32                          hash;
     };
 
-    void printStats(std::string occasion);
+    typedef std::set<Bliss::Phoneme::Id>                                                                   PhonemeIdSet;
+    typedef Core::HashMap<RootKey, StateId, RootKey::Hash>                                                 RootHash;
+    typedef Core::HashMap<StateId, StateId>                                                                SkipRootsHash;
+    typedef Core::HashMap<Search::PersistentStateTree::Exit, u32, Search::PersistentStateTree::Exit::Hash> ExitHash;
+    typedef Core::HashMap<RootKey, std::set<StateId>, RootKey::Hash>                                       CoarticulationJointHash;
+    typedef Core::HashMap<StatePredecessor, Search::StateId, StatePredecessor::Hash>                       PredecessorsHash;
+
+    s32  minPhones_;
+    bool addCiTransitions_;
+    bool useRootForCiExits_;
+    bool forceExactWordEnds_;
+    bool keepRoots_;
+    bool allowCrossWordSkips_;
+    bool repeatSilence_;
+    u32  minimizeIterations_;
+    bool reverse_;
+
+    PhonemeIdSet initialPhonemes_;
+    PhonemeIdSet finalPhonemes_;
+
+    // Keys according to which specific states are supposed to be unique
+    // Required to omit merging of paths in some critical locations
+    Core::HashMap<StateId, RootKey> stateUniqueKeys_;
+
+    RootHash                roots_;  // Contains roots and joint-states
+    SkipRootsHash           skipRoots_;
+    std::set<StateId>       skipRootSet_;
+    ExitHash                exitHash_;
+    CoarticulationJointHash initialPhoneSuffix_;
+    CoarticulationJointHash initialFinalPhoneSuffix_;
+    PredecessorsHash        predecessors_;
+
+    void        printStats(std::string occasion);
+    std::string describe(std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id>);
+
+    bool isContextDependent(Bliss::Phoneme::Id phone) const;
+
+    void buildBody();
     void buildFanInOutStructure();
     void addCrossWordSkips();
-    void skipRootTransitions();
-    void propagateExits(StateId state, Search::HMMStateNetwork::ChangePlan change);
-    bool isContextDependent(Bliss::Phoneme::Id phone) const;
+    void skipRootTransitions(StateId start = 1);
 
     Search::StateTree::StateDesc rootDesc() const;
 
@@ -156,18 +207,17 @@ protected:
     StateId createRoot(Bliss::Phoneme::Id left, Bliss::Phoneme::Id right, int depth);
     StateId createState(Search::StateTree::StateDesc desc);
     u32     createExit(Search::PersistentStateTree::Exit exit);
-    u32     addExit(StateId                       prePredecessor,
-                    StateId                       predecessor,
+    u32     addExit(StateId                       predecessor,
                     Bliss::Phoneme::Id            leftPhoneme,
                     Bliss::Phoneme::Id            rightPhoneme,
                     int                           depth,
                     Bliss::LemmaPronunciation::Id pron);
-    void    hmmFromAllophone(HMMSequence&       ret,
-                             Bliss::Phoneme::Id left,
-                             Bliss::Phoneme::Id central,
-                             Bliss::Phoneme::Id right,
-                             u32                boundary         = 0,
-                             bool               allowNonStandard = true);
+
+    void hmmFromAllophone(HMMSequence&       ret,
+                          Bliss::Phoneme::Id left,
+                          Bliss::Phoneme::Id central,
+                          Bliss::Phoneme::Id right,
+                          u32                boundary = 0);
 
     // Adds the successor as successor of the predecessor, if it isn't in the list yet
     bool                        addSuccessor(StateId predecessor, StateId successor);
@@ -180,60 +230,15 @@ protected:
     StateId                     extendBodyState(StateId state, Bliss::Phoneme::Id first, Bliss::Phoneme::Id second, Search::StateTree::StateDesc desc);
     StateId                     extendFanIn(StateId successor, Search::StateTree::StateDesc desc);
     StateId                     extendFanIn(const std::set<StateId>& successors, Search::StateTree::StateDesc desc);
-    void                        minimizeState(StateId state, std::vector<StateId>& minimizeMap);
-    void                        minimizeExits(StateId state, const std::vector<u32>& minimizeExitsMap);
-    static void                 mapSet(std::set<StateId>& set, const std::vector<StateId>& minimizeMap, bool force);
 
-    std::string describe(std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id>);
+    // Returns a mapping of state-indices. Zero means 'invalid'.
+    // If onlyMinimizeBackwards is true, then no forward determinization is performed, but rather only backwards minimization.
+    // If allowLost is true, losing states is allowed. Happens if there are unreachable garbage states.
+    std::vector<StateId> minimize(bool forceDeterminization = true, bool onlyMinimizeBackwards = false, bool allowLost = false);
+    void                 minimizeState(StateId state, std::vector<StateId>& minimizeMap);
+    void                 minimizeExits(StateId state, const std::vector<u32>& minimizeExitsMap);
+    static void          mapSet(std::set<StateId>& set, const std::vector<StateId>& minimizeMap, bool force);
 
-    const Bliss::Lexicon&        lexicon_;
-    const Am::AcousticModel&     acousticModel_;
-    Search::PersistentStateTree& network_;
-    Core::Configuration          config_;
-    s32                          minPhones_;
-    bool                         forceExactWordEnds_;
-    bool                         keepRoots_;
-    bool                         allowCrossWordSkips_;
-    bool                         repeatSilence_;
-    bool                         reverse_;
-    bool                         arcBased_;
-    std::set<Bliss::Phoneme::Id> initialPhonemes_, finalPhonemes_;
-
-    // Keys according to which specific states are supposed to be unique
-    // Required to omit merging of paths in some critical locations
-    Core::HashMap<StateId, RootKey> stateUniqueKeys_;
-
-    typedef Core::HashMap<HMMSequence, u32, HMMSequence::Hash> ArcSequenceHash;
-    ArcSequenceHash                                            arcSequencesHash_;
-    std::vector<HMMSequence>                                   arcSequences_;
-    struct ArcDesc {
-        ArcDesc()
-                : left(Bliss::Phoneme::term),
-                  central(Bliss::Phoneme::term),
-                  right(Bliss::Phoneme::term) {
-        }
-        Bliss::Phoneme::Id left;
-        Bliss::Phoneme::Id central;
-        Bliss::Phoneme::Id right;
-    };
-    std::vector<ArcDesc> arcDescs_;
-
-    typedef Core::HashMap<RootKey, StateId, RootKey::Hash> RootHash;
-    RootHash                                               roots_;  // Contains roots and joint-states
-
-    typedef Core::HashMap<StateId, StateId> SkipRootsHash;
-    SkipRootsHash                           skipRoots_;
-    std::set<StateId>                       skipRootSet_;
-
-    typedef Core::HashMap<Search::PersistentStateTree::Exit, u32, Search::PersistentStateTree::Exit::Hash> ExitHash;
-    ExitHash                                                                                               exitHash_;
-
-    typedef Core::HashMap<RootKey, std::set<StateId>, RootKey::Hash> CoarticulationJointHash;
-    CoarticulationJointHash                                          initialPhoneSuffix_, initialFinalPhoneSuffix_;
-
-    typedef Core::HashMap<StatePredecessor, Search::StateId, StatePredecessor::Hash> PredecessorsHash;
-    PredecessorsHash                                                                 predecessors_;
-protected:
     void updateHashFromMap(const std::vector<StateId>& map, const std::vector<u32>& exitMap);
     void mapCoarticulationJointHash(CoarticulationJointHash& hash, const std::vector<StateId>& map, const std::vector<u32>& exitMap);
     void mapSuccessors(const std::set<StateId>&, std::set<StateId>&, const std::vector<StateId>&, const std::vector<u32>&);


### PR DESCRIPTION
Integrates the refactoring of the TreeBuilder from AppTek RASR. 
This mainly involves adjustments to allow different tree variants.
Code by @curufinwe 