### PR TITLE
Add interface to librasr for direct access to orthography

### DIFF
--- a/src/Python/AllophoneStateFsaBuilder.cc
+++ b/src/Python/AllophoneStateFsaBuilder.cc
@@ -42,12 +42,16 @@ AllophoneStateFsaBuilder::AllophoneStateFsaBuilder(const Core::Configuration& c)
     segmentToOrthMap_          = build_segment_to_orth_map(select("corpus"));
 }
 
-py::tuple AllophoneStateFsaBuilder::buildBySegmentName(const std::string& segmentName) {
+std::string AllophoneStateFsaBuilder::getOrthography(const std::string& segmentName) {
     auto iter = segmentToOrthMap_->find(segmentName);
     if (iter == segmentToOrthMap_->end()) {
         throw std::invalid_argument("Could not find segment with name " + segmentName);
     }
-    return buildByOrthography(iter->second);
+    return iter->second;
+}
+
+py::tuple AllophoneStateFsaBuilder::buildBySegmentName(const std::string& segmentName) {
+    return buildByOrthography(getOrthography(segmentName));
 }
 
 py::tuple AllophoneStateFsaBuilder::buildByOrthography(const std::string& orthography) {

--- a/src/Python/AllophoneStateFsaBuilder.cc
+++ b/src/Python/AllophoneStateFsaBuilder.cc
@@ -42,7 +42,7 @@ AllophoneStateFsaBuilder::AllophoneStateFsaBuilder(const Core::Configuration& c)
     segmentToOrthMap_          = build_segment_to_orth_map(select("corpus"));
 }
 
-std::string AllophoneStateFsaBuilder::getOrthography(const std::string& segmentName) {
+std::string AllophoneStateFsaBuilder::getOrthographyBySegmentName(const std::string& segmentName) {
     auto iter = segmentToOrthMap_->find(segmentName);
     if (iter == segmentToOrthMap_->end()) {
         throw std::invalid_argument("Could not find segment with name " + segmentName);

--- a/src/Python/AllophoneStateFsaBuilder.cc
+++ b/src/Python/AllophoneStateFsaBuilder.cc
@@ -51,7 +51,7 @@ std::string AllophoneStateFsaBuilder::getOrthographyBySegmentName(const std::str
 }
 
 py::tuple AllophoneStateFsaBuilder::buildBySegmentName(const std::string& segmentName) {
-    return buildByOrthography(getOrthography(segmentName));
+    return buildByOrthography(getOrthographyBySegmentName(segmentName));
 }
 
 py::tuple AllophoneStateFsaBuilder::buildByOrthography(const std::string& orthography) {

--- a/src/Python/AllophoneStateFsaBuilder.hh
+++ b/src/Python/AllophoneStateFsaBuilder.hh
@@ -15,7 +15,7 @@ public:
     AllophoneStateFsaBuilder(const Core::Configuration& c);
     ~AllophoneStateFsaBuilder() = default;
 
-    std::string getOrthography(const std::string& segmentName);
+    std::string getOrthographyBySegmentName(const std::string& segmentName);
 
     py::tuple buildBySegmentName(const std::string& segmentName);
 

--- a/src/Python/AllophoneStateFsaBuilder.hh
+++ b/src/Python/AllophoneStateFsaBuilder.hh
@@ -15,6 +15,8 @@ public:
     AllophoneStateFsaBuilder(const Core::Configuration& c);
     ~AllophoneStateFsaBuilder() = default;
 
+    std::string getOrthography(const std::string& segmentName);
+
     py::tuple buildBySegmentName(const std::string& segmentName);
 
     py::tuple buildByOrthography(const std::string& orthography);

--- a/src/Tools/LibRASR/PybindModule.cc
+++ b/src/Tools/LibRASR/PybindModule.cc
@@ -23,7 +23,7 @@ PYBIND11_MODULE(librasr, m) {
 
     py::class_<AllophoneStateFsaBuilder> pyFsaBuilder(m, "AllophoneStateFsaBuilder");
     pyFsaBuilder.def(py::init<const Core::Configuration&>());
-    pyFsaBuilder.def("get_orthography",
+    pyFsaBuilder.def("get_orthography_by_segment_name",
                      &AllophoneStateFsaBuilder::getOrthographyBySegmentName);
     pyFsaBuilder.def("build_by_orthography",
                      &AllophoneStateFsaBuilder::buildByOrthography);

--- a/src/Tools/LibRASR/PybindModule.cc
+++ b/src/Tools/LibRASR/PybindModule.cc
@@ -24,7 +24,7 @@ PYBIND11_MODULE(librasr, m) {
     py::class_<AllophoneStateFsaBuilder> pyFsaBuilder(m, "AllophoneStateFsaBuilder");
     pyFsaBuilder.def(py::init<const Core::Configuration&>());
     pyFsaBuilder.def("get_orthography",
-                     &AllophoneStateFsaBuilder::getOrthography);
+                     &AllophoneStateFsaBuilder::getOrthographyBySegmentName);
     pyFsaBuilder.def("build_by_orthography",
                      &AllophoneStateFsaBuilder::buildByOrthography);
     pyFsaBuilder.def("build_by_segment_name",

--- a/src/Tools/LibRASR/PybindModule.cc
+++ b/src/Tools/LibRASR/PybindModule.cc
@@ -23,6 +23,8 @@ PYBIND11_MODULE(librasr, m) {
 
     py::class_<AllophoneStateFsaBuilder> pyFsaBuilder(m, "AllophoneStateFsaBuilder");
     pyFsaBuilder.def(py::init<const Core::Configuration&>());
+    pyFsaBuilder.def("get_orthography",
+                     &AllophoneStateFsaBuilder::getOrthography);
     pyFsaBuilder.def("build_by_orthography",
                      &AllophoneStateFsaBuilder::buildByOrthography);
     pyFsaBuilder.def("build_by_segment_name",


### PR DESCRIPTION
In training, it's sometimes beneficial to directly access the orthography instead of only seeing the FSA. E.g. in sequence concatenation, it's easy to concatenate strings and then build FSA than concatenating FSAs directly. This was implemented by Daniel and I just want to make the PR for him.