### PR TITLE
Add new `SearchAlgorithmV2` interface

### DIFF
--- a/src/Flf/IncrementalRecognizer.cc
+++ b/src/Flf/IncrementalRecognizer.cc
@@ -597,7 +597,7 @@ private:
     SegmentwiseFeatureExtractorRef                  featureExtractor_;
     SegmentwiseModelAdaptorRef                      modelAdaptor_;
     Core::XmlChannel                                tracebackChannel_;
-    Search::SearchAlgorithm::Traceback              traceback_;
+    Search::Traceback                               traceback_;
     std::vector<Flow::Timestamp>                    featureTimes_;
     std::unique_ptr<IncrementalRecognizer>          backwardRecognizer_;
 
@@ -656,14 +656,14 @@ private:
     DataSourceRef dataSource_;
 
 protected:
-    void addPartialToTraceback(Search::SearchAlgorithm::Traceback& partialTraceback) {
+    void addPartialToTraceback(Search::Traceback& partialTraceback) {
         if (!traceback_.empty() && traceback_.back().time == partialTraceback.front().time)
             partialTraceback.erase(partialTraceback.begin());
         traceback_.insert(traceback_.end(), partialTraceback.begin(), partialTraceback.end());
     }
 
     void processResult() {
-        Search::SearchAlgorithm::Traceback remainingTraceback;
+        Search::Traceback remainingTraceback;
         recognizer_->getCurrentBestSentence(remainingTraceback);
         addPartialToTraceback(remainingTraceback);
 
@@ -1512,10 +1512,10 @@ protected:
             }
             if (fwdBwdThreshold_ >= 0 || minArcsPerSecond_ || maxArcsPerSecond_ < Core::Type<f32>::max) {
                 l                               = pruneByFwdBwdScores(l,
-                                        fb,
+                                                                      fb,
                                         fwdBwdThreshold_ < 0 ? (fb->max() - fb->min()) : fwdBwdThreshold_,
-                                        minArcsPerSecond_,
-                                        maxArcsPerSecond_);
+                                                                      minArcsPerSecond_,
+                                                                      maxArcsPerSecond_);
                 StaticLatticeRef trimmedLattice = StaticLatticeRef(new StaticLattice);
                 copy(l, trimmedLattice.get(), 0);
                 trimInPlace(trimmedLattice);
@@ -1527,11 +1527,11 @@ protected:
         return l;
     }
 
-    void logTraceback(const Search::SearchAlgorithm::Traceback& traceback) {
+    void logTraceback(const Search::Traceback& traceback) {
         tracebackChannel_ << Core::XmlOpen("traceback") + Core::XmlAttribute("type", "xml");
-        u32                                  previousIndex = traceback.begin()->time;
-        Search::SearchAlgorithm::ScoreVector previousScore(0.0, 0.0);
-        for (std::vector<Search::SearchAlgorithm::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
+        u32                 previousIndex = traceback.begin()->time;
+        Search::ScoreVector previousScore(0.0, 0.0);
+        for (std::vector<Search::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
             if (tbi->pronunciation) {
                 tracebackChannel_ << Core::XmlOpen("item") + Core::XmlAttribute("type", "pronunciation")
                                   << Core::XmlFull("orth", tbi->pronunciation->lemma()->preferredOrthographicForm())

--- a/src/Flf/Recognizer.cc
+++ b/src/Flf/Recognizer.cc
@@ -65,7 +65,7 @@ private:
     SegmentwiseFeatureExtractorRef                  featureExtractor_;
     SegmentwiseModelAdaptorRef                      modelAdaptor_;
     Core::XmlChannel                                tracebackChannel_;
-    Search::SearchAlgorithm::Traceback              traceback_;
+    Search::Traceback                               traceback_;
     std::vector<Flow::Timestamp>                    featureTimes_;
 
     bool addPronunciationScores_;
@@ -88,14 +88,14 @@ private:
     DataSourceRef dataSource_;
 
 protected:
-    void addPartialToTraceback(Search::SearchAlgorithm::Traceback& partialTraceback) {
+    void addPartialToTraceback(Search::Traceback& partialTraceback) {
         if (!traceback_.empty() && traceback_.back().time == partialTraceback.front().time)
             partialTraceback.erase(partialTraceback.begin());
         traceback_.insert(traceback_.end(), partialTraceback.begin(), partialTraceback.end());
     }
 
     void processResult() {
-        Search::SearchAlgorithm::Traceback remainingTraceback;
+        Search::Traceback remainingTraceback;
         recognizer_->getCurrentBestSentence(remainingTraceback);
         addPartialToTraceback(remainingTraceback);
 
@@ -258,11 +258,11 @@ protected:
         return l;
     }
 
-    void logTraceback(const Search::SearchAlgorithm::Traceback& traceback) {
+    void logTraceback(const Search::Traceback& traceback) {
         tracebackChannel_ << Core::XmlOpen("traceback") + Core::XmlAttribute("type", "xml");
-        u32                                  previousIndex = traceback.begin()->time;
-        Search::SearchAlgorithm::ScoreVector previousScore(0.0, 0.0);
-        for (std::vector<Search::SearchAlgorithm::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
+        u32                 previousIndex = traceback.begin()->time;
+        Search::ScoreVector previousScore(0.0, 0.0);
+        for (std::vector<Search::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
             if (tbi->pronunciation) {
                 tracebackChannel_ << Core::XmlOpen("item") + Core::XmlAttribute("type", "pronunciation")
                                   << Core::XmlFull("orth", tbi->pronunciation->lemma()->preferredOrthographicForm())

--- a/src/Flf/Traceback.cc
+++ b/src/Flf/Traceback.cc
@@ -91,8 +91,8 @@ protected:
         if (l && (l->initialStateId() != Fsa::InvalidStateId)) {
             Core::Ref<const Bliss::LemmaPronunciationAlphabet> lpAlphabet =
                     Lexicon::us()->lemmaPronunciationAlphabet();
-            Search::SearchAlgorithm::Traceback traceback;
-            Lexicon::AlphabetId                alphabetId = Lexicon::us()->alphabetId(l->getInputAlphabet());
+            Search::Traceback   traceback;
+            Lexicon::AlphabetId alphabetId = Lexicon::us()->alphabetId(l->getInputAlphabet());
             if (alphabetId != Lexicon::LemmaPronunciationAlphabetId)
                 warning("DumpTracebackNode: Input alphabet of \"%s\" "
                         "is not lemma pronunciation; map alphabet",
@@ -118,11 +118,11 @@ protected:
                 }
                 traceback.clear();
                 traceback.push_back(
-                        Search::SearchAlgorithm::TracebackItem(
+                        Search::TracebackItem(
                                 0,
                                 0,
-                                Search::SearchAlgorithm::ScoreVector(0.0, 0),
-                                Search::SearchAlgorithm::TracebackItem::Transit()));
+                                Search::ScoreVector(0.0, 0),
+                                Search::TracebackItem::Transit()));
                 Score score = Semiring::One;
                 for (; sr->hasArcs(); sr = p->getState(sr->begin()->target())) {
                     verify(sr->nArcs() == 1);
@@ -139,22 +139,22 @@ protected:
                     if (lemmaPron) {
                         const Boundary& b = boundaries.get(a.target());
                         traceback.push_back(
-                                Search::SearchAlgorithm::TracebackItem(
+                                Search::TracebackItem(
                                         lemmaPron,
                                         b.time(),
-                                        Search::SearchAlgorithm::ScoreVector(score, 0),
-                                        Search::SearchAlgorithm::TracebackItem::Transit()));
+                                        Search::ScoreVector(score, 0),
+                                        Search::TracebackItem::Transit()));
                     }
                 }
                 verify(sr->isFinal());
                 score += sr->weight()->project(scales);
                 const Boundary& b = boundaries.get(sr->id());
                 traceback.push_back(
-                        Search::SearchAlgorithm::TracebackItem(
+                        Search::TracebackItem(
                                 0,
                                 b.time(),
-                                Search::SearchAlgorithm::ScoreVector(score, 0),
-                                Search::SearchAlgorithm::TracebackItem::Transit()));
+                                Search::ScoreVector(score, 0),
+                                Search::TracebackItem::Transit()));
                 Core::XmlOpen tracebackOpen("traceback");
                 tracebackOpen + Core::XmlAttribute("source", "recognized");
                 tracebackOpen + Core::XmlAttribute("n", i);

--- a/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.cc
+++ b/src/Search/AdvancedTreeSearch/AdvancedTreeSearch.cc
@@ -22,6 +22,7 @@
 #include <Lattice/Lattice.hh>
 #include <Lattice/LatticeAdaptor.hh>
 #include <Search/StateTree.hh>
+#include <Search/Traceback.hh>
 #include <vector>
 #include "SearchSpace.hh"
 #include "SearchSpaceStatistics.hh"
@@ -37,7 +38,7 @@ using Core::tie;
 // ===========================================================================
 // Bookkeeping
 
-void AdvancedTreeSearchManager::traceback(Ref<Trace> end, SearchAlgorithm::Traceback& result, Ref<Trace> boundary) const {
+void AdvancedTreeSearchManager::traceback(Ref<Trace> end, Traceback& result, Ref<Trace> boundary) const {
     result.clear();
     for (; end && end != boundary; end = end->predecessor) {
         result.push_back(*end);
@@ -228,7 +229,7 @@ void AdvancedTreeSearchManager::feed(const Mm::FeatureScorer::Scorer& emissionSc
     ss_->pruneAndAddScores();
 
     if (time_ % cleanupInterval_ == 0 || ss_->needCleanup()) {
-        //We have to rescale before activating the word ends
+        // We have to rescale before activating the word ends
         ss_->rescale(ss_->bestScore());
         ss_->cleanup();
     }
@@ -419,9 +420,9 @@ void AdvancedTreeSearchManager::mergeEpsilonTraces(Ref<Trace> trace) const {
                 if (preTrace->pronunciation == epsilonLemmaPronunciation()) {
                     // Share another correction
                     Correction                     correction(preTrace->predecessor.get(),
-                                          preTrace->time - preTrace->predecessor->time,
-                                          preTrace->score.acoustic - preTrace->predecessor->score.acoustic,
-                                          preTrace->transit);
+                                                              preTrace->time - preTrace->predecessor->time,
+                                                              preTrace->score.acoustic - preTrace->predecessor->score.acoustic,
+                                                              preTrace->transit);
                     CorrectionHash::const_iterator it = corrections.find(correction);
                     if (it != corrections.end()) {
                         preTrace = arcTrace->predecessor = it->second;
@@ -452,7 +453,7 @@ void AdvancedTreeSearchManager::getCurrentBestSentence(Traceback& result) const 
     traceback(t, result);
 }
 
-void AdvancedTreeSearchManager::getCurrentBestSentencePartial(SearchAlgorithm::Traceback& result) const {
+void AdvancedTreeSearchManager::getCurrentBestSentencePartial(Traceback& result) const {
     Ref<Trace> t = sentenceEnd();
     if (!t) {
         result.clear();

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -2160,13 +2160,13 @@ inline Core::Ref<Trace> SearchSpace::getModifiedTrace(TraceId traceId, const Bli
         bool encodeState = this->encodeState();
 
         verify(trace.get());
-        SearchAlgorithm::TracebackItem::Transit transit;
-        TraceManager::Modification              offsets = trace_manager_.getModification(traceId);
+        TracebackItem::Transit     transit;
+        TraceManager::Modification offsets = trace_manager_.getModification(traceId);
         if (offsets.first || offsets.second || offsets.third) {
             // Add an epsilon traceback entry which corrects the time, score and transit-entry
             TimeframeIndex time = trace->time + offsets.first;
             verify(time <= timeFrame_);
-            SearchAlgorithm::ScoreVector score = trace->score;
+            ScoreVector score = trace->score;
             if (offsets.second)
                 score.acoustic += reinterpret_cast<Search::Score&>(offsets.second);
 
@@ -2542,8 +2542,8 @@ void SearchSpace::addStartupWordEndHypothesis(TimeframeIndex time) {
     verify(rch.isValid());
     verify(lah.isValid());
     verify(sch.isValid());
-    SearchAlgorithm::ScoreVector score(0.0, 0.0);
-    Core::Ref<Trace>             t(new Trace(time, score, describeRootState(rootState)));
+    ScoreVector      score(0.0, 0.0);
+    Core::Ref<Trace> t(new Trace(time, score, describeRootState(rootState)));
     t->score.acoustic += globalScoreOffset_;
     wordEndHypotheses.push_back(WordEndHypothesis(rch, lah, sch, rootState, 0, score, t, Core::Type<u32>::max, PathTrace()));
 }
@@ -2679,8 +2679,8 @@ Core::Ref<Trace> SearchSpace::getSentenceEnd(TimeframeIndex time, bool shallCrea
                     else
                         ++activeUncoartic;
                 }
-                Score                        score = (*it).score + globalScoreOffset_;
-                SearchAlgorithm::ScoreVector scores(trace_manager_.traceItem((*it).trace).trace->score);
+                Score       score = (*it).score + globalScoreOffset_;
+                ScoreVector scores(trace_manager_.traceItem((*it).trace).trace->score);
                 scores.acoustic = score - scores.lm - at.totalBackOffOffset;
 
                 // Append score- and time correcting epsilon item
@@ -2688,7 +2688,7 @@ Core::Ref<Trace> SearchSpace::getSentenceEnd(TimeframeIndex time, bool shallCrea
                                              epsilonLemmaPronunciation(),
                                              time - 1,
                                              scores,
-                                             encodeState ? describeRootState(it->state) : SearchAlgorithm::TracebackItem::Transit()));
+                                             encodeState ? describeRootState(it->state) : TracebackItem::Transit()));
                 // Append sentence-end epsilon arc
                 t = Core::Ref<Trace>(new Trace(t, 0, time, t->score, describeRootState(net.rootState)));
 
@@ -2936,9 +2936,9 @@ public:
     u32 kept, killed;
 
 private:
-    std::map<Trace*, bool>       keepTraces_;
-    Core::Ref<Trace>             initialTrace_;
-    SearchAlgorithm::ScoreVector baseScore_;
+    std::map<Trace*, bool> keepTraces_;
+    Core::Ref<Trace>       initialTrace_;
+    ScoreVector            baseScore_;
 };
 
 void SearchSpace::changeInitialTrace(Core::Ref<Trace> trace) {
@@ -3621,7 +3621,7 @@ void SearchSpace::processOneWordEnd(Instance const& at, StateHypothesis const& h
     verify_(item.scoreHistory.isValid());
 
     EarlyWordEndHypothesis weh(hyp.trace,
-                               SearchAlgorithm::ScoreVector(hyp.score - item.trace->score.lm - at.totalBackOffOffset, item.trace->score.lm),
+                               ScoreVector(hyp.score - item.trace->score.lm - at.totalBackOffOffset, item.trace->score.lm),
                                exit,
                                hyp.pathTrace);
     weh.score.acoustic += exitPenalty;
@@ -3642,7 +3642,7 @@ void SearchSpace::processOneWordEnd(Instance const& at, StateHypothesis const& h
     if (onTheFlyRescoring) {
         Core::Ref<Trace> trace = item.trace;
         for (AlternativeHistory const& h : trace->alternativeHistories.container()) {
-            SearchAlgorithm::ScoreVector newScore = oldScore + h.offset;
+            ScoreVector newScore = oldScore + h.offset;
             if (we->pronunciation != Bliss::LemmaPronunciation::invalidId) {
                 Lm::addLemmaPronunciationScoreOmitExtension(lm_, lexicon_->lemmaPronunciation(we->pronunciation), wpScale_, lm_->scale(), h.hist, newScore.lm);
             }

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -22,6 +22,7 @@
 #include <Lm/BackingOff.hh>
 #include <Lm/Module.hh>
 #include <Mm/GaussDiagonalMaximumFeatureScorer.hh>
+#include <Search/Traceback.hh>
 
 #include "AcousticLookAhead.hh"
 #include "PersistentStateTree.hh"

--- a/src/Search/AdvancedTreeSearch/SearchSpace.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.hh
@@ -22,6 +22,7 @@
 #include <Search/Histogram.hh>
 #include <Search/Search.hh>
 #include <Search/StateTree.hh>
+#include <Search/Traceback.hh>
 
 #include "Helpers.hh"
 #include "LanguageModelLookahead.hh"

--- a/src/Search/AdvancedTreeSearch/SearchSpace.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.hh
@@ -22,7 +22,6 @@
 #include <Search/Histogram.hh>
 #include <Search/Search.hh>
 #include <Search/StateTree.hh>
-#include <Search/Traceback.hh>
 
 #include "Helpers.hh"
 #include "LanguageModelLookahead.hh"

--- a/src/Search/AdvancedTreeSearch/SearchSpaceHelpers.hh
+++ b/src/Search/AdvancedTreeSearch/SearchSpaceHelpers.hh
@@ -160,7 +160,7 @@ struct Instance {
     std::vector<StateHypothesis> rootStateHypotheses;
 
     /// Enter this tree with the given trace, entry-node and score
-    void enter(TraceManager &trace_manager, Core::Ref<Trace> trace, StateId entryNode, Score score);
+    void enter(TraceManager& trace_manager, Core::Ref<Trace> trace, StateId entryNode, Score score);
 
     /// Enter this tree with the given StateHypothesis whose trace can have longer histories than tree's
     void enterWithState(const StateHypothesis& st);
@@ -195,7 +195,7 @@ struct Instance {
     /// The tree this one is a back-off tree of
     Instance* backOffParent;
 
-    ///Total back-off offset of the scores within this tree, relative to all backoff parents combined.
+    /// Total back-off offset of the scores within this tree, relative to all backoff parents combined.
     Score totalBackOffOffset;
 
     /// LM-Cache caching the LM scores in the context of this tree for more efficient access
@@ -204,12 +204,12 @@ struct Instance {
 };
 
 struct EarlyWordEndHypothesis {
-    TraceId                      trace;
-    SearchAlgorithm::ScoreVector score;
-    u32                          exit;
-    PathTrace                    pathTrace;
+    TraceId     trace;
+    ScoreVector score;
+    u32         exit;
+    PathTrace   pathTrace;
 
-    EarlyWordEndHypothesis(TraceId _trace, const SearchAlgorithm::ScoreVector& _score, u32 _exit, PathTrace _pathTrace)
+    EarlyWordEndHypothesis(TraceId _trace, const ScoreVector& _score, u32 _exit, PathTrace _pathTrace)
             : trace(_trace), score(_score), exit(_exit), pathTrace(_pathTrace) {
     }
     EarlyWordEndHypothesis()
@@ -223,13 +223,13 @@ struct WordEndHypothesis {
     Lm::History                      scoreHistory;
     StateId                          transitState;
     const Bliss::LemmaPronunciation* pronunciation;
-    SearchAlgorithm::ScoreVector     score;
+    ScoreVector                      score;
     Core::Ref<Trace>                 trace;
-    u32                              endExit;  //Exit from which this word end hypothesis was constructed
+    u32                              endExit;  // Exit from which this word end hypothesis was constructed
     PathTrace                        pathTrace;
 
     WordEndHypothesis(const Lm::History& rch, const Lm::History& lah, const Lm::History& sch, StateId e,
-                      const Bliss::LemmaPronunciation* p, SearchAlgorithm::ScoreVector s,
+                      const Bliss::LemmaPronunciation* p, ScoreVector s,
                       const Core::Ref<Trace>& t, u32 _endExit, PathTrace _pathTrace)
             : recombinationHistory(rch),
               lookaheadHistory(lah),

--- a/src/Search/AdvancedTreeSearch/Trace.cc
+++ b/src/Search/AdvancedTreeSearch/Trace.cc
@@ -31,14 +31,14 @@ void Trace::write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory> phi
     os << std::endl;
 }
 
-Trace::Trace(SearchAlgorithm::TimeframeIndex t, SearchAlgorithm::ScoreVector s, const Search::SearchAlgorithm::TracebackItem::Transit& transit)
+Trace::Trace(SearchAlgorithm::TimeframeIndex t, ScoreVector s, const Search::TracebackItem::Transit& transit)
         : TracebackItem(0, t, s, transit) {}
 
-Trace::Trace(const Core::Ref<Trace>&                                pre,
-             const Bliss::LemmaPronunciation*                       p,
-             SearchAlgorithm::TimeframeIndex                        t,
-             SearchAlgorithm::ScoreVector                           s,
-             const Search::SearchAlgorithm::TracebackItem::Transit& transit)
+Trace::Trace(const Core::Ref<Trace>&               pre,
+             const Bliss::LemmaPronunciation*      p,
+             SearchAlgorithm::TimeframeIndex       t,
+             ScoreVector                           s,
+             const Search::TracebackItem::Transit& transit)
         : TracebackItem(p, t, s, transit), predecessor(pre), pruningMark(0) {}
 
 void Trace::getLemmaSequence(std::vector<Bliss::Lemma*>& lemmaSequence) const {

--- a/src/Search/AdvancedTreeSearch/Trace.hh
+++ b/src/Search/AdvancedTreeSearch/Trace.hh
@@ -18,15 +18,16 @@
 #include <Core/ReferenceCounting.hh>
 #include <Search/Search.hh>
 #include <Search/StateTree.hh>
+#include <Search/Traceback.hh>
 #include <Search/Types.hh>
 #include "PathTrace.hh"
 
 namespace Search {
 
 struct AlternativeHistory {
-    Lm::History                  hist;
-    SearchAlgorithm::ScoreVector offset;
-    Core::Ref<class Trace>       trace;
+    Lm::History            hist;
+    ScoreVector            offset;
+    Core::Ref<class Trace> trace;
 };
 
 struct AlternativeHistoryCompare {
@@ -49,7 +50,7 @@ public:
 using AlternativeHistoryQueue = AccessiblePriorityQueue<AlternativeHistory, std::vector<AlternativeHistory>, AlternativeHistoryCompare>;
 
 class Trace : public Core::ReferenceCounted,
-              public SearchAlgorithm::TracebackItem {
+              public TracebackItem {
 public:
     Core::Ref<Trace> predecessor;
     Core::Ref<Trace> sibling;
@@ -62,10 +63,10 @@ public:
     Trace(Core::Ref<Trace> const&          pre,
           Bliss::LemmaPronunciation const* p,
           TimeframeIndex                   t,
-          SearchAlgorithm::ScoreVector     s,
+          ScoreVector                      s,
           Transit const&                   transit);
 
-    Trace(TimeframeIndex t, SearchAlgorithm::ScoreVector s, const Transit& transit);
+    Trace(TimeframeIndex t, ScoreVector s, const Transit& transit);
 
     void write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory> phi) const;
 

--- a/src/Search/Makefile
+++ b/src/Search/Makefile
@@ -17,6 +17,7 @@ LIBSPRINTSEARCH_O	= \
 		$(OBJDIR)/Search.o \
 		$(OBJDIR)/StateTree.o \
 		$(OBJDIR)/StateTreeIo.o \
+		$(OBJDIR)/Traceback.o \
 		$(OBJDIR)/WordConditionedTreeSearch.o
 
 CHECK_O		= $(OBJDIR)/check.o \

--- a/src/Search/Search.cc
+++ b/src/Search/Search.cc
@@ -23,68 +23,10 @@ Speech::ModelCombination::Mode SearchAlgorithm::modelCombinationNeeded() const {
     return Speech::ModelCombination::complete;
 }
 
-void SearchAlgorithm::Traceback::write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory> phi) const {
-    for (const_iterator tbi = begin(); tbi != end(); ++tbi) {
-        os << "t=" << std::setw(5) << tbi->time << "    s=" << std::setw(8) << tbi->score;
-        if (tbi->pronunciation) {
-            os << "    "
-               << std::setw(20) << std::setiosflags(std::ios::left)
-               << tbi->pronunciation->lemma()->preferredOrthographicForm()
-               << "    "
-               << "/" << tbi->pronunciation->pronunciation()->format(phi) << "/";
-        }
-        os << "    "
-           << ((tbi->transit.final == Bliss::Phoneme::term) ? "#" : phi->phoneme(tbi->transit.final)->symbol().str())
-           << "|"
-           << ((tbi->transit.initial == Bliss::Phoneme::term) ? "#" : phi->phoneme(tbi->transit.initial)->symbol().str())
-           << std::endl;
-    }
+void SearchAlgorithm::getCurrentBestSentencePartial(Traceback& result) const {
 }
 
-Fsa::ConstAutomatonRef SearchAlgorithm::Traceback::lemmaAcceptor(Core::Ref<const Bliss::Lexicon> lexicon) const {
-    Bliss::LemmaAcceptor* result = new Bliss::LemmaAcceptor(lexicon);
-    Fsa::State *          s1, *s2;
-    s1 = result->newState();
-    result->setInitialStateId(s1->id());
-    for (u32 i = 0; i < size(); ++i)
-        if ((*this)[i].pronunciation) {
-            s2 = result->newState();
-            s1->newArc(s2->id(), result->semiring()->one(), (*this)[i].pronunciation->lemma()->id());
-            s1 = s2;
-        }
-    result->setStateFinal(s1);
-    return Fsa::ConstAutomatonRef(result);
-}
-
-Fsa::ConstAutomatonRef SearchAlgorithm::Traceback::lemmaPronunciationAcceptor(Core::Ref<const Bliss::Lexicon> lexicon) const {
-    Bliss::LemmaPronunciationAcceptor*       result = new Bliss::LemmaPronunciationAcceptor(lexicon);
-    const Bliss::LemmaPronunciationAlphabet* abet   = result->lemmaPronunciationAlphabet();
-    Fsa::State *                             s1, *s2;
-    s1 = result->newState();
-    result->setInitialStateId(s1->id());
-    for (u32 i = 0; i < size(); ++i) {
-        if (!(*this)[i].pronunciation)
-            continue;
-        s2 = result->newState();
-        s1->newArc(s2->id(), result->semiring()->one(), abet->index((*this)[i].pronunciation));
-        s1 = s2;
-    }
-    result->setStateFinal(s1);
-    return Fsa::ConstAutomatonRef(result);
-}
-
-Lattice::WordLatticeRef SearchAlgorithm::Traceback::wordLattice(Core::Ref<const Bliss::Lexicon> lexicon) const {
-    // NOTE: This function returns a word lattice with dummy word boundaries
-    Lattice::WordLatticeRef result(new Lattice::WordLattice());
-    result->setFsa(lemmaPronunciationAcceptor(lexicon), Lattice::WordLattice::acousticFsa);
-    result->setWordBoundaries(Core::ref(new Lattice::WordBoundaries));
-    return result;
-}
-
-void SearchAlgorithm::getCurrentBestSentencePartial(SearchAlgorithm::Traceback& result) const {
-}
-
-void SearchAlgorithm::getPartialSentence(SearchAlgorithm::Traceback&) {
+void SearchAlgorithm::getPartialSentence(Traceback&) {
 }
 
 SearchAlgorithm::PruningRef SearchAlgorithm::describePruning() {

--- a/src/Search/Search.hh
+++ b/src/Search/Search.hh
@@ -22,6 +22,7 @@
 #include <Lm/LanguageModel.hh>
 #include <Search/LatticeAdaptor.hh>
 #include <Speech/ModelCombination.hh>
+#include "Traceback.hh"
 #include "Types.hh"
 
 namespace Search {
@@ -37,51 +38,6 @@ public:
     typedef Speech::Score          Score;
     typedef Speech::TimeframeIndex TimeframeIndex;
 
-    struct ScoreVector {
-        Score acoustic, lm;
-        ScoreVector(Score a, Score l)
-                : acoustic(a), lm(l) {}
-        operator Score() const {
-            return acoustic + lm;
-        };
-        ScoreVector operator+(ScoreVector const& other) const {
-            return ScoreVector(acoustic + other.acoustic, lm + other.lm);
-        }
-        ScoreVector operator-(ScoreVector const& other) const {
-            return ScoreVector(acoustic - other.acoustic, lm - other.lm);
-        }
-        ScoreVector& operator+=(ScoreVector const& other) {
-            acoustic += other.acoustic;
-            lm += other.lm;
-            return *this;
-        }
-        ScoreVector& operator-=(ScoreVector const& other) {
-            acoustic -= other.acoustic;
-            lm -= other.lm;
-            return *this;
-        }
-    };
-    struct TracebackItem {
-    public:
-        typedef Lattice::WordBoundary::Transit Transit;
-
-    public:
-        const Bliss::LemmaPronunciation* pronunciation;
-        TimeframeIndex                   time;     // Ending time
-        ScoreVector                      score;    // Absolute score
-        Transit                          transit;  // Final transition description
-        TracebackItem(const Bliss::LemmaPronunciation* p, TimeframeIndex t, ScoreVector s, Transit te)
-                : pronunciation(p), time(t), score(s), transit(te) {}
-    };
-    class Traceback : public std::vector<TracebackItem> {
-    public:
-        void                    write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory>) const;
-        Fsa::ConstAutomatonRef  lemmaAcceptor(Core::Ref<const Bliss::Lexicon>) const;
-        Fsa::ConstAutomatonRef  lemmaPronunciationAcceptor(Core::Ref<const Bliss::Lexicon>) const;
-        Lattice::WordLatticeRef wordLattice(Core::Ref<const Bliss::Lexicon>) const;
-    };
-
-public:
     SearchAlgorithm(const Core::Configuration&);
     virtual ~SearchAlgorithm() {}
 

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -1,0 +1,163 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef SEARCH_V2_HH
+#define SEARCH_V2_HH
+
+#include <Am/AcousticModel.hh>
+#include <Bliss/CorpusDescription.hh>
+#include <Bliss/Lexicon.hh>
+#include <Nn/LabelScorer/LabelScorer.hh>
+#include <Nn/Types.hh>
+#include <Search/LatticeAdaptor.hh>
+#include <Search/Types.hh>
+#include <Speech/Feature.hh>
+#include <Speech/ModelCombination.hh>
+#include <Speech/Types.hh>
+
+namespace Search {
+
+/*
+ * Abstract base class for search algorithms that can work in an online or offline manner.
+ * In contrast to the previous `SearchAlgorithm` this receives features instead of `Mm::FeatureScorers`
+ * and the algorithm is supposed to perform scoring internally (usually with a `Nn::LabelScorer`).
+ *
+ * The "workflow" usually happens as follows:
+ *  1. Check which `Speech::ModelCombination` (and possibly `Am::AcousticModel`) are needed by the search algorithm via
+ *     `requiredModelCombination` (and `requiredAcousticModel`).
+ *  2. Create appropriate `Speech::ModelCombination` and provide it to the search algorithm via `setModelCombination`.
+ *  3. Signal segment start via `enterSegment`.
+ *  4. Add audio features via `addFeature` or `addFeatures`.
+ *  (5. Call `decodeStep` or `decodeMore` to run the next search step(s) given the currently available features.)
+ *  (6. Optionally retreive intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
+ *  7. Call `finishSegment` to signal that all features have been passed and the search doesn't need to wait for more.
+ *  8. Call `decodeMore` to finalize the search with all the segment features.
+ *  9. Retreive the final result via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
+ *  (10. Optionally log search statistics via `logStatistics`).
+ *  11. Call `reset` to clean up any buffered features, hypotheses, flags etc. from the previous segment and prepare the algorithm for the next one.
+ *  (12. Optionally also reset search statistics via `resetStatistics`).
+ *  13. Continue again at step 3.
+ */
+class SearchAlgorithmV2 : public virtual Core::Component {
+public:
+    // Struct to keep track of a collection of scores
+    struct ScoreVector {
+        Score acoustic, lm;
+
+        ScoreVector(Score am, Score lm)
+                : acoustic(am), lm(lm) {}
+        operator Score() const {
+            return acoustic + lm;
+        };
+        ScoreVector operator+(ScoreVector const& other) const {
+            return ScoreVector(acoustic + other.acoustic, lm + other.lm);
+        }
+        ScoreVector operator-(ScoreVector const& other) const {
+            return ScoreVector(acoustic - other.acoustic, lm - other.lm);
+        }
+        ScoreVector& operator+=(ScoreVector const& other) {
+            acoustic += other.acoustic;
+            lm += other.lm;
+            return *this;
+        }
+        ScoreVector& operator-=(ScoreVector const& other) {
+            acoustic -= other.acoustic;
+            lm -= other.lm;
+            return *this;
+        }
+    };
+
+    // Struct to store data for a single traceback entry
+    struct TracebackItem {
+    public:
+        const Bliss::LemmaPronunciation* pronunciation;  // pronunciation for lattice creation
+        const Bliss::Lemma*              lemma;          // possible no pronunciation
+        Speech::TimeframeIndex           time;           // TODO: Proper word boundaries with Flow::Timestamp instead of indices
+        ScoreVector                      scores;         // Absolute score
+        // TracebackItem(const Bliss::LemmaPronunciation* p, const Bliss::Lemma* l, Flow::Timestamp t, ScoreVector s)
+        TracebackItem(const Bliss::LemmaPronunciation* p, const Bliss::Lemma* l, Speech::TimeframeIndex t, ScoreVector s)
+                : pronunciation(p), lemma(l), time(t), scores(s) {}
+    };
+
+    // List of TracebackItems representing a full traceback path
+    class Traceback : public std::vector<TracebackItem>, public Core::ReferenceCounted {
+    public:
+        void                    write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory>) const;
+        Fsa::ConstAutomatonRef  lemmaAcceptor(Core::Ref<const Bliss::Lexicon>) const;
+        Fsa::ConstAutomatonRef  lemmaPronunciationAcceptor(Core::Ref<const Bliss::Lexicon>) const;
+        Lattice::WordLatticeRef wordLattice(Core::Ref<const Bliss::Lexicon>) const;
+    };
+
+    SearchAlgorithmV2(Core::Configuration const&)
+            : Core::Component(config) {}
+    virtual ~SearchAlgorithmV2() = default;
+
+    // Check which parts of the `Speech::ModelCombination` are required for the search and need to be set via `setModelCombination`
+    virtual Speech::ModelCombination::Mode requiredModelCombination() const = 0;
+
+    // Check which parts of the `Am::AcousticModel` are required for the search (only in the case that an `AcousticModel` is needed in the ModelCombination).
+    virtual Am::AcousticModel::Mode requiredAcousticModel() const {
+        return Am::AcousticModel::noEmissions | Am::AcousticModel::noStateTying | Am::AcousticModel::noStateTransition;
+    }
+
+    // Pass a `Speech::ModelCombination` that matches the requirements set by `requiredModelCombination` (and `requiredAcousticModel`) to the search.
+    virtual bool setModelCombination(Speech::ModelCombination const& modelCombination) = 0;
+
+    // Cleans up buffers, hypotheses, flags etc. from the previous segment recognition.
+    virtual void reset() = 0;
+
+    // Signal the beginning of a new audio segment.
+    virtual void enterSegment()                            = 0;
+    virtual void enterSegment(Bliss::SpeechSegment const*) = 0;
+
+    // Signal that all features of the current segment have been passed.
+    virtual void finishSegment() = 0;
+
+    // Pass a single feature vector.
+    virtual void addFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) = 0;
+    virtual void addFeature(std::vector<f32> const& data)                                 = 0;
+
+    // Pass feature vectors for multiple time steps.
+    virtual void addFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
+
+    // Return the current best traceback. May contain unstable results.
+    virtual Core::Ref<const Traceback> getCurrentBestTraceback() const = 0;
+
+    // Similar to `getCurrentBestTraceback` but return the lattice instead of just single-best traceback.
+    virtual Core::Ref<const LatticeAdaptor> getCurrentBestWordLattice() const = 0;
+
+    // Log all statistics tracked by the search algorithm (e.g. score-timing, average hypothesis counts etc.).
+    virtual void logStatistics() const = 0;
+
+    // Reset all statistics tracked by the search algorithm.
+    virtual void resetStatistics() = 0;
+
+    // Try to decode one more step. Return bool indicates whether a step could be made.
+    virtual bool decodeStep() = 0;
+
+    // Decode as much as possible given the currently available features. Return bool indicates whether any steps could be made.
+    virtual bool decodeMore() {
+        bool success = false;
+        while (decodeStep()) {
+            // Set to true if at least one iteration is successful
+            success = true;
+        }
+
+        return success;
+    }
+};
+
+}  // namespace Search
+
+#endif  // SEARCH_V2_HH

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -93,15 +93,14 @@ public:
     // Try to decode one more step. Return bool indicates whether a step could be made.
     virtual bool decodeStep() = 0;
 
-    // Decode as much as possible given the currently available features. Return bool indicates whether any steps could be made.
-    virtual bool decodeManySteps() {
-        bool success = false;
+    // Decode as much as possible given the currently available features. Return number of successfull steps.
+    virtual unsigned decodeManySteps() {
+        unsigned count = 0u;
         while (decodeStep()) {
-            // Set to true if at least one iteration is successful
-            success = true;
+            count++;
         }
 
-        return success;
+        return count;
     }
 };
 

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -81,13 +81,12 @@ public:
     // Struct to store data for a single traceback entry
     struct TracebackItem {
     public:
-        const Bliss::LemmaPronunciation* pronunciation;  // pronunciation for lattice creation
-        const Bliss::Lemma*              lemma;          // possible no pronunciation
-        Speech::TimeframeIndex           time;           // TODO: Proper word boundaries with Flow::Timestamp instead of indices
+        const Bliss::Lemma*              lemma;          // Corresponding lexicon lemma
+        const Bliss::LemmaPronunciation* pronunciation;  // Pronunciation of lexicon lemma for lattice creation
+        Speech::TimeframeIndex           time;           // Ending timeframe
         ScoreVector                      scores;         // Absolute score
-        // TracebackItem(const Bliss::LemmaPronunciation* p, const Bliss::Lemma* l, Flow::Timestamp t, ScoreVector s)
-        TracebackItem(const Bliss::LemmaPronunciation* p, const Bliss::Lemma* l, Speech::TimeframeIndex t, ScoreVector s)
-                : pronunciation(p), lemma(l), time(t), scores(s) {}
+        TracebackItem(const Bliss::Lemma* l, const Bliss::LemmaPronunciation* p, Speech::TimeframeIndex t, ScoreVector s)
+                : lemma(l), pronunciation(p), time(t), scores(s) {}
     };
 
     // List of TracebackItems representing a full traceback path

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -38,7 +38,7 @@ namespace Search {
  *     `requiredModelCombination` (and `requiredAcousticModel`).
  *  2. Create appropriate `Speech::ModelCombination` and provide it to the search algorithm via `setModelCombination`.
  *  3. Signal segment start via `enterSegment`.
- *  4. Add audio features via `addFeature` or `addFeatures`.
+ *  4. Pass audio features via `passFeature` or `passFeatures`.
  *  (5. Call `decodeStep` or `decodeMore` to run the next search step(s) given the currently available features.)
  *  (6. Optionally retreive intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
  *  7. Call `finishSegment` to signal that all features have been passed and the search doesn't need to wait for more.
@@ -125,11 +125,11 @@ public:
     virtual void finishSegment() = 0;
 
     // Pass a single feature vector.
-    virtual void addFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) = 0;
-    virtual void addFeature(std::vector<f32> const& data)                                 = 0;
+    virtual void passFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) = 0;
+    virtual void passFeature(std::vector<f32> const& data)                                 = 0;
 
     // Pass feature vectors for multiple time steps.
-    virtual void addFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
+    virtual void passFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
 
     // Return the current best traceback. May contain unstable results.
     virtual Core::Ref<const Traceback> getCurrentBestTraceback() const = 0;

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -40,10 +40,10 @@ namespace Search {
  *  3. Signal segment start via `enterSegment`.
  *  4. Pass audio features via `passFeature` or `passFeatures`.
  *  (5. Call `decodeStep` or `decodeMore` to run the next search step(s) given the currently available features.)
- *  (6. Optionally retreive intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
+ *  (6. Optionally retrieve intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
  *  7. Call `finishSegment` to signal that all features have been passed and the search doesn't need to wait for more.
  *  8. Call `decodeMore` to finalize the search with all the segment features.
- *  9. Retreive the final result via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
+ *  9. Retrieve the final result via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
  *  (10. Optionally log search statistics via `logStatistics`).
  *  11. Call `reset` to clean up any buffered features, hypotheses, flags etc. from the previous segment and prepare the algorithm for the next one.
  *  (12. Optionally also reset search statistics via `resetStatistics`).

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -78,8 +78,8 @@ public:
     virtual void finishSegment() = 0;
 
     // Pass a single feature vector.
-    virtual void passFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) = 0;
-    virtual void passFeature(std::vector<f32> const& data)                                 = 0;
+    virtual void putFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) = 0;
+    virtual void putFeature(std::vector<f32> const& data)                                 = 0;
 
     // Pass feature vectors for multiple time steps.
     virtual void passFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
@@ -94,7 +94,7 @@ public:
     virtual bool decodeStep() = 0;
 
     // Decode as much as possible given the currently available features. Return bool indicates whether any steps could be made.
-    virtual bool decodeMore() {
+    virtual bool decodeManySteps() {
         bool success = false;
         while (decodeStep()) {
             // Set to true if at least one iteration is successful

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -40,8 +40,8 @@ namespace Search {
  *     `requiredModelCombination` (and `requiredAcousticModel`).
  *  2. Create appropriate `Speech::ModelCombination` and provide it to the search algorithm via `setModelCombination`.
  *  3. Signal segment start via `enterSegment`.
- *  4. Pass audio features via `passFeature` or `passFeatures`.
- *  (5. Call `decodeStep` or `decodeMore` to run the next search step(s) given the currently available features.)
+ *  4. Pass audio features via `putFeature` or `putFeatures`.
+ *  (5. Call `decodeStep` or `decodeManySteps` to run the next search step(s) given the currently available features.)
  *  (6. Optionally retrieve intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
  *  7. Call `finishSegment` to signal that all features have been passed and the search doesn't need to wait for more.
  *  8. Call `decodeMore` to finalize the search with all the segment features.
@@ -82,7 +82,7 @@ public:
     virtual void putFeature(std::vector<f32> const& data)                                 = 0;
 
     // Pass feature vectors for multiple time steps.
-    virtual void passFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
+    virtual void putFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) = 0;
 
     // Return the current best traceback. May contain unstable results.
     virtual Core::Ref<const Traceback> getCurrentBestTraceback() const = 0;

--- a/src/Search/Traceback.cc
+++ b/src/Search/Traceback.cc
@@ -1,0 +1,77 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "Traceback.hh"
+
+namespace Search {
+
+void Traceback::write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory> phi) const {
+    for (const_iterator tbi = begin(); tbi != end(); ++tbi) {
+        os << "t=" << std::setw(5) << tbi->time << "    s=" << std::setw(8) << tbi->score;
+        if (tbi->pronunciation) {
+            os << "    "
+               << std::setw(20) << std::setiosflags(std::ios::left)
+               << tbi->pronunciation->lemma()->preferredOrthographicForm()
+               << "    "
+               << "/" << tbi->pronunciation->pronunciation()->format(phi) << "/";
+        }
+        os << "    "
+           << ((tbi->transit.final == Bliss::Phoneme::term) ? "#" : phi->phoneme(tbi->transit.final)->symbol().str())
+           << "|"
+           << ((tbi->transit.initial == Bliss::Phoneme::term) ? "#" : phi->phoneme(tbi->transit.initial)->symbol().str())
+           << std::endl;
+    }
+}
+
+Fsa::ConstAutomatonRef Traceback::lemmaAcceptor(Core::Ref<const Bliss::Lexicon> lexicon) const {
+    Bliss::LemmaAcceptor* result = new Bliss::LemmaAcceptor(lexicon);
+    Fsa::State *          s1, *s2;
+    s1 = result->newState();
+    result->setInitialStateId(s1->id());
+    for (u32 i = 0; i < size(); ++i)
+        if ((*this)[i].pronunciation) {
+            s2 = result->newState();
+            s1->newArc(s2->id(), result->semiring()->one(), (*this)[i].pronunciation->lemma()->id());
+            s1 = s2;
+        }
+    result->setStateFinal(s1);
+    return Fsa::ConstAutomatonRef(result);
+}
+
+Fsa::ConstAutomatonRef Traceback::lemmaPronunciationAcceptor(Core::Ref<const Bliss::Lexicon> lexicon) const {
+    Bliss::LemmaPronunciationAcceptor*       result = new Bliss::LemmaPronunciationAcceptor(lexicon);
+    const Bliss::LemmaPronunciationAlphabet* abet   = result->lemmaPronunciationAlphabet();
+    Fsa::State *                             s1, *s2;
+    s1 = result->newState();
+    result->setInitialStateId(s1->id());
+    for (u32 i = 0; i < size(); ++i) {
+        if (!(*this)[i].pronunciation)
+            continue;
+        s2 = result->newState();
+        s1->newArc(s2->id(), result->semiring()->one(), abet->index((*this)[i].pronunciation));
+        s1 = s2;
+    }
+    result->setStateFinal(s1);
+    return Fsa::ConstAutomatonRef(result);
+}
+
+Lattice::WordLatticeRef Traceback::wordLattice(Core::Ref<const Bliss::Lexicon> lexicon) const {
+    // NOTE: This function returns a word lattice with dummy word boundaries
+    Lattice::WordLatticeRef result(new Lattice::WordLattice());
+    result->setFsa(lemmaPronunciationAcceptor(lexicon), Lattice::WordLattice::acousticFsa);
+    result->setWordBoundaries(Core::ref(new Lattice::WordBoundaries));
+    return result;
+}
+}  // namespace Search

--- a/src/Search/Traceback.hh
+++ b/src/Search/Traceback.hh
@@ -1,0 +1,73 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef TRACEBACK_HH
+#define TRACEBACK_HH
+
+#include <Bliss/Lexicon.hh>
+#include <Lattice/Lattice.hh>
+#include <Search/LatticeAdaptor.hh>
+#include <Speech/Types.hh>
+
+namespace Search {
+
+struct ScoreVector {
+    Speech::Score acoustic, lm;
+    ScoreVector(Speech::Score a, Speech::Score l)
+            : acoustic(a), lm(l) {}
+    operator Speech::Score() const {
+        return acoustic + lm;
+    };
+    ScoreVector operator+(ScoreVector const& other) const {
+        return ScoreVector(acoustic + other.acoustic, lm + other.lm);
+    }
+    ScoreVector operator-(ScoreVector const& other) const {
+        return ScoreVector(acoustic - other.acoustic, lm - other.lm);
+    }
+    ScoreVector& operator+=(ScoreVector const& other) {
+        acoustic += other.acoustic;
+        lm += other.lm;
+        return *this;
+    }
+    ScoreVector& operator-=(ScoreVector const& other) {
+        acoustic -= other.acoustic;
+        lm -= other.lm;
+        return *this;
+    }
+};
+
+struct TracebackItem {
+public:
+    typedef Lattice::WordBoundary::Transit Transit;
+
+public:
+    const Bliss::LemmaPronunciation* pronunciation;  // Pronunciation of lexicon lemma for lattice creation
+    Speech::TimeframeIndex           time;           // Ending time
+    ScoreVector                      score;          // Absolute score
+    Transit                          transit;        // Final transition description
+    TracebackItem(const Bliss::LemmaPronunciation* p, Speech::TimeframeIndex t, ScoreVector s, Transit te)
+            : pronunciation(p), time(t), score(s), transit(te) {}
+};
+
+class Traceback : public std::vector<TracebackItem> {
+public:
+    void                    write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory>) const;
+    Fsa::ConstAutomatonRef  lemmaAcceptor(Core::Ref<const Bliss::Lexicon>) const;
+    Fsa::ConstAutomatonRef  lemmaPronunciationAcceptor(Core::Ref<const Bliss::Lexicon>) const;
+    Lattice::WordLatticeRef wordLattice(Core::Ref<const Bliss::Lexicon>) const;
+};
+
+}  // namespace Search
+
+#endif  // TRACEBACK_HH

--- a/src/Search/Wfst/Traceback.cc
+++ b/src/Search/Wfst/Traceback.cc
@@ -14,6 +14,7 @@
  */
 #include <OpenFst/LabelMap.hh>
 #include <OpenFst/SymbolTable.hh>
+#include <Search/Traceback.hh>
 #include <Search/Wfst/Traceback.hh>
 
 using namespace Search::Wfst;
@@ -21,9 +22,6 @@ using OpenFst::Epsilon;
 
 void BestPath::getTraceback(Bliss::LexiconRef lexicon, OutputType outputType,
                             const OpenFst::LabelMap* olabelMap, Traceback* result) const {
-    typedef SearchAlgorithm::TracebackItem TracebackItem;
-    typedef SearchAlgorithm::ScoreVector   ScoreVector;
-
     result->clear();
     result->push_back(TracebackItem(0, 0, ScoreVector(0, 0), TracebackItem::Transit()));
     Core::Ref<const Bliss::LemmaPronunciationAlphabet> alphabet = lexicon->lemmaPronunciationAlphabet();

--- a/src/Search/Wfst/Traceback.hh
+++ b/src/Search/Wfst/Traceback.hh
@@ -17,6 +17,7 @@
 
 #include <OpenFst/Types.hh>
 #include <Search/Search.hh>
+#include <Search/Traceback.hh>
 #include <Search/Types.hh>
 #include <Search/Wfst/ExpandingFsaSearch.hh>
 
@@ -27,11 +28,9 @@ class WordEndDetector;
 
 class BestPath {
 protected:
-    typedef OpenFst::Label             Label;
-    typedef SearchAlgorithm::Traceback Traceback;
+    typedef OpenFst::Label Label;
 
 public:
-    typedef SearchAlgorithm::ScoreVector ScoreVector;
     struct Item {
         Label          word;
         TimeframeIndex time;

--- a/src/Speech/Recognizer.cc
+++ b/src/Speech/Recognizer.cc
@@ -306,9 +306,9 @@ void OfflineRecognizer::setFeatureDescription(const Mm::FeatureDescription& desc
 
 void OfflineRecognizer::logTraceback(const Recognizer::Traceback& traceback) {
     tracebackChannel_ << Core::XmlOpen("traceback") + Core::XmlAttribute("type", "xml");
-    u32                                  previousIndex = traceback.begin()->time;
-    Search::SearchAlgorithm::ScoreVector previousScore(0.0, 0.0);
-    for (std::vector<Search::SearchAlgorithm::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
+    u32                 previousIndex = traceback.begin()->time;
+    Search::ScoreVector previousScore(0.0, 0.0);
+    for (std::vector<Search::TracebackItem>::const_iterator tbi = traceback.begin(); tbi != traceback.end(); ++tbi) {
         if (tbi->pronunciation) {
             tracebackChannel_ << Core::XmlOpen("item") + Core::XmlAttribute("type", "pronunciation")
                               << Core::XmlFull("orth", tbi->pronunciation->lemma()->preferredOrthographicForm())

--- a/src/Speech/Recognizer.hh
+++ b/src/Speech/Recognizer.hh
@@ -45,10 +45,10 @@ public:
     static const Core::ParameterChoice paramSearch;
 
 protected:
-    typedef Search::SearchAlgorithm::Traceback Traceback;
-    Core::Ref<const Bliss::Lexicon>            lexicon_;
-    Core::Ref<Am::AcousticModel>               acousticModel_;
-    Search::SearchAlgorithm*                   recognizer_;
+    typedef Search::Traceback       Traceback;
+    Core::Ref<const Bliss::Lexicon> lexicon_;
+    Core::Ref<Am::AcousticModel>    acousticModel_;
+    Search::SearchAlgorithm*        recognizer_;
 
 protected:
     void         initializeRecognizer(Am::AcousticModel::Mode acousticModelMode);


### PR DESCRIPTION
Abstract base class for search algorithms that can work in an online or offline manner.
In contrast to the previous `SearchAlgorithm` this receives features instead of `Mm::FeatureScorers` and the algorithm is supposed to perform scoring internally (usually with a `Nn::LabelScorer`).

The "workflow" usually happens as follows:
 1. Check which `Speech::ModelCombination` (and possibly `Am::AcousticModel`) are needed by the search algorithm via `requiredModelCombination` (and `requiredAcousticModel`).
 2. Create appropriate `Speech::ModelCombination` and provide it to the search algorithm via `setModelCombination`.
 3. Signal segment start via `enterSegment`.
 4. Pass audio features via `passFeature` or `passFeatures`.
 5. Optionally call `decodeStep` or `decodeMore` to run the next search step(s) given the currently available features.
 6. Optionally retrieve intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
 7. Call `finishSegment` to signal that all features have been passed and the search doesn't need to wait for more.
 8. Call `decodeMore` to finalize the search with all the segment features.
 9. Retrieve the final result via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
 10. Optionally log search statistics via `logStatistics`.
 11. Call `reset` to clean up any buffered features, hypotheses, flags etc. from the previous segment and prepare the algorithm for the next one.
 12. Optionally also reset search statistics via `resetStatistics`.
 13. Continue again at step 3.

Note that the `ScoreVector`, `TracebackItem` and `Traceback` are pretty much copy pasted from old code. Do we want to change anything about them?