### PR TITLE
Fix compilation of lm-utility tool

### DIFF
--- a/src/Tools/Lm/Makefile
+++ b/src/Tools/Lm/Makefile
@@ -61,7 +61,7 @@ install:
 	$(INSTALL) $(TARGETS) $(INSTALL_TARGET)
 
 lm-util$(exe): $(LM_UTIL_TOOL_O)
-	$(LD) $^ -o $@ $(LDFLAGS)
+	$(LD) $(LD_START_GROUP) $^ $(LD_END_GROUP) -o $@ $(LDFLAGS)
 
 include $(TOPDIR)/Rules.make
 


### PR DESCRIPTION
The Makefile of the `lm-util` tool was incorrect because the libraries are not in a group which can break when circular dependencies are present. This seemingly wasn't an issue before but breaks compilation now after the merge of #119. The wrap into `$(LD_START_GROUP) ... $(LD_END_GROUP)` is already present in the Makefiles of all other tools that use `LIBS_SEARCH` but was missing from `lm-util`.