### PR TITLE
Add VocabTextLexiconParser for simple text-based lexica

### DIFF
--- a/src/Bliss/Lexicon.hh
+++ b/src/Bliss/Lexicon.hh
@@ -477,7 +477,7 @@ class LemmaToEvaluationTokenTransducer;
  *
  * A lemma may be assigned a symbolic name, which the system can
  * use to identify lemmas which have a special meaning to it.
- * E.g. the silence word is is identified by the symbolic name
+ * E.g. the silence word is identified by the symbolic name
  * "silence".  Such lemmas a called "special lemmas".
  */
 
@@ -551,6 +551,14 @@ public:
         return dependency_;
     }
 
+    /** Type of the lexicon/the lexicon file format */
+    enum LexiconType {
+        vocabTxtLexicon,
+        xmlLexicon,
+    };
+    static const Core::Choice          lexiconTypeChoice;
+    static const Core::ParameterChoice paramLexiconType;
+
     /** Create a new lemma. */
     Lemma* newLemma();
 
@@ -607,7 +615,7 @@ public:
     void defineSpecialLemma(const std::string& name, Lemma* lemma);
 
     /**
-     * Load lexicon from XML file.
+     * Load lexicon from XML or txt file.
      */
     void load(const std::string& filename);
 

--- a/src/Bliss/LexiconParser.cc
+++ b/src/Bliss/LexiconParser.cc
@@ -257,7 +257,7 @@ void LexiconElement::addPhon(const WeightedPhonemeString& phon) {
         return;
     if (!product_->phonemeInventory()) {
         parser()->warning(
-                "No phoneme inventory defined. Ingnoring pronunciation");
+                "No phoneme inventory defined. Ignoring pronunciation");
         return;
     }
 
@@ -358,7 +358,7 @@ const Core::ParameterString paramEncoding(
         "utf-8");
 }  // namespace
 
-void LexiconParser::loadWhitelist(const Core::Configuration& config, Core::StringHashSet& whitelist) {
+void XmlLexiconParser::loadWhitelist(const Core::Configuration& config, Core::StringHashSet& whitelist) {
     std::string filename = paramFile(config);
     if (!filename.empty()) {
         Core::CompressedInputStream* cis = new Core::CompressedInputStream(filename.c_str());
@@ -379,12 +379,90 @@ void LexiconParser::loadWhitelist(const Core::Configuration& config, Core::Strin
     }
 }
 
-LexiconParser::LexiconParser(const Core::Configuration& c, Lexicon* _lexicon)
-        : Precursor(c) {
+XmlLexiconParser::XmlLexiconParser(const Core::Configuration& c, Lexicon* _lexicon)
+        : LexiconParser(),
+          XmlSchemaParser(c) {
     lexicon_ = _lexicon;
 
     // build schema
     LexiconElement* lexElement = new LexiconElement(this, LexiconElement::creationHandler(&Self::pseudoCreateLexicon), c);
     loadWhitelist(select("vocab"), lexElement->whitelist_);
     setRoot(collect(lexElement));
+}
+
+// use base class parse function
+bool XmlLexiconParser::parseFile(const std::string& filename) {
+    return parser()->Core::XmlSchemaParser::parseFile(filename.c_str()) == 0;
+}
+
+VocabTextLexiconParser::VocabTextLexiconParser(Lexicon* _lexicon)
+        : LexiconParser() {
+    lexicon_          = _lexicon;
+    phonemeInventory_ = new PhonemeInventory();
+}
+
+// parse txt file line by line to a Bliss::Lexicon
+// in the first step, the phonemes are created and the phoneme inventory is set
+// and afterwards the lemmata can be created from these phonemes
+bool VocabTextLexiconParser::parseFile(const std::string& filename) {
+    // collect all labels from the file and add them as phonemes to the phoneme inventory
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        return false;
+    }
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty())
+            continue;
+        createPhoneme(line);
+    }
+
+    // set the phoneme inventory
+    lexicon_->setPhonemeInventory(Core::ref(phonemeInventory_));
+    // iterate over the phonemes in the inventory to create the lemmata in the lexicon
+    createLemmata();
+    return true;
+}
+
+// helper function to handle one label and create a corresponding phoneme
+void VocabTextLexiconParser::createPhoneme(const std::string& line) {
+    std::string symbol(line);
+    stripWhitespace(symbol);  // in case there are any unintentional whitespaces
+    suppressTrailingBlank(symbol);
+
+    // check if phoneme was already added (if one label appears more than once)
+    if (phonemeInventory_->phoneme(symbol)) {
+        return;
+    }
+
+    // create a new phoneme
+    Phoneme* newPhoneme_ = phonemeInventory_->newPhoneme();
+    // set symbol
+    phonemeInventory_->assignSymbol(newPhoneme_, symbol);
+    // set variation to none
+    newPhoneme_->setContextDependent(false);
+}
+
+// helper function to create the lemmata
+void VocabTextLexiconParser::createLemmata() {
+    // iterate over the phonemes which were assigned to the inventory previously
+    auto phonemes = phonemeInventory_->phonemes();
+    for (auto it = phonemes.first; it != phonemes.second; ++it) {
+        const Phoneme* phoneme = *it;
+        std::string    symbol  = phoneme->symbol();
+
+        // check if lemma was already added (should not happen)
+        if (lexicon_->lemma(symbol)) {
+            return;
+        }
+
+        // create a new lemma
+        Lemma* newLemma_ = lexicon_->newLemma();
+        // set orth
+        lexicon_->setOrthographicForms(newLemma_, {symbol});
+        // set phon
+        Pronunciation* pron = lexicon_->getPronunciation(symbol);
+        lexicon_->addPronunciation(newLemma_, pron);
+        lexicon_->setDefaultLemmaName(newLemma_);
+    }
 }

--- a/src/Bliss/LexiconParser.hh
+++ b/src/Bliss/LexiconParser.hh
@@ -31,7 +31,7 @@ class PhonemeInventoryElement : public Core::XmlBuilderElement<
             PhonemeInventory,
             Core::XmlRegularElement,
             Core::CreateUsingNew>
-            Precursor;
+                                    Precursor;
     typedef PhonemeInventoryElement Self;
 
 private:
@@ -51,17 +51,20 @@ struct WeightedPhonemeString;
 class PronunciationElement;
 class LexiconElement;
 class LexiconParser;
+class TextLexiconParser;
+class XmlLexiconParser;
 
 class LexiconElement : public Core::XmlBuilderElement<
                                Lexicon,
                                Core::XmlRegularElement,
                                Core::CreateByContext> {
     friend class LexiconParser;
+    friend class XmlLexiconParser;
     typedef Core::XmlBuilderElement<
             Lexicon,
             Core::XmlRegularElement,
             Core::CreateByContext>
-            Precursor;
+                           Precursor;
     typedef LexiconElement Self;
 
 private:
@@ -93,7 +96,17 @@ private:
 
 public:
     LexiconElement(Core::XmlContext*, CreationHandler, const Core::Configuration& c);
-    virtual void characters(const char*, int){};
+    virtual void characters(const char*, int) {};
+};
+
+/*
+ * Base lexicon parser class
+ */
+class LexiconParser {
+public:
+    virtual ~LexiconParser() {}
+    virtual bool     parseFile(const std::string& filename) = 0;
+    virtual Lexicon* lexicon() const                        = 0;
 };
 
 /**
@@ -103,10 +116,8 @@ public:
  * Format Reference</a>.  It is normally not used directly but
  * through Lexicon.
  */
-
-class LexiconParser : public Core::XmlSchemaParser {
-    typedef Core::XmlSchemaParser Precursor;
-    typedef LexiconParser         Self;
+class XmlLexiconParser : public virtual LexiconParser, public Core::XmlSchemaParser {
+    typedef XmlLexiconParser Self;
 
 private:
     Lexicon* lexicon_;
@@ -116,8 +127,29 @@ private:
     void loadWhitelist(const Core::Configuration&, Core::StringHashSet&);
 
 public:
-    LexiconParser(const Core::Configuration& c, Lexicon*);
-    Lexicon* lexicon() const {
+    XmlLexiconParser(const Core::Configuration& c, Lexicon*);
+    bool     parseFile(const std::string& filename) override;
+    Lexicon* lexicon() const override {
+        return lexicon_;
+    }
+};
+
+/**
+ * Parser for text lexicon files containing the vocab, so only the labels
+ * This is meant for "lexicon-free" search
+ * The .txt-file should contain one label per line
+ */
+class VocabTextLexiconParser : public LexiconParser {
+private:
+    Lexicon*          lexicon_;
+    PhonemeInventory* phonemeInventory_;
+    void              createPhoneme(const std::string& line);
+    void              createLemmata();
+
+public:
+    VocabTextLexiconParser(Lexicon*);
+    bool     parseFile(const std::string& filename) override;
+    Lexicon* lexicon() const override {
         return lexicon_;
     }
 };


### PR DESCRIPTION
Support for simple text lexica containing the vocabulary/list of lemmas.
This is can for example be used in the Lexiconfree beam search (#101) for which the XML-format is unnecessarily complicated.
Instead of an XML-lexicon, one can use a txt-file containing one label per line.
For example

```
A
B
C
```

will be parsed to a Bliss Lexicon equivalent to

```
<?xml version="1.0" ?>
<lexicon>
  <phoneme-inventory>
    <phoneme>
      <symbol>A</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
      <symbol>B</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
      <symbol>C</symbol>
      <variation>none</variation>
    </phoneme>
    <phoneme>
 </phoneme-inventory>
  <lemma>
    <orth>A</orth>
    <phon>A</phon>
  </lemma>
  <lemma>
    <orth>B</orth>
    <phon>B</phon>
  </lemma>
  <lemma>
    <orth>C</orth>
    <phon>C</phon>
  </lemma>
</lexicon>
```

