### PR TITLE
Add EncoderDecoderLabelScorer

### DIFF
--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
@@ -1,0 +1,85 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "EncoderDecoderLabelScorer.hh"
+
+namespace Nn {
+
+EncoderDecoderLabelScorer::EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<LabelScorer> const& decoder)
+        : Core::Component(config),
+          LabelScorer(config),
+          encoder_(encoder),
+          decoder_(decoder) {
+}
+
+void EncoderDecoderLabelScorer ::reset() {
+    encoder_->reset();
+    decoder_->reset();
+}
+
+ScoringContextRef EncoderDecoderLabelScorer::getInitialScoringContext() {
+    return decoder_->getInitialScoringContext();
+}
+
+ScoringContextRef EncoderDecoderLabelScorer::extendedScoringContext(Request const& request) {
+    return decoder_->extendedScoringContext(request);
+}
+
+void EncoderDecoderLabelScorer::addInput(std::shared_ptr<const f32[]> const& input, size_t featureSize) {
+    encoder_->addInput(input, featureSize);
+    passEncoderToDecoder();
+}
+
+void EncoderDecoderLabelScorer::addInput(std::vector<f32> const& input) {
+    // The custom deleter ties the lifetime of the vector to the lifetime
+    // of `dataPtr` by capturing the `inputWrapper` by value.
+    // This makes sure that the underlying data isn't invalidated prematurely.
+    auto inputWrapper = std::make_shared<std::vector<f32>>(input);
+    auto dataPtr      = std::shared_ptr<const f32[]>(
+            inputWrapper->data(),
+            [inputWrapper](const f32*) mutable {});
+    encoder_->addInput(dataPtr, input.size());
+    passEncoderToDecoder();
+}
+
+void EncoderDecoderLabelScorer::addInputs(std::shared_ptr<const f32[]> const& input, size_t timeSize, size_t featureSize) {
+    encoder_->addInputs(input, timeSize, featureSize);
+    passEncoderToDecoder();
+}
+
+void EncoderDecoderLabelScorer::signalNoMoreFeatures() {
+    encoder_->signalNoMoreFeatures();
+    // Call `passEncoderToDecoder()` before signaling segment end to the decoder since the decoder
+    // is supposed to receive all available encoder outputs before this signal
+    passEncoderToDecoder();
+    decoder_->signalNoMoreFeatures();
+}
+
+std::optional<LabelScorer::ScoreWithTime> EncoderDecoderLabelScorer::computeScoreWithTime(LabelScorer::Request const& request) {
+    return decoder_->computeScoreWithTime(request);
+}
+
+std::optional<LabelScorer::ScoresWithTimes> EncoderDecoderLabelScorer::computeScoresWithTimes(std::vector<LabelScorer::Request> const& requests) {
+    return decoder_->computeScoresWithTimes(requests);
+}
+
+void EncoderDecoderLabelScorer::passEncoderToDecoder() {
+    std::optional<std::shared_ptr<const f32[]>> encoderOutput;
+    while ((encoderOutput = encoder_->getNextOutput())) {
+        decoder_->addInput(*encoderOutput, encoder_->getOutputSize());
+    }
+}
+
+}  // namespace Nn

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
@@ -39,7 +39,7 @@ ScoringContextRef EncoderDecoderLabelScorer::extendedScoringContext(Request cons
 
 void EncoderDecoderLabelScorer::addInput(std::shared_ptr<const f32[]> const& input, size_t featureSize) {
     encoder_->addInput(input, featureSize);
-    passEncoderToDecoder();
+    passEncoderOutputsToDecoder();
 }
 
 void EncoderDecoderLabelScorer::addInput(std::vector<f32> const& input) {
@@ -51,19 +51,19 @@ void EncoderDecoderLabelScorer::addInput(std::vector<f32> const& input) {
             inputWrapper->data(),
             [inputWrapper](const f32*) mutable {});
     encoder_->addInput(dataPtr, input.size());
-    passEncoderToDecoder();
+    passEncoderOutputsToDecoder();
 }
 
 void EncoderDecoderLabelScorer::addInputs(std::shared_ptr<const f32[]> const& input, size_t timeSize, size_t featureSize) {
     encoder_->addInputs(input, timeSize, featureSize);
-    passEncoderToDecoder();
+    passEncoderOutputsToDecoder();
 }
 
 void EncoderDecoderLabelScorer::signalNoMoreFeatures() {
     encoder_->signalNoMoreFeatures();
-    // Call `passEncoderToDecoder()` before signaling segment end to the decoder since the decoder
+    // Call `passEncoderOutputsToDecoder()` before signaling segment end to the decoder since the decoder
     // is supposed to receive all available encoder outputs before this signal
-    passEncoderToDecoder();
+    passEncoderOutputsToDecoder();
     decoder_->signalNoMoreFeatures();
 }
 
@@ -75,7 +75,7 @@ std::optional<LabelScorer::ScoresWithTimes> EncoderDecoderLabelScorer::computeSc
     return decoder_->computeScoresWithTimes(requests);
 }
 
-void EncoderDecoderLabelScorer::passEncoderToDecoder() {
+void EncoderDecoderLabelScorer::passEncoderOutputsToDecoder() {
     std::optional<std::shared_ptr<const f32[]>> encoderOutput;
     while ((encoderOutput = encoder_->getNextOutput())) {
         decoder_->addInput(*encoderOutput, encoder_->getOutputSize());

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
@@ -17,6 +17,7 @@
 #define ENCODER_DECODER_LABEL_SCORER_HH
 
 #include <Core/Component.hh>
+
 #include "Encoder.hh"
 #include "LabelScorer.hh"
 
@@ -68,7 +69,7 @@ private:
 
     // Fetch as many outputs as possible from the encoder given its available features and pass
     // these outputs over to the decoder
-    void passEncoderToDecoder();
+    void passEncoderOutputsToDecoder();
 };
 
 }  // namespace Nn

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
@@ -24,8 +24,8 @@ namespace Nn {
 
 /*
  * Glue class to represent encoder-decoder model architectures. It consists of an
- * encoder component that does history-independent feature encoding once in the beginning
- * and a decoder component which is another internal Sub-LabelScorer that receives the encoded
+ * encoder component that computes feature encodings without requiring a ScoringContext
+ * and a decoder component which is an arbitrary sub-LabelScorer that receives the encoded
  * features as its inputs.
  * This glue class automatically handles the information flow between its encoder and
  * decoder components.

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
@@ -1,0 +1,76 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ENCODER_DECODER_LABEL_SCORER_HH
+#define ENCODER_DECODER_LABEL_SCORER_HH
+
+#include <Core/Component.hh>
+#include "Encoder.hh"
+#include "LabelScorer.hh"
+
+namespace Nn {
+
+/*
+ * Glue class to represent encoder-decoder model architectures. It consists of an
+ * encoder component that does history-independent feature encoding once in the beginning
+ * and a decoder component which is another internal Sub-LabelScorer that receives the encoded
+ * features as its inputs.
+ * This glue class automatically handles the information flow between its encoder and
+ * decoder components.
+ */
+class EncoderDecoderLabelScorer : public LabelScorer {
+public:
+    EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<LabelScorer> const& decoder);
+    virtual ~EncoderDecoderLabelScorer() = default;
+
+    // Resets both encoder and decoder component
+    void reset() override;
+
+    // Signal end of feature stream to encoder, then encode features, pass them to the decoder and
+    // finally signal end of feature stream to decoder.
+    void signalNoMoreFeatures() override;
+
+    // Get start context from decoder component
+    ScoringContextRef getInitialScoringContext() override;
+
+    // Get extended context from decoder component
+    ScoringContextRef extendedScoringContext(Request const& request) override;
+
+    // Add an input feature to the encoder component and if possible forward the encoder and add
+    // the encoder states as inputs to the decoder component
+    void addInput(std::shared_ptr<const f32[]> const& input, size_t featureSize) override;
+    void addInput(std::vector<f32> const& input) override;
+
+    // Same as `addInput` but adds features for multiple timesteps at once
+    void addInputs(std::shared_ptr<const f32[]> const& input, size_t timeSize, size_t featureSize) override;
+
+    // Run request through decoder component
+    std::optional<LabelScorer::ScoreWithTime> computeScoreWithTime(LabelScorer::Request const& request) override;
+
+    // Run requests through decoder component
+    std::optional<LabelScorer::ScoresWithTimes> computeScoresWithTimes(std::vector<LabelScorer::Request> const& requests) override;
+
+private:
+    Core::Ref<Encoder>     encoder_;
+    Core::Ref<LabelScorer> decoder_;
+
+    // Fetch as many outputs as possible from the encoder given its available features and pass
+    // these outputs over to the decoder
+    void passEncoderToDecoder();
+};
+
+}  // namespace Nn
+
+#endif  // ENCODER_DECODER_LABEL_SCORER_HH

--- a/src/Nn/LabelScorer/Makefile
+++ b/src/Nn/LabelScorer/Makefile
@@ -13,6 +13,7 @@ LIBSPRINTLABELSCORER_O =  \
     $(OBJDIR)/BufferedLabelScorer.o \
     $(OBJDIR)/CombineLabelScorer.o \
     $(OBJDIR)/Encoder.o \
+    $(OBJDIR)/EncoderDecoderLabelScorer.o \
     $(OBJDIR)/EncoderFactory.o \
     $(OBJDIR)/LabelScorer.o \
     $(OBJDIR)/LabelScorerFactory.o \


### PR DESCRIPTION
Add a new LabelScorer class `EncoderDecoderLabelScorer`. This is a glue class to represent encoder-decoder model architectures. It consists of an encoder component that computes feature encodings without requiring a `ScoringContext` and a decoder component which is an arbitrary sub-LabelScorer that receives the encoded features as its inputs.

This class handles the information flow between its encoder and decoder components.