### PR TITLE
Add TransducerTreeBuilder

### DIFF
--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -136,6 +136,7 @@ const Core::Choice choiceTreeBuilderType(
         "classic-hmm", static_cast<int>(TreeBuilderType::classicHmm),
         "minimized-hmm", static_cast<int>(TreeBuilderType::minimizedHmm),
         "ctc", static_cast<int>(TreeBuilderType::ctc),
+        "transducer", static_cast<int>(TreeBuilderType::transducer),
         Core::Choice::endMark());
 
 const Core::ParameterChoice paramTreeBuilderType(


### PR DESCRIPTION
This PR introduces a `TransducerTreeBuilder` for constructing a search tree with Transducer topology, similar to #93.
Since it shares most of its logic, I made it a subclass of `CtcTreeBuilder`. The only difference is the absence of self-loops on the (non-blank) labels.
Depends on #98.