### PR TITLE
Change order of pruning and recombination in the new search algorithms

### DIFF
--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -134,6 +134,7 @@ private:
     Core::StopWatch contextExtensionTime_;
 
     Core::Statistics<u32> numHypsAfterScorePruning_;
+    Core::Statistics<u32> numHypsAfterRecombination_;
     Core::Statistics<u32> numHypsAfterBeamPruning_;
     Core::Statistics<u32> numActiveHyps_;
 
@@ -155,7 +156,7 @@ private:
     /*
      * Helper function for pruning to maxBeamSize_
      */
-    void beamSizePruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions) const;
+    void beamSizePruning(std::vector<LabelHypothesis>& hypotheses) const;
 
     /*
      * Helper function for pruning to scoreThreshold_

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -134,10 +134,9 @@ private:
 
     // Pre-allocated intermediate vectors
     std::vector<ExtensionCandidate>       extensions_;
-    std::vector<ExtensionCandidate>       withinWordExtensions_;
-    std::vector<ExtensionCandidate>       wordEndExtensions_;
     std::vector<LabelHypothesis>          beam_;
     std::vector<LabelHypothesis>          newBeam_;
+    std::vector<LabelHypothesis>          wordEndHypotheses_;
     std::vector<Nn::LabelScorer::Request> requests_;
     std::vector<LabelHypothesis>          recombinedHypotheses_;
 
@@ -153,10 +152,13 @@ private:
     Core::StopWatch contextExtensionTime_;
 
     Core::Statistics<u32> numHypsAfterScorePruning_;
+    Core::Statistics<u32> numHypsAfterRecombination_;
     Core::Statistics<u32> numHypsAfterBeamPruning_;
     Core::Statistics<u32> numWordEndHypsAfterScorePruning_;
+    Core::Statistics<u32> numWordEndHypsAfterRecombination_;
     Core::Statistics<u32> numWordEndHypsAfterBeamPruning_;
     Core::Statistics<u32> numActiveHyps_;
+    Core::Statistics<u32> numActiveTrees_;
 
     LabelHypothesis const& getBestHypothesis() const;
     LabelHypothesis const& getWorstHypothesis() const;
@@ -173,7 +175,7 @@ private:
     /*
      * Helper function for pruning to maxBeamSize
      */
-    void beamSizePruning(std::vector<TreeTimesyncBeamSearch::ExtensionCandidate>& extensions, size_t maxBeamSize) const;
+    void beamSizePruning(std::vector<LabelHypothesis>& hypotheses, size_t maxBeamSize) const;
 
     /*
      * Helper function for pruning to scoreThreshold


### PR DESCRIPTION
We revisited the new search algorithms again and came to the conclusion that it is mathematically more correct to perform the recombination of the hypotheses/extensions first and prune them afterwards. 
As a small optimization, we decided to score-prune first, then call the recombination function and finally apply beam-size-pruning. This approach remains mathematically valid, but a bit more efficient as we avoid many unnecessary `labelScorer_->extendedScoringContext` calls.

A small additional feature I added is the logging about statistics on the number of active trees.