### PR TITLE
Lexiconfree beam search

### DIFF
--- a/Modules.make
+++ b/Modules.make
@@ -148,6 +148,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/apptainer/2022-10-21_tensorflow-1.15_arm_v1/makefiles/Modules.make
+++ b/apptainer/2022-10-21_tensorflow-1.15_arm_v1/makefiles/Modules.make
@@ -143,6 +143,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/apptainer/2022-10-21_tensorflow-1.15_v1/makefiles/Modules.make
+++ b/apptainer/2022-10-21_tensorflow-1.15_v1/makefiles/Modules.make
@@ -143,6 +143,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/apptainer/2023-05-08_tensorflow-2.8_v1/makefiles/Modules.make
+++ b/apptainer/2023-05-08_tensorflow-2.8_v1/makefiles/Modules.make
@@ -143,6 +143,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/apptainer/2023-08-09_tensorflow-2.8_onnx-1.15_v1/makefiles/Modules.make
+++ b/apptainer/2023-08-09_tensorflow-2.8_onnx-1.15_v1/makefiles/Modules.make
@@ -147,6 +147,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/apptainer/2023-11-08_tensorflow-2.14_v1/makefiles/Modules.make
+++ b/apptainer/2023-11-08_tensorflow-2.14_v1/makefiles/Modules.make
@@ -148,6 +148,7 @@ endif
 
 # ****** Libraries ******
 LIBS_SEARCH = src/Search/libSprintSearch.$(a)
+LIBS_SEARCH += src/Search/LexiconfreeTimesyncBeamSearch/libSprintLexiconfreeTimesyncBeamSearch.$(a)
 ifdef MODULE_SEARCH_WFST
 LIBS_SEARCH += src/Search/Wfst/libSprintSearchWfst.$(a)
 LIBS_SEARCH += src/OpenFst/libSprintOpenFst.$(a)

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -1,0 +1,442 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "LexiconfreeTimesyncBeamSearch.hh"
+#include <Core/XmlStream.hh>
+#include <Lattice/LatticeAdaptor.hh>
+#include <Nn/LabelScorer/LabelScorer.hh>
+#include <Nn/LabelScorer/ScoringContext.hh>
+#include <algorithm>
+#include <strings.h>
+
+namespace Search {
+
+/*
+ * =====================================
+ * === LexiconfreeTimesyncBeamSearch ===
+ * =====================================
+ */
+
+const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaxBeamSize(
+        "max-beam-size",
+        "Maximum number of elements in the search beam.",
+        1, 1);
+
+const Core::ParameterFloat LexiconfreeTimesyncBeamSearch::paramScoreThreshold(
+        "score-threshold",
+        "Prune any hypotheses with a score that is at least this much worse than the best hypothesis. If not set, no score pruning will be done.",
+        Core::Type<Score>::max, 0);
+
+const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramBlankLabelIndex(
+        "blank-label-index",
+        "Index of the blank label in the lexicon. If not set, the search will not use blank.",
+        Core::Type<int>::max);
+
+const Core::ParameterBool LexiconfreeTimesyncBeamSearch::paramAllowLabelLoop(
+        "allow-label-loop",
+        "Collapse repeated emission of the same label into one output. If false, every emission is treated like a new output.",
+        false);
+
+const Core::ParameterBool LexiconfreeTimesyncBeamSearch::paramLogStepwiseStatistics(
+        "log-stepwise-statistics",
+        "Log statistics about the beam at every search step.",
+        false);
+
+const Core::ParameterBool LexiconfreeTimesyncBeamSearch::paramDebugLogging(
+        "debug-logging",
+        "Enable detailed logging for debugging purposes.",
+        false);
+
+LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration const& config)
+        : Core::Component(config),
+          SearchAlgorithmV2(config),
+          maxBeamSize_(paramMaxBeamSize(config)),
+          scoreThreshold_(paramScoreThreshold(config)),
+          blankLabelIndex_(paramBlankLabelIndex(config)),
+          allowLabelLoop_(paramAllowLabelLoop(config)),
+          logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
+          debugLogging_(paramDebugLogging(config)),
+          labelScorer_(),
+          beam_(),
+          initializationTime_(),
+          featureProcessingTime_(),
+          scoringTime_(),
+          contextExtensionTime_() {
+    beam_.reserve(maxBeamSize_);
+    useBlank_        = blankLabelIndex_ != Core::Type<int>::max;
+    useScorePruning_ = scoreThreshold_ != Core::Type<Score>::max;
+}
+
+void LexiconfreeTimesyncBeamSearch::reset() {
+    initializationTime_.tic();
+
+    labelScorer_->reset();
+
+    // Reset beam to a single empty hypothesis
+    beam_.clear();
+    beam_.push_back(LabelHypothesis());
+    beam_.front().scoringContext = labelScorer_->getInitialScoringContext();
+
+    initializationTime_.toc();
+}
+
+Speech::ModelCombination::Mode LexiconfreeTimesyncBeamSearch::requiredModelCombination() const {
+    return Speech::ModelCombination::useLabelScorer | Speech::ModelCombination::useLexicon;
+}
+
+bool LexiconfreeTimesyncBeamSearch::setModelCombination(Speech::ModelCombination const& modelCombination) {
+    lexicon_     = modelCombination.lexicon();
+    labelScorer_ = modelCombination.labelScorer();
+
+    reset();
+    return true;
+}
+
+void LexiconfreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
+    initializationTime_.tic();
+    labelScorer_->reset();
+    resetStatistics();
+    initializationTime_.toc();
+}
+
+void LexiconfreeTimesyncBeamSearch::finishSegment() {
+    featureProcessingTime_.tic();
+    labelScorer_->signalNoMoreFeatures();
+    featureProcessingTime_.toc();
+    decodeManySteps();
+    logStatistics();
+}
+
+void LexiconfreeTimesyncBeamSearch::putFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) {
+    featureProcessingTime_.tic();
+    labelScorer_->addInput(data, featureSize);
+    featureProcessingTime_.toc();
+}
+
+void LexiconfreeTimesyncBeamSearch::putFeature(std::vector<f32> const& data) {
+    featureProcessingTime_.tic();
+    labelScorer_->addInput(data);
+    featureProcessingTime_.toc();
+}
+
+void LexiconfreeTimesyncBeamSearch::putFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) {
+    featureProcessingTime_.tic();
+    labelScorer_->addInputs(data, timeSize, featureSize);
+    featureProcessingTime_.toc();
+}
+
+Core::Ref<const Traceback> LexiconfreeTimesyncBeamSearch::getCurrentBestTraceback() const {
+    return Core::ref(new Traceback(beam_.front().traceback));
+}
+
+Core::Ref<const LatticeAdaptor> LexiconfreeTimesyncBeamSearch::getCurrentBestWordLattice() const {
+    if (beam_.front().traceback.empty()) {
+        return Core::ref(new Lattice::WordLatticeAdaptor());
+    }
+
+    // use default LemmaAlphabet mode of StandardWordLattice
+    Core::Ref<Lattice::StandardWordLattice> result(new Lattice::StandardWordLattice(lexicon_));
+    Core::Ref<Lattice::WordBoundaries>      wordBoundaries(new Lattice::WordBoundaries);
+
+    // create a linear lattice from the traceback
+    Fsa::State* currentState = result->initialState();
+    for (auto it = beam_.front().traceback.begin(); it != beam_.front().traceback.end(); ++it) {
+        wordBoundaries->set(currentState->id(), Lattice::WordBoundary(it->time));
+        Fsa::State* nextState;
+        if (std::next(it) == beam_.front().traceback.end()) {
+            nextState = result->finalState();
+        }
+        else {
+            nextState = result->newState();
+        }
+        ScoreVector scores = it->score;
+        if (it != beam_.front().traceback.begin()) {
+            scores -= std::prev(it)->score;
+        }
+        result->newArc(currentState, nextState, it->pronunciation->lemma(), scores.acoustic, scores.lm);
+        currentState = nextState;
+    }
+
+    result->setWordBoundaries(wordBoundaries);
+    result->addAcyclicProperty();
+
+    return Core::ref(new Lattice::WordLatticeAdaptor(result));
+}
+
+void LexiconfreeTimesyncBeamSearch::resetStatistics() {
+    initializationTime_.reset();
+    featureProcessingTime_.reset();
+    scoringTime_.reset();
+    contextExtensionTime_.reset();
+}
+
+void LexiconfreeTimesyncBeamSearch::logStatistics() const {
+    clog() << Core::XmlOpen("timing-statistics") + Core::XmlAttribute("unit", "milliseconds");
+    clog() << Core::XmlOpen("initialization-time") << initializationTime_.getTotalMilliseconds() << Core::XmlClose("initialization-time");
+    clog() << Core::XmlOpen("feature-processing-time") << featureProcessingTime_.getTotalMilliseconds() << Core::XmlClose("feature-processing-time");
+    clog() << Core::XmlOpen("scoring-time") << scoringTime_.getTotalMilliseconds() << Core::XmlClose("scoring-time");
+    clog() << Core::XmlOpen("context-extension-time") << contextExtensionTime_.getTotalMilliseconds() << Core::XmlClose("context-extension-time");
+    clog() << Core::XmlClose("timing-statistics");
+}
+
+Nn::LabelScorer::TransitionType LexiconfreeTimesyncBeamSearch::inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const {
+    // These checks will result in false if `blankLabelIndex_` is still `Core::Type<int>::max`, i.e. no blank is used
+    bool prevIsBlank = (prevLabel == blankLabelIndex_);
+    bool nextIsBlank = (nextLabel == blankLabelIndex_);
+
+    if (prevIsBlank) {
+        if (nextIsBlank) {
+            return Nn::LabelScorer::TransitionType::BLANK_LOOP;
+        }
+        else {
+            return Nn::LabelScorer::TransitionType::BLANK_TO_LABEL;
+        }
+    }
+    else {
+        if (nextIsBlank) {
+            return Nn::LabelScorer::TransitionType::LABEL_TO_BLANK;
+        }
+        else if (allowLabelLoop_ and prevLabel == nextLabel) {
+            return Nn::LabelScorer::TransitionType::LABEL_LOOP;
+        }
+        else {
+            return Nn::LabelScorer::TransitionType::LABEL_TO_LABEL;
+        }
+    }
+}
+
+void LexiconfreeTimesyncBeamSearch::beamPruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions) const {
+    if (extensions.size() <= maxBeamSize_) {
+        return;
+    }
+
+    // Sort the hypotheses by associated score value such that the first `beamSize_` elements are the best and sorted
+    std::nth_element(extensions.begin(), extensions.begin() + maxBeamSize_, extensions.end());
+    extensions.resize(maxBeamSize_);  // Get rid of excessive elements
+}
+
+void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions) const {
+    // Compute the pruning threshold
+    auto   pruningThreshold = extensions.front().score + scoreThreshold_;
+    size_t numSurvivingHyps = 0ul;
+    // Use the fact that hypotheses are sorted by corresponding score and prune all indices after the first one that
+    // violates the score threshold
+    for (auto const& ext : extensions) {
+        if (ext.score > pruningThreshold) {
+            break;
+        }
+        ++numSurvivingHyps;
+    }
+    extensions.resize(numSurvivingHyps);  // Resize the hypotheses to keep only the surviving items
+}
+
+void LexiconfreeTimesyncBeamSearch::recombination(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>& hypotheses) {
+    std::vector<LabelHypothesis> recombinedHypotheses;
+
+    std::unordered_set<Nn::ScoringContextRef, Nn::ScoringContextHash, Nn::ScoringContextEq> seenScoringContexts;
+    for (auto const& hyp : hypotheses) {
+        if (seenScoringContexts.find(hyp.scoringContext) == seenScoringContexts.end()) {
+            recombinedHypotheses.push_back(hyp);
+            seenScoringContexts.insert(hyp.scoringContext);
+        }
+    }
+    hypotheses.swap(recombinedHypotheses);
+}
+
+bool LexiconfreeTimesyncBeamSearch::decodeStep() {
+    // Assume the output labels are stored as lexicon lemma orth and ordered consistently with NN output index
+    auto lemmas = lexicon_->lemmas();
+
+    /*
+     * Collect all possible extensions for all hypotheses in the beam.
+     */
+    std::vector<ExtensionCandidate> extensions;
+    extensions.reserve(beam_.size() * lexicon_->nLemmas());
+
+    for (size_t hypIndex = 0ul; hypIndex < beam_.size(); ++hypIndex) {
+        auto& hyp = beam_[hypIndex];
+
+        // Iterate over possible successors (all lemmas)
+        for (auto lemmaIt = lemmas.first; lemmaIt != lemmas.second; ++lemmaIt) {
+            const Bliss::Lemma* lemma(*lemmaIt);
+            Nn::LabelIndex      tokenIdx = lemma->id();
+
+            extensions.push_back(
+                    {tokenIdx,
+                     lemma->pronunciations().first,
+                     hyp.score,
+                     0,
+                     inferTransitionType(hyp.currentToken, tokenIdx),
+                     hypIndex});
+        }
+    }
+
+    /*
+     * Create scoring requests for the label scorer.
+     * Each extension candidate makes up a request.
+     */
+    std::vector<Nn::LabelScorer::Request> requests;
+    requests.reserve(extensions.size());
+    for (const auto& extension : extensions) {
+        requests.push_back({beam_[extension.baseHypIndex].scoringContext, extension.nextToken, extension.transitionType});
+    }
+
+    /*
+     * Perform scoring of all the requests with the label scorer.
+     */
+    scoringTime_.tic();
+    auto result = labelScorer_->computeScoresWithTimes(requests);
+    scoringTime_.toc();
+
+    if (not result) {
+        // LabelScorer could not compute scores -> no search step can be made.
+        return false;
+    }
+
+    for (size_t requestIdx = 0ul; requestIdx < extensions.size(); ++requestIdx) {
+        extensions[requestIdx].score += result->scores[requestIdx];
+        extensions[requestIdx].timeframe = result->timeframes[requestIdx];
+    }
+
+    /*
+     * Prune set of possible extensions by max beam size and possibly also by score.
+     */
+    beamPruning(extensions);
+    if (debugLogging_) {
+        log() << extensions.size() << " candidates survived beam pruning";
+    }
+
+    std::sort(extensions.begin(), extensions.end());
+
+    if (useScorePruning_) {
+        // Extensions are sorted by score after `beamPruning`.
+        scorePruning(extensions);
+
+        if (debugLogging_) {
+            log() << extensions.size() << " candidates survived score pruning";
+        }
+    }
+
+    /*
+     * Create new beam from surviving extensions.
+     */
+    std::vector<LabelHypothesis> newBeam;
+    newBeam.reserve(extensions.size());
+
+    for (auto const& extension : extensions) {
+        auto const& baseHyp           = beam_[extension.baseHypIndex];
+        auto        newScoringContext = labelScorer_->extendedScoringContext({baseHyp.scoringContext, extension.nextToken, extension.transitionType});
+        newBeam.push_back({baseHyp, extension, newScoringContext});
+    }
+
+    /*
+     * For all hypotheses with the same scoring context keep only the best since they will
+     * all develop in the same way.
+     */
+    recombination(newBeam);
+    if (debugLogging_) {
+        log() << newBeam.size() << " hypotheses after recombination";
+
+        std::stringstream ss;
+        for (size_t hypIdx = 0ul; hypIdx < newBeam.size(); ++hypIdx) {
+            ss << "Hypothesis " << hypIdx + 1ul << ":  " << newBeam[hypIdx].toString() << "\n";
+        }
+        log() << ss.str();
+    }
+
+    beam_.swap(newBeam);
+
+    if (logStepwiseStatistics_) {
+        clog() << Core::XmlOpen("search-step-stats");
+        clog() << Core::XmlOpen("active-hyps") << beam_.size() << Core::XmlClose("active-hyps");
+        clog() << Core::XmlOpen("best-hyp-score") << beam_.front().score << Core::XmlClose("best-hyp-score");
+        clog() << Core::XmlOpen("worst-hyp-score") << beam_.back().score << Core::XmlClose("worst-hyp-score");
+        clog() << Core::XmlClose("search-step-stats");
+    }
+
+    return true;
+}
+
+/*
+ * =======================
+ * === LabelHypothesis ===
+ * =======================
+ */
+
+LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis()
+        : scoringContext(),
+          currentToken(Core::Type<Nn::LabelIndex>::max),
+          score(0.0),
+          traceback() {}
+
+LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
+        LexiconfreeTimesyncBeamSearch::LabelHypothesis const&    base,
+        LexiconfreeTimesyncBeamSearch::ExtensionCandidate const& extension,
+        Nn::ScoringContextRef const&                             newScoringContext)
+        : scoringContext(newScoringContext),
+          currentToken(extension.nextToken),
+          score(extension.score),
+          traceback(base.traceback) {
+    switch (extension.transitionType) {
+        case Nn::LabelScorer::LABEL_TO_LABEL:
+        case Nn::LabelScorer::LABEL_TO_BLANK:
+        case Nn::LabelScorer::BLANK_TO_LABEL:
+            this->traceback.push_back(TracebackItem(extension.pron, extension.timeframe + 1u, ScoreVector(extension.score, 0.0), {}));
+            break;
+        case Nn::LabelScorer::LABEL_LOOP:
+        case Nn::LabelScorer::BLANK_LOOP:
+            if (not this->traceback.empty()) {
+                this->traceback.back().score.acoustic = extension.score;
+                this->traceback.back().time           = extension.timeframe + 1u;
+            }
+            break;
+    }
+}
+
+std::string LexiconfreeTimesyncBeamSearch::LabelHypothesis::toString() const {
+    std::stringstream ss;
+    ss << "Score: " << score << ", label sequence: ";
+    for (auto& item : traceback) {
+        if (item.pronunciation != nullptr) {
+            ss << item.pronunciation->lemma()->symbol() << " ";
+        }
+    }
+    return ss.str();
+}
+
+/*
+ * =======================
+ * === TimeStatistic =====
+ * =======================
+ */
+
+void LexiconfreeTimesyncBeamSearch::TimeStatistic::reset() {
+    total = 0.0;
+}
+
+void LexiconfreeTimesyncBeamSearch::TimeStatistic::tic() {
+    startTime = std::chrono::steady_clock::now();
+}
+
+void LexiconfreeTimesyncBeamSearch::TimeStatistic::toc() {
+    auto endTime = std::chrono::steady_clock::now();
+    // Duration in milliseconds
+    total += std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1, 1000>>>(endTime - startTime).count();
+}
+
+double LexiconfreeTimesyncBeamSearch::TimeStatistic::getTotalMilliseconds() const {
+    return total;
+}
+}  // namespace Search

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -142,6 +142,7 @@ Core::Ref<const Traceback> LexiconfreeTimesyncBeamSearch::getCurrentBestTracebac
 }
 
 Core::Ref<const LatticeAdaptor> LexiconfreeTimesyncBeamSearch::getCurrentBestWordLattice() const {
+    // TODO: Currently this is just a linear lattice representing the best traceback. Create a proper lattice instead.
     if (beam_.front().traceback.empty()) {
         return Core::ref(new Lattice::WordLatticeAdaptor());
     }
@@ -439,4 +440,5 @@ void LexiconfreeTimesyncBeamSearch::TimeStatistic::toc() {
 double LexiconfreeTimesyncBeamSearch::TimeStatistic::getTotalMilliseconds() const {
     return total;
 }
+
 }  // namespace Search

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -125,6 +125,10 @@ private:
     void resetStatistics();
     void logStatistics() const;
 
+    /*
+     * Infer type of transition between two tokens based on whether each of them is blank
+     * and/or whether they are the same
+     */
     Nn::LabelScorer::TransitionType inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const;
 
     /*

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -1,0 +1,170 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LEXICONFREE_TIMESYNC_BEAM_SEARCH_HH
+#define LEXICONFREE_TIMESYNC_BEAM_SEARCH_HH
+
+#include <Bliss/Lexicon.hh>
+#include <Core/Parameter.hh>
+#include <Nn/LabelScorer/LabelScorer.hh>
+#include <Nn/LabelScorer/ScoringContext.hh>
+#include <Search/SearchV2.hh>
+#include <chrono>
+
+namespace Search {
+
+/*
+ * Simple time synchronous beam search algorithm without pronunciation lexicon, word-level LM or transition model.
+ * Can handle a blank symbol if a blank index is set.
+ * Main purpose is open vocabulary search with CTC/Neural Transducer (or similar) models.
+ * Supports global pruning by max beam-size and by score difference to the best hypothesis.
+ * Uses a LabelScorer to context initialization/extension and scoring.
+ *
+ * The search requires a lexicon that represents the vocabulary. Each lemma is viewed as a token with its index
+ * in the lexicon corresponding to the associated output index of the label scorer.
+ */
+class LexiconfreeTimesyncBeamSearch : public SearchAlgorithmV2 {
+protected:
+    /*
+     * Possible extension for some label hypothesis in the beam
+     */
+    struct ExtensionCandidate {
+        Nn::LabelIndex                   nextToken;       // Proposed token to extend the hypothesis with
+        const Bliss::LemmaPronunciation* pron;            // Pronunciation of lemma corresponding to `nextToken` for traceback
+        Score                            score;           // Would-be score of full hypothesis after extension
+        Search::TimeframeIndex           timeframe;       // Timestamp of `nextToken` for traceback
+        Nn::LabelScorer::TransitionType  transitionType;  // Type of transition toward `nextToken`
+        size_t                           baseHypIndex;    // Index of base hypothesis in global beam
+
+        bool operator<(ExtensionCandidate const& other) {
+            return score < other.score;
+        }
+    };
+
+    /*
+     * Struct containing all information about a single hypothesis in the beam
+     */
+    struct LabelHypothesis {
+        Nn::ScoringContextRef scoringContext;  // Context to compute scores based on this hypothesis
+        Nn::LabelIndex        currentToken;    // Most recent token in associated label sequence (useful to infer transition type)
+        Score                 score;           // Full score of hypothesis
+        Traceback             traceback;       // Associated traceback to return
+
+        LabelHypothesis();
+        LabelHypothesis(LabelHypothesis const& base);
+        LabelHypothesis(LabelHypothesis const& base, ExtensionCandidate const& extension, Nn::ScoringContextRef const& newScoringContext);
+
+        /*
+         * Get string representation for debugging
+         */
+        std::string toString() const;
+    };
+
+    /*
+     * Timer to add up computation times for sub-tasks performed repeatedly
+     * across the search.
+     */
+    struct TimeStatistic {
+    public:
+        // Reset accumulated total to zero.
+        void reset();
+
+        // Start timer
+        void tic();
+
+        // End running timer and add duration to total
+        void toc();
+
+        // Get total accumulated time in milliseconds
+        double getTotalMilliseconds() const;
+
+    private:
+        std::chrono::time_point<std::chrono::steady_clock> startTime;
+        double                                             total;
+    };
+
+public:
+    static const Core::ParameterInt   paramMaxBeamSize;
+    static const Core::ParameterFloat paramScoreThreshold;
+    static const Core::ParameterInt   paramBlankLabelIndex;
+    static const Core::ParameterBool  paramAllowLabelLoop;
+    static const Core::ParameterBool  paramUseSentenceEnd;
+    static const Core::ParameterBool  paramSentenceEndIndex;
+    static const Core::ParameterBool  paramLogStepwiseStatistics;
+    static const Core::ParameterBool  paramDebugLogging;
+
+    LexiconfreeTimesyncBeamSearch(Core::Configuration const&);
+
+    // Inherited methods from `SearchAlgorithmV2`
+
+    Speech::ModelCombination::Mode  requiredModelCombination() const override;
+    bool                            setModelCombination(Speech::ModelCombination const& modelCombination) override;
+    void                            reset() override;
+    void                            enterSegment(Bliss::SpeechSegment const* = nullptr) override;
+    void                            finishSegment() override;
+    void                            putFeature(std::shared_ptr<const f32[]> const& data, size_t featureSize) override;
+    void                            putFeature(std::vector<f32> const& data) override;
+    void                            putFeatures(std::shared_ptr<const f32[]> const& data, size_t timeSize, size_t featureSize) override;
+    Core::Ref<const Traceback>      getCurrentBestTraceback() const override;
+    Core::Ref<const LatticeAdaptor> getCurrentBestWordLattice() const override;
+    bool                            decodeStep() override;
+
+private:
+    void resetStatistics();
+    void logStatistics() const;
+
+    Nn::LabelScorer::TransitionType inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const;
+
+    /*
+     * Helper function for pruning to maxBeamSize_
+     */
+    void beamPruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions) const;
+
+    /*
+     * Helper function for pruning to scoreThreshold_
+     */
+    void scorePruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions) const;
+
+    /*
+     * Helper function for recombination of hypotheses with the same scoring context
+     */
+    void recombination(std::vector<LabelHypothesis>& hypotheses);
+
+    size_t maxBeamSize_;
+
+    bool  useScorePruning_;
+    Score scoreThreshold_;
+
+    bool           useBlank_;
+    Nn::LabelIndex blankLabelIndex_;
+
+    bool allowLabelLoop_;
+
+    bool logStepwiseStatistics_;
+    bool debugLogging_;
+
+    Core::Ref<Nn::LabelScorer>   labelScorer_;
+    Bliss::LexiconRef            lexicon_;
+    std::vector<LabelHypothesis> beam_;
+
+    TimeStatistic initializationTime_;
+    TimeStatistic featureProcessingTime_;
+    TimeStatistic scoringTime_;
+    TimeStatistic contextExtensionTime_;
+};
+
+}  // namespace Search
+
+#endif  // LEXICONFREE_BEAM_SEARCH_HH

--- a/src/Search/LexiconfreeTimesyncBeamSearch/Makefile
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/Makefile
@@ -1,0 +1,24 @@
+#!gmake
+
+TOPDIR		= ../../..
+
+include $(TOPDIR)/Makefile.cfg
+
+# -----------------------------------------------------------------------------
+
+SUBDIRS		=
+TARGETS		= libSprintLexiconfreeTimesyncBeamSearch.$(a)
+
+LIBSPRINTLEXICONFREETIMESYNCBEAMSEARCH_O = $(OBJDIR)/LexiconfreeTimesyncBeamSearch.o
+
+
+# -----------------------------------------------------------------------------
+
+all: $(TARGETS)
+
+libSprintLexiconfreeTimesyncBeamSearch.$(a): $(LIBSPRINTLEXICONFREETIMESYNCBEAMSEARCH_O)
+	$(MAKELIB) $@ $^
+
+include $(TOPDIR)/Rules.make
+
+sinclude $(LIBSPRINTLEXICONFREETIMESYNCBEAMSEARCH_O:.o=.d)

--- a/src/Search/Makefile
+++ b/src/Search/Makefile
@@ -33,6 +33,7 @@ LIBSPRINTSEARCH_O += $(OBJDIR)/MinimumBayesRiskAStarSearch.o
 LIBSPRINTSEARCH_O += $(OBJDIR)/MinimumBayesRiskNBestListSearch.o
 LIBSPRINTSEARCH_O += $(OBJDIR)/MinimumBayesRiskSearchUtil.o
 endif
+SUBDIRS += LexiconfreeTimesyncBeamSearch
 ifdef MODULE_SEARCH_WFST
 SUBDIRS += Wfst
 endif
@@ -62,6 +63,9 @@ Wfst:
 
 AdvancedTreeSearch:
 	$(MAKE) -C $@ libSprintAdvancedTreeSearch.$(a)
+
+LexiconfreeTimesyncBeamSearch:
+	$(MAKE) -C $@ libSprintLexiconfreeTimesyncBeamSearch.$(a)
 
 include $(TOPDIR)/Rules.make
 

--- a/src/Search/Traceback.hh
+++ b/src/Search/Traceback.hh
@@ -16,6 +16,7 @@
 #define TRACEBACK_HH
 
 #include <Bliss/Lexicon.hh>
+#include <Core/ReferenceCounting.hh>
 #include <Lattice/Lattice.hh>
 #include <Search/LatticeAdaptor.hh>
 #include <Speech/Types.hh>
@@ -60,7 +61,7 @@ public:
             : pronunciation(p), time(t), score(s), transit(te) {}
 };
 
-class Traceback : public std::vector<TracebackItem> {
+class Traceback : public std::vector<TracebackItem>, public Core::ReferenceCounted {
 public:
     void                    write(std::ostream& os, Core::Ref<const Bliss::PhonemeInventory>) const;
     Fsa::ConstAutomatonRef  lemmaAcceptor(Core::Ref<const Bliss::Lexicon>) const;


### PR DESCRIPTION
Simple time synchronous beam search algorithm based on the new `SearchAlgorithmV2` interface. Does not use (proper) pronunciation lexicon, word-level LM or transition model. Performs special handling of blank if a blank index is set. Main purpose is open vocabulary search with CTC/Neural Transducer (or similar) models.

Supports global pruning by max beam-size and by score difference to the best hypothesis. Uses a LabelScorer to context initialization/extension and scoring.

The search requires a lexicon that represents the vocabulary. Each lemma is viewed as a token with its index in the lexicon corresponding to the associated output index of the LabelScorer.