### PR TITLE
Implement No-Op LabelScorer

### DIFF
--- a/src/Nn/LabelScorer/Makefile
+++ b/src/Nn/LabelScorer/Makefile
@@ -14,6 +14,7 @@ LIBSPRINTLABELSCORER_O =  \
     $(OBJDIR)/Encoder.o \
     $(OBJDIR)/LabelScorer.o \
     $(OBJDIR)/LabelScorerFactory.o \
+    $(OBJDIR)/NoOpLabelScorer.o \
     $(OBJDIR)/ScoringContext.o
 
 # -----------------------------------------------------------------------------

--- a/src/Nn/LabelScorer/NoOpLabelScorer.cc
+++ b/src/Nn/LabelScorer/NoOpLabelScorer.cc
@@ -1,0 +1,45 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "NoOpLabelScorer.hh"
+#include "ScoringContext.hh"
+
+namespace Nn {
+
+StepwiseNoOpLabelScorer::StepwiseNoOpLabelScorer(Core::Configuration const& config)
+        : Core::Component(config), Precursor(config) {}
+
+ScoringContextRef StepwiseNoOpLabelScorer::getInitialScoringContext() {
+    return Core::ref(new StepScoringContext());
+}
+
+ScoringContextRef StepwiseNoOpLabelScorer::extendedScoringContext(LabelScorer::Request const& request) {
+    StepScoringContextRef stepHistory(dynamic_cast<const StepScoringContext*>(request.context.get()));
+    return Core::ref(new StepScoringContext(stepHistory->currentStep + 1));
+}
+
+std::optional<LabelScorer::ScoreWithTime> StepwiseNoOpLabelScorer::computeScoreWithTime(LabelScorer::Request const& request) {
+    StepScoringContextRef stepHistory(dynamic_cast<const StepScoringContext*>(request.context.get()));
+    if (inputBuffer_.size() <= stepHistory->currentStep) {
+        return {};
+    }
+    if (request.nextToken >= featureSize_) {
+        error() << "Tried to get score for token " << request.nextToken << " but only have " << featureSize_ << " scores available.";
+    }
+
+    return ScoreWithTime{inputBuffer_.at(stepHistory->currentStep)[request.nextToken], stepHistory->currentStep};
+}
+
+}  // namespace Nn

--- a/src/Nn/LabelScorer/NoOpLabelScorer.hh
+++ b/src/Nn/LabelScorer/NoOpLabelScorer.hh
@@ -23,6 +23,9 @@ namespace Nn {
 /*
  * Label Scorer that performs no computation internally. It assumes that the input features are already
  * finished score vectors and just returns the score at the current time step.
+ *
+ * This is useful for example when the scores are computed externally and transmitted via a pybind interface
+ * or when they are computed inside a flow node.
  */
 class StepwiseNoOpLabelScorer : public BufferedLabelScorer {
     using Precursor = BufferedLabelScorer;

--- a/src/Nn/LabelScorer/NoOpLabelScorer.hh
+++ b/src/Nn/LabelScorer/NoOpLabelScorer.hh
@@ -1,0 +1,45 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef NO_OP_LABEL_SCORER_HH
+#define NO_OP_LABEL_SCORER_HH
+
+#include "BufferedLabelScorer.hh"
+
+namespace Nn {
+
+/*
+ * Label Scorer that performs no computation internally. It assumes that the input features are already
+ * finished score vectors and just returns the score at the current time step.
+ */
+class StepwiseNoOpLabelScorer : public BufferedLabelScorer {
+    using Precursor = BufferedLabelScorer;
+
+public:
+    StepwiseNoOpLabelScorer(const Core::Configuration& config);
+
+    // Initial scoring context just contains step 0.
+    ScoringContextRef getInitialScoringContext() override;
+
+    // Scoring context with step incremented by 1.
+    virtual ScoringContextRef extendedScoringContext(LabelScorer::Request const& request) override;
+
+    // Gets the buffered score for the requested token at the requested step
+    std::optional<LabelScorer::ScoreWithTime> computeScoreWithTime(LabelScorer::Request const& request) override;
+};
+
+}  // namespace Nn
+
+#endif  // NO_OP_LABEL_SCORER_HH

--- a/src/Nn/LabelScorer/ScoringContext.cc
+++ b/src/Nn/LabelScorer/ScoringContext.cc
@@ -31,4 +31,17 @@ bool ScoringContext::isEqual(ScoringContextRef const& other) const {
     return true;
 }
 
+/*
+ * =============================
+ * === StepScoringContext ======
+ * =============================
+ */
+size_t StepScoringContext::hash() const {
+    return currentStep;
+}
+
+bool StepScoringContext::isEqual(ScoringContextRef const& other) const {
+    return currentStep == dynamic_cast<const StepScoringContext*>(other.get())->currentStep;
+}
+
 }  // namespace Nn

--- a/src/Nn/LabelScorer/ScoringContext.hh
+++ b/src/Nn/LabelScorer/ScoringContext.hh
@@ -47,6 +47,23 @@ struct ScoringContextEq {
     }
 };
 
+/*
+ * Scoring context that only describes the current decoding step
+ */
+struct StepScoringContext : public ScoringContext {
+    size_t currentStep;
+
+    StepScoringContext()
+            : currentStep(0ul) {}
+
+    StepScoringContext(size_t step)
+            : currentStep(step) {}
+
+    bool   isEqual(ScoringContextRef const& other) const;
+    size_t hash() const;
+};
+
+typedef Core::Ref<const StepScoringContext> StepScoringContextRef;
 }  // namespace Nn
 
 #endif  // SCORING_CONTEXT_HH

--- a/src/Nn/Module.cc
+++ b/src/Nn/Module.cc
@@ -17,6 +17,7 @@
 
 #include <Modules.hh>
 #include "LabelScorer/LabelScorerFactory.hh"
+#include "LabelScorer/NoOpLabelScorer.hh"
 #include "Module.hh"
 #include "Statistics.hh"
 
@@ -73,6 +74,13 @@ Module_::Module_()
     Mm::Module::instance().featureScorerFactory()->registerFeatureScorer<PythonFeatureScorer, Mm::MixtureSet, Mm::AbstractMixtureSetLoader>(
             pythonFeatureScorer, "python-feature-scorer");
 #endif
+
+    // Assume inputs are already finished scores and just passes on the score at the current step
+    labelScorerFactory_.registerLabelScorer(
+            "no-op",
+            [](Core::Configuration const& config) {
+                return Core::ref(new StepwiseNoOpLabelScorer(config));
+            });
 };
 
 Module_::~Module_() {


### PR DESCRIPTION
Add `StepwiseNoOpLabelScorer` which is a LabelScorer that performs no computation internally. It assumes that the input features are already finished score vectors and just returns the score at the current time step.

This is useful for example when the scores are computed externally and transmitted via a pybind interface or when they are computed inside a flow node.