### PR TITLE
Fix CTCTopologyGraphBuilder: force blank label between two consecutive identical labels

### DIFF
--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -467,7 +467,7 @@ Fsa::ConstAutomatonRef CTCTopologyGraphBuilder::buildTransducer(Fsa::ConstAutoma
     Fsa::ConstAutomatonRef model = buildFlatTransducer(lemmaAcceptor);
     model = addLoopTransition(model);
     // remove epsilon so that repeated identical label detection could work
-    model = Fsa::removeEpsilons(Fsa::removeDisambiguationSymbols(Fsa::projectInput(model)));
+    model = Fsa::removeEpsilons(Fsa::removeDisambiguationSymbols(model));
     Core::Ref<Fsa::StaticAutomaton> automaton = Fsa::staticCopy(model);
 
     finalStateId_ = Core::Type<Fsa::StateId>::max;

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -500,9 +500,9 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
     // find non-blank loop label for later consecutive identical label handling
     Fsa::LabelId loopLabel = Fsa::InvalidLabelId;
     for (u32 idx = 0; idx < nArcs; ++idx) {
-        const Fsa::Arc* arcLoop = state->getArc(idx);
-        if ((arcLoop->target_ == s) && (arcLoop->input_ != blankId_)) {
-            loopLabel = arcLoop->input_;
+        const Fsa::Arc* arc = state->getArc(idx);
+        if (arc->target_ == s && arc->input_ != blankId_) {
+            loopLabel = arc->input_;
             break;
         }
     }
@@ -524,10 +524,10 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
         // we should overwrite the original arc target to make the blank unskippable
         if (loopLabel != Fsa::InvalidLabelId &&
             acousticModel_->emissionIndex(input) == acousticModel_->emissionIndex(loopLabel)) {
-            Fsa::Arc* aa = const_cast<Fsa::Arc*>(state->getArc(idx));
-            aa->target_ = blankStateId;
-            aa->input_ = blankId_;
-            aa->weight_ = zeroWeight;
+            Fsa::Arc* arc = const_cast<Fsa::Arc*>(a);
+            arc->target_ = blankStateId;
+            arc->input_ = blankId_;
+            arc->weight_ = zeroWeight;
         } else {
             state->newArc(blankStateId, zeroWeight, blankId_, Fsa::Epsilon);  // optional blank
         }
@@ -540,8 +540,8 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
                 ns->newArc(target, zeroWeight, input, Fsa::Epsilon);
                 target = automaton->maxStateId();
             }
-            Fsa::Arc* aa = const_cast<Fsa::Arc*>(state->getArc(idx));
-            aa->target_ = target;
+            Fsa::Arc* arc = const_cast<Fsa::Arc*>(a);
+            arc->target_ = target;
             blankState->rbegin()->target_ = target;
         }
     }

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -502,8 +502,8 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
     for (u32 idx = 0; idx < nArcs; ++idx) {
         const Fsa::Arc* arc = state->getArc(idx);
         if (arc->target_ == s && arc->input_ != blankId_) {
+            require(loopLabel == Fsa::InvalidLabelId);  // we expect only one loop label
             loopLabel = arc->input_;
-            break;
         }
     }
     for (u32 idx = 0; idx < nArcs; ++idx) {

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -522,7 +522,7 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
         blankState->newArc(target, a->weight_, input, a->output_);
         // handle consecutive identical label: if label loop and forward represent the same label,
         // we should overwrite the original arc target to make the blank unskippable
-        if (loopLabel != Fsa::InvalidLabelId && 
+        if (loopLabel != Fsa::InvalidLabelId &&
             acousticModel_->emissionIndex(input) == acousticModel_->emissionIndex(loopLabel)) {
             Fsa::Arc* aa = const_cast<Fsa::Arc*>(state->getArc(idx));
             aa->target_ = blankStateId;
@@ -531,7 +531,6 @@ void CTCTopologyGraphBuilder::addBlank(Core::Ref<Fsa::StaticAutomaton>& automato
         } else {
             state->newArc(blankStateId, zeroWeight, blankId_, Fsa::Epsilon);  // optional blank
         }
-
 
         // apply minimum duration here to avoid traversing the automaton again
         if (minDuration_ > 1 && input != silenceId_) {


### PR DESCRIPTION
When training CTC model with FSA created by AllophoneStateGraphBuilder, we observe around 5% relative WER degradation compared to training with built-in Pytorch CTC loss. We found out this is due to incorrect handling of repeated identical labels(e.g. aa in aachen when using character label unit). Without a forced blank in between, CTC topology can't differentiate loop and forward between repeated identical labels. After using the fixed version, we are able to get the same WER.