### PR TITLE
Python bindings for Search Algorithm

### DIFF
--- a/src/Python/Makefile
+++ b/src/Python/Makefile
@@ -21,6 +21,7 @@ LIBPYTHON_O    = \
 		$(OBJDIR)/Configuration.o            \
 		$(OBJDIR)/Init.o                     \
 		$(OBJDIR)/Numpy.o                    \
+		$(OBJDIR)/Search.o                   \
 		$(OBJDIR)/Utilities.o
 
 CHECK_O		= $(OBJDIR)/check.o 			\

--- a/src/Python/Search.cc
+++ b/src/Python/Search.cc
@@ -1,0 +1,106 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "Search.hh"
+
+#include <Search/Module.hh>
+#include <Speech/ModelCombination.hh>
+
+namespace py = pybind11;
+
+SearchAlgorithm::SearchAlgorithm(const Core::Configuration& c)
+        : Core::Component(c),
+          searchAlgorithm_(Search::Module::instance().createSearchAlgorithmV2(select("search-algorithm"))) {
+    searchAlgorithm_->setModelCombination({config, searchAlgorithm_->requiredModelCombination(), searchAlgorithm_->requiredAcousticModel()});
+}
+
+void SearchAlgorithm::reset() {
+    searchAlgorithm_->reset();
+}
+
+void SearchAlgorithm::enterSegment() {
+    searchAlgorithm_->enterSegment();
+}
+
+void SearchAlgorithm::finishSegment() {
+    searchAlgorithm_->finishSegment();
+}
+
+void SearchAlgorithm::putFeature(py::array_t<f32> const& feature) {
+    size_t F = 0ul;
+    if (feature.ndim() == 2) {
+        if (feature.shape(0) != 1) {
+            error() << "Received feature tensor with non-trivial batch dimension " << feature.shape(0) << "; should be 1";
+        }
+        F = feature.shape(1);
+    }
+    else if (feature.ndim() != 1) {
+        error() << "Received feature vector of invalid dim " << feature.ndim() << "; should be 1";
+        F = feature.shape(0);
+    }
+
+    searchAlgorithm_->putFeature({feature, F});
+}
+
+void SearchAlgorithm::putFeatures(py::array_t<f32> const& features) {
+    size_t T = 0ul;
+    size_t F = 0ul;
+    if (features.ndim() == 3) {
+        if (features.shape(0) != 1) {
+            error() << "Received feature tensor with non-trivial batch dimension " << features.shape(0) << "; should be 1";
+        }
+        T = features.shape(1);
+        F = features.shape(2);
+    }
+    else if (features.ndim() != 2) {
+        error() << "Received feature tensor of invalid dim " << features.ndim() << "; should be 2 or 3";
+        T = features.shape(0);
+        F = features.shape(1);
+    }
+
+    for (size_t t = 0ul; t < T; ++t) {
+        searchAlgorithm_->putFeatures({features, T * F}, T);
+    }
+}
+
+Traceback SearchAlgorithm::getCurrentBestTraceback() {
+    searchAlgorithm_->decodeManySteps();
+
+    auto                       traceback = searchAlgorithm_->getCurrentBestTraceback();
+    std::vector<TracebackItem> result;
+    result.reserve(traceback->size());
+
+    u32 prevTime = 0;
+
+    for (auto it = traceback->begin(); it != traceback->end(); ++it) {
+        result.push_back({
+                it->pronunciation->lemma()->symbol(),
+                it->score.acoustic,
+                it->score.lm,
+                prevTime,
+                it->time,
+        });
+        prevTime = it->time;
+    }
+    return result;
+}
+
+Traceback SearchAlgorithm::recognizeSegment(py::array_t<f32> const& features) {
+    reset();
+    enterSegment();
+    putFeatures(features);
+    finishSegment();
+    return getCurrentBestTraceback();
+}

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -1,0 +1,75 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef _PYTHON_SEARCH_HH
+#define _PYTHON_SEARCH_HH
+
+#include <Search/SearchV2.hh>
+
+#pragma push_macro("ensure")  // Macro duplication in numpy.h
+#undef ensure
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#pragma pop_macro("ensure")
+
+#include <Core/Application.hh>
+#include <Core/Archive.hh>
+#include <Core/Configuration.hh>
+#include <Flf/FlfCore/Lattice.hh>
+
+namespace py = pybind11;
+
+struct TracebackItem {
+    std::string lemma;
+    f32         amScore;
+    f32         lmScore;
+    u32         startTime;
+    u32         endTime;
+};
+
+typedef std::vector<TracebackItem> Traceback;
+
+class SearchAlgorithm : public Core::Component {
+public:
+    SearchAlgorithm(const Core::Configuration& c);
+
+    // Call before starting a new recognition. Clean up existing data structures
+    // from the previous run.
+    void reset();
+
+    // Call at the beginning of a new segment.
+    void enterSegment();
+
+    // Call after all features of the current segment have been passed
+    void finishSegment();
+
+    // Pass a feature array of shape [F] or [1, F]
+    void putFeature(py::array_t<f32> const&);
+
+    // Pass an array of features of shape [T, F] or [1, T, F]
+    void putFeatures(py::array_t<f32> const&);
+
+    // Return the current best result. May contain unstable results.
+    Traceback getCurrentBestTraceback();
+
+    // Convenience function to recognize a full segment given all the features as a tensor of shape [T, F]
+    // Returns the recognition result
+    Traceback recognizeSegment(py::array_t<f32> const&);
+
+private:
+    std::unique_ptr<Search::SearchAlgorithmV2> searchAlgorithm_;
+};
+
+#endif  // _PYTHON_SEARCH_HH

--- a/src/Tools/LibRASR/Makefile
+++ b/src/Tools/LibRASR/Makefile
@@ -13,6 +13,7 @@ CXXFLAGS += -fPIC
 LDFLAGS += -shared
 
 RASR_LIB_O = $(OBJDIR)/LibRASR.o \
+			 $(OBJDIR)/Search.o \
              ../../Flf/libSprintFlf.$(a) \
              ../../Flf/FlfCore/libSprintFlfCore.$(a) \
              ../../Speech/libSprintSpeech.$(a) \

--- a/src/Tools/LibRASR/PybindModule.cc
+++ b/src/Tools/LibRASR/PybindModule.cc
@@ -1,11 +1,12 @@
-#include <string>
+#include "LibRASR.hh"
 
+#include <string>
 #include <pybind11/pybind11.h>
 
 #include <Python/AllophoneStateFsaBuilder.hh>
 #include <Python/Configuration.hh>
 
-#include "LibRASR.hh"
+#include "Search.hh"
 
 namespace py = pybind11;
 
@@ -19,7 +20,7 @@ PYBIND11_MODULE(librasr, m) {
     py::class_<PyConfiguration> pyRasrConfig(m, "Configuration", baseConfigClass);
     pyRasrConfig.def(py::init<>());
     pyRasrConfig.def("set_from_file",
-                     (bool(Core::Configuration::*)(const std::string&)) & Core::Configuration::setFromFile);
+                     (bool (Core::Configuration::*)(const std::string&))&Core::Configuration::setFromFile);
 
     py::class_<AllophoneStateFsaBuilder> pyFsaBuilder(m, "AllophoneStateFsaBuilder");
     pyFsaBuilder.def(py::init<const Core::Configuration&>());
@@ -27,4 +28,6 @@ PYBIND11_MODULE(librasr, m) {
                      &AllophoneStateFsaBuilder::buildByOrthography);
     pyFsaBuilder.def("build_by_segment_name",
                      &AllophoneStateFsaBuilder::buildBySegmentName);
+
+    bind_search_algorithm(m);
 }

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -1,0 +1,115 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "Search.hh"
+
+#include <Python/Search.hh>
+#include <sstream>
+
+void bind_search_algorithm(py::module_& module) {
+    /*
+     * ========================
+     * === Traceback ==========
+     * ========================
+     */
+    py::class_<TracebackItem> pyTracebackItem(
+            module,
+            "TracebackItem",
+            "Represents attributes of a single traceback item.");
+    pyTracebackItem.def_readwrite("lemma", &TracebackItem::lemma);
+    pyTracebackItem.def_readwrite("am_score", &TracebackItem::amScore);
+    pyTracebackItem.def_readwrite("lm_score", &TracebackItem::lmScore);
+    pyTracebackItem.def_readwrite("start_time", &TracebackItem::startTime);
+    pyTracebackItem.def_readwrite("end_time", &TracebackItem::endTime);
+
+    pyTracebackItem.def(
+            "__repr__",
+            [](TracebackItem const& t) {
+                std::stringstream ss;
+                ss << "<TracebackItem(";
+                ss << "lemma='" << t.lemma << "'";
+                ss << ", am_score=" << t.amScore;
+                ss << ", lm_score=" << t.lmScore;
+                ss << ", start_time=" << t.startTime;
+                ss << ", end_time=" << t.endTime;
+                ss << ")>";
+                return ss.str();
+            });
+
+    pyTracebackItem.def(
+            "__str__",
+            [](TracebackItem const& t) {
+                return t.lemma;
+            });
+
+    /*
+     * ========================
+     * === Search Algorithm ===
+     * ========================
+     */
+    py::class_<SearchAlgorithm> pySearchAlgorithm(
+            module,
+            "SearchAlgorithm",
+            "Class that can perform recognition using RASR.\n\n"
+            "The search algorithm is configured with a RASR config object.\n"
+            "It works by calling `enter_segment()`, passing segment features\n"
+            "via `put_feature` or `put_features` and finally calling `finish_segment()`.\n"
+            "Intermediate and final results can be retrieved via `get_current_best_traceback()`.\n"
+            "There is also a convenience function `recognize_segment` that performs all\n"
+            "these steps in one go given an array of segment features.");
+
+    pySearchAlgorithm.def(
+            py::init<const Core::Configuration&>(),
+            py::arg("config"),
+            "Initialize search algorithm using a RASR config.");
+
+    pySearchAlgorithm.def(
+            "reset",
+            &SearchAlgorithm::reset,
+            "Call before starting a new recognition. Cleans up existing data structures from the previous run.");
+
+    pySearchAlgorithm.def(
+            "enter_segment",
+            &SearchAlgorithm::enterSegment,
+            "Call at the beginning of a new segment.");
+
+    pySearchAlgorithm.def(
+            "finish_segment",
+            &SearchAlgorithm::finishSegment,
+            "Call after all features of the current segment have been passed");
+
+    pySearchAlgorithm.def(
+            "put_feature",
+            &SearchAlgorithm::putFeature,
+            py::arg("feature_vector"),
+            "Pass a single feature as a numpy array of shape [F].");
+
+    pySearchAlgorithm.def(
+            "put_features",
+            &SearchAlgorithm::putFeatures,
+            py::arg("feature_array"),
+            "Pass multiple features as a numpy array of shape [T, F].");
+
+    pySearchAlgorithm.def(
+            "get_current_best_traceback",
+            &SearchAlgorithm::getCurrentBestTraceback,
+            "Get the best traceback given all features that have been passed thus far.");
+
+    pySearchAlgorithm.def(
+            "recognize_segment",
+            &SearchAlgorithm::recognizeSegment,
+            py::arg("features"),
+            "Convenience function to start a segment, pass all the features as a numpy array of shape [T, F], finish the segment, and return the recognition result.");
+}

--- a/src/Tools/LibRASR/Search.hh
+++ b/src/Tools/LibRASR/Search.hh
@@ -1,0 +1,23 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+/*
+ * Create bindings for search functionalities and tracebacks
+ */
+void bind_search_algorithm(py::module_& module);


### PR DESCRIPTION
This PR adds python bindings in `LibRASR` that can run recognition using a `SearchAlgorithmV2`. These bindings can be used for example to perform RASR search in a regular `ReturnnForwardJob`.

Depends on #112.