### PR TITLE
Add Encoder class for LabelScorers

### DIFF
--- a/src/Nn/LabelScorer/Encoder.cc
+++ b/src/Nn/LabelScorer/Encoder.cc
@@ -14,9 +14,9 @@
  */
 
 #include "Encoder.hh"
+
 #include <Flow/Data.hh>
 #include <Mm/Module.hh>
-#include <algorithm>
 
 namespace Nn {
 
@@ -80,6 +80,12 @@ std::optional<std::shared_ptr<const f32[]>> Encoder::getNextOutput() {
     // Encoder is ready to run, so run it and try fetching an output again.
     encode();
     postEncodeCleanup();
+
+    // If there are still no outputs after encoding, return None to avoid recursive call
+    // resulting in infinite loop
+    if (outputBuffer_.empty()) {
+        return {};
+    }
 
     return getNextOutput();
 }

--- a/src/Nn/LabelScorer/Encoder.cc
+++ b/src/Nn/LabelScorer/Encoder.cc
@@ -1,0 +1,95 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "Encoder.hh"
+#include <Flow/Data.hh>
+#include <Mm/Module.hh>
+#include <algorithm>
+
+namespace Nn {
+
+Encoder::Encoder(Core::Configuration const& config)
+        : Core::Component(config),
+          inputBuffer_(),
+          outputBuffer_(),
+          featureSize_(Core::Type<size_t>::max),
+          outputSize_(Core::Type<size_t>::max),
+          expectMoreFeatures_(true) {}
+
+void Encoder::reset() {
+    expectMoreFeatures_ = true;
+    inputBuffer_.clear();
+
+    featureSize_ = Core::Type<size_t>::max;
+    outputSize_  = Core::Type<size_t>::max;
+
+    outputBuffer_.clear();
+}
+
+void Encoder::signalNoMoreFeatures() {
+    expectMoreFeatures_ = false;
+}
+
+void Encoder::addInput(std::shared_ptr<const f32[]> const& input, size_t featureSize) {
+    if (featureSize_ == Core::Type<size_t>::max) {
+        featureSize_ = featureSize;
+    }
+    else if (featureSize_ != featureSize) {
+        error() << "Encoder received incompatible feature size " << featureSize << "; was set to " << featureSize_ << " before.";
+    }
+
+    inputBuffer_.push_back(input);
+}
+
+void Encoder::addInputs(std::shared_ptr<const f32[]> const& input, size_t timeSize, size_t featureSize) {
+    for (size_t t = 0ul; t < timeSize; ++t) {
+        // Use aliasing constructor to create sub-`shared_ptr`s that share ownership with the original one but point to different memory locations
+        addInput(std::shared_ptr<const f32[]>(input, input.get() + t * featureSize), featureSize);
+    }
+}
+
+bool Encoder::canEncode() const {
+    return not inputBuffer_.empty() and not expectMoreFeatures_;
+}
+
+std::optional<std::shared_ptr<const f32[]>> Encoder::getNextOutput() {
+    // Check if there are still outputs in the buffer to pass
+    if (not outputBuffer_.empty()) {
+        auto result = outputBuffer_.front();
+        outputBuffer_.pop_front();
+        return result;
+    }
+
+    // Output buffer is empty but encoder is not ready? -> Return none
+    if (not canEncode()) {
+        return {};
+    }
+
+    // Encoder is ready to run, so run it and try fetching an output again.
+    encode();
+    postEncodeCleanup();
+
+    return getNextOutput();
+}
+
+size_t Encoder::getOutputSize() const {
+    return outputSize_;
+}
+
+void Encoder::postEncodeCleanup() {
+    inputBuffer_.clear();
+}
+
+}  // namespace Nn

--- a/src/Nn/LabelScorer/Encoder.cc
+++ b/src/Nn/LabelScorer/Encoder.cc
@@ -15,9 +15,6 @@
 
 #include "Encoder.hh"
 
-#include <Flow/Data.hh>
-#include <Mm/Module.hh>
-
 namespace Nn {
 
 Encoder::Encoder(Core::Configuration const& config)

--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -16,11 +16,12 @@
 #ifndef ENCODER_HH
 #define ENCODER_HH
 
+#include <deque>
+#include <optional>
+
 #include <Core/Component.hh>
 #include <Nn/Types.hh>
 #include <Speech/Feature.hh>
-#include <deque>
-#include <optional>
 
 namespace Nn {
 
@@ -46,7 +47,7 @@ public:
     // Add input features for multiple time steps at once
     virtual void addInputs(std::shared_ptr<const f32[]> const& inputs, size_t timeSize, size_t featureSize);
 
-    // Retrieve a single encoder output
+    // Retrieve the next encoder output frame
     // Performs encoder forwarding internally if necessary
     // Can return None if not enough input features are available yet
     std::optional<std::shared_ptr<const f32[]>> getNextOutput();

--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -1,0 +1,79 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ENCODER_HH
+#define ENCODER_HH
+
+#include <Core/Component.hh>
+#include <Nn/Types.hh>
+#include <Speech/Feature.hh>
+#include <deque>
+#include <optional>
+
+namespace Nn {
+
+/*
+ * Encoder class can take features (e.g. from feature flow) and run them through an encoder model to get encoder states.
+ * Works with input/output buffer logic, i.e. features get added to an input buffer and outputs are retreived from an output buffer.
+ */
+class Encoder : public virtual Core::Component,
+                public Core::ReferenceCounted {
+public:
+    Encoder(Core::Configuration const& config);
+    virtual ~Encoder() = default;
+
+    // Clear buffers and reset segment end flag.
+    virtual void reset();
+
+    // Signal that no more features are expected for the current segment.
+    void signalNoMoreFeatures();
+
+    // Add a single input feature
+    virtual void addInput(std::shared_ptr<const f32[]> const& input, size_t featureSize);
+
+    // Add input features for multiple time steps at once
+    virtual void addInputs(std::shared_ptr<const f32[]> const& inputs, size_t timeSize, size_t featureSize);
+
+    // Retrieve a single encoder output
+    // Performs encoder forwarding internally if necessary
+    // Can return None if not enough input features are available yet
+    std::optional<std::shared_ptr<const f32[]>> getNextOutput();
+
+    size_t getOutputSize() const;
+
+protected:
+    std::deque<std::shared_ptr<const f32[]>> inputBuffer_;
+    std::deque<std::shared_ptr<const f32[]>> outputBuffer_;
+
+    size_t featureSize_;
+    size_t outputSize_;
+    bool   expectMoreFeatures_;
+
+    // Consume all features inside input buffer, encode them and put the results into the output buffer
+    // By default no-op, i.e. just move from input buffer over to output buffer
+    virtual void encode() = 0;
+
+    // Clean up all features from input buffer that have been processed by `encode` and are not needed anymore.
+    // By default, this clears out the entire input buffer.
+    virtual void postEncodeCleanup();
+
+    // Check if encoder is ready to encode.
+    // By default, allow encoding only after segment end has been signaled.
+    virtual bool canEncode() const;
+};
+
+}  // namespace Nn
+
+#endif  // ENCODER_HH

--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -20,8 +20,6 @@
 #include <optional>
 
 #include <Core/Component.hh>
-#include <Nn/Types.hh>
-#include <Speech/Feature.hh>
 
 namespace Nn {
 

--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -52,6 +52,7 @@ public:
     // Can return None if not enough input features are available yet
     std::optional<std::shared_ptr<const f32[]>> getNextOutput();
 
+    // Get dimension of outputs that are fetched via `getNextOutput`.
     size_t getOutputSize() const;
 
 protected:
@@ -62,8 +63,7 @@ protected:
     size_t outputSize_;
     bool   expectMoreFeatures_;
 
-    // Consume all features inside input buffer, encode them and put the results into the output buffer
-    // By default no-op, i.e. just move from input buffer over to output buffer
+    // Encode features inside the input buffer and put the results into the output buffer
     virtual void encode() = 0;
 
     // Clean up all features from input buffer that have been processed by `encode` and are not needed anymore.

--- a/src/Nn/LabelScorer/Makefile
+++ b/src/Nn/LabelScorer/Makefile
@@ -10,6 +10,7 @@ SUBDIRS		=
 TARGETS		= libSprintLabelScorer.$(a)
 
 LIBSPRINTLABELSCORER_O =  \
+    $(OBJDIR)/Encoder.o \
     $(OBJDIR)/LabelScorer.o \
     $(OBJDIR)/ScoringContext.o
 


### PR DESCRIPTION
Add `Encoder` class can take features (e.g. from feature flow) and run them through an encoder model to get encoder states. Works with input/output buffer logic, i.e. features get added to an input buffer and outputs are retrieved from an output buffer.


This will later get concrete implementations such as `OnnxEncoder` as subclasses and can be used to pre-process the input features of a LabelScorer in the context of encoder-decoder LabelScorers.