### PR TITLE
Add TransitionLabelScorer

### DIFF
--- a/src/Nn/LabelScorer/Makefile
+++ b/src/Nn/LabelScorer/Makefile
@@ -21,7 +21,8 @@ LIBSPRINTLABELSCORER_O =  \
     $(OBJDIR)/FixedContextOnnxLabelScorer.o \
     $(OBJDIR)/NoContextOnnxLabelScorer.o \
     $(OBJDIR)/NoOpLabelScorer.o \
-    $(OBJDIR)/ScoringContext.o
+    $(OBJDIR)/ScoringContext.o \
+    $(OBJDIR)/TransitionLabelScorer.o
 
 # -----------------------------------------------------------------------------
 

--- a/src/Nn/LabelScorer/TransitionLabelScorer.cc
+++ b/src/Nn/LabelScorer/TransitionLabelScorer.cc
@@ -1,0 +1,139 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "TransitionLabelScorer.hh"
+
+#include <Nn/Module.hh>
+
+#include "LabelScorer.hh"
+#include "ScoringContext.hh"
+
+namespace Nn {
+
+const Core::ParameterFloat TransitionLabelScorer::paramLabelToLabelScore(
+        "label-to-label-score",
+        "Score for label-to-label transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramLabelLoopScore(
+        "label-loop-score",
+        "Score for label-loop transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramLabelToBlankScore(
+        "label-to-blank-score",
+        "Score for label-to-blank transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramBlankToLabelScore(
+        "blank-to-label-score",
+        "Score for blank-to-label transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramBlankLoopScore(
+        "blank-loop-score",
+        "Score for blank-loop transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramInitialLabelScore(
+        "initial-label-score",
+        "Score for initial-label transitions",
+        0.0);
+
+const Core::ParameterFloat TransitionLabelScorer::paramInitialBlankScore(
+        "initial-blank-score",
+        "Score for initial-blank transitions",
+        0.0);
+
+TransitionLabelScorer::TransitionLabelScorer(Core::Configuration const& config)
+        : Core::Component(config),
+          Precursor(config),
+          labelToLabelScore_(paramLabelToLabelScore(config)),
+          labelLoopScore_(paramLabelLoopScore(config)),
+          labelToBlankScore_(paramLabelToBlankScore(config)),
+          blankToLabelScore_(paramBlankToLabelScore(config)),
+          blankLoopScore_(paramBlankLoopScore(config)),
+          initialLabelScore_(paramInitialLabelScore(config)),
+          initialBlankScore_(paramInitialBlankScore(config)),
+          baseLabelScorer_(Nn::Module::instance().labelScorerFactory().createLabelScorer(select("base-scorer"))) {}
+
+void TransitionLabelScorer::reset() {
+    baseLabelScorer_->reset();
+}
+
+void TransitionLabelScorer::signalNoMoreFeatures() {
+    baseLabelScorer_->signalNoMoreFeatures();
+}
+
+ScoringContextRef TransitionLabelScorer::getInitialScoringContext() {
+    return baseLabelScorer_->getInitialScoringContext();
+}
+
+ScoringContextRef TransitionLabelScorer::extendedScoringContext(LabelScorer::Request const& request) {
+    return baseLabelScorer_->extendedScoringContext(request);
+}
+
+void TransitionLabelScorer::cleanupCaches(Core::CollapsedVector<ScoringContextRef> const& activeContexts) {
+    baseLabelScorer_->cleanupCaches(activeContexts);
+}
+
+void TransitionLabelScorer::addInput(DataView const& input) {
+    baseLabelScorer_->addInput(input);
+}
+
+void TransitionLabelScorer::addInputs(DataView const& input, size_t nTimesteps) {
+    baseLabelScorer_->addInputs(input, nTimesteps);
+}
+
+std::optional<LabelScorer::ScoreWithTime> TransitionLabelScorer::computeScoreWithTime(LabelScorer::Request const& request) {
+    auto result = baseLabelScorer_->computeScoreWithTime(request);
+    if (result) {
+        result->score += getTransitionScore(request.transitionType);
+    }
+    return result;
+}
+
+std::optional<LabelScorer::ScoresWithTimes> TransitionLabelScorer::computeScoresWithTimes(std::vector<LabelScorer::Request> const& requests) {
+    auto results = baseLabelScorer_->computeScoresWithTimes(requests);
+    if (results) {
+        for (size_t i = 0ul; i < requests.size(); ++i) {
+            results->scores[i] += getTransitionScore(requests[i].transitionType);
+        }
+    }
+    return results;
+}
+
+LabelScorer::Score TransitionLabelScorer::getTransitionScore(LabelScorer::TransitionType transitionType) const {
+    switch (transitionType) {
+        case TransitionType::LABEL_TO_LABEL:
+            return labelToLabelScore_;
+        case TransitionType::LABEL_LOOP:
+            return labelLoopScore_;
+        case TransitionType::LABEL_TO_BLANK:
+            return labelToBlankScore_;
+        case TransitionType::BLANK_TO_LABEL:
+            return blankToLabelScore_;
+        case TransitionType::BLANK_LOOP:
+            return blankLoopScore_;
+        case TransitionType::INITIAL_LABEL:
+            return initialLabelScore_;
+        case TransitionType::INITIAL_BLANK:
+            return initialBlankScore_;
+        default:
+            error() << "Unknown transition type " << transitionType;
+    }
+    return 0;
+}
+
+}  // namespace Nn

--- a/src/Nn/LabelScorer/TransitionLabelScorer.hh
+++ b/src/Nn/LabelScorer/TransitionLabelScorer.hh
@@ -21,9 +21,9 @@
 namespace Nn {
 
 /*
- * Label Scorer that adds predefined transition scores to the scores of an underlying base
- * label scorer based on the transition type of each request.
- * The score for each transition type is set via config parameters.
+ * This PR adds a new label scorer `TransitionLabelScorer` which wraps a base LabelScorer
+ * and adds predefined transition scores to the base scores depending on the transition type of each request.
+ * The transition scores are all individually specified as config parameters.
  */
 class TransitionLabelScorer : public LabelScorer {
     static const Core::ParameterFloat paramLabelToLabelScore;

--- a/src/Nn/LabelScorer/TransitionLabelScorer.hh
+++ b/src/Nn/LabelScorer/TransitionLabelScorer.hh
@@ -1,0 +1,86 @@
+/** Copyright 2025 RWTH Aachen University. All rights reserved.
+ *
+ *  Licensed under the RWTH ASR License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.hltpr.rwth-aachen.de/rwth-asr/rwth-asr-license.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef TRANSITION_LABEL_SCORER_HH
+#define TRANSITION_LABEL_SCORER_HH
+
+#include "LabelScorer.hh"
+
+namespace Nn {
+
+/*
+ * Label Scorer that adds predefined transition scores to the scores of an underlying base
+ * label scorer based on the transition type of each request.
+ * The score for each transition type is set via config parameters.
+ */
+class TransitionLabelScorer : public LabelScorer {
+    static const Core::ParameterFloat paramLabelToLabelScore;
+    static const Core::ParameterFloat paramLabelLoopScore;
+    static const Core::ParameterFloat paramLabelToBlankScore;
+    static const Core::ParameterFloat paramBlankToLabelScore;
+    static const Core::ParameterFloat paramBlankLoopScore;
+    static const Core::ParameterFloat paramInitialLabelScore;
+    static const Core::ParameterFloat paramInitialBlankScore;
+
+public:
+    using Precursor = LabelScorer;
+
+    TransitionLabelScorer(Core::Configuration const& config);
+    virtual ~TransitionLabelScorer() = default;
+
+    // Reset base scorer
+    void reset() override;
+
+    // Forward signal to base scorer
+    void signalNoMoreFeatures() override;
+
+    // Initial context of base scorer
+    ScoringContextRef getInitialScoringContext() override;
+
+    // Extend context via base scorer
+    ScoringContextRef extendedScoringContext(Request const& request) override;
+
+    // Clean up base scorer
+    void cleanupCaches(Core::CollapsedVector<ScoringContextRef> const& activeContexts) override;
+
+    // Add input to base scorer
+    void addInput(DataView const& input) override;
+
+    // Add inputs to sub-scorer
+    void addInputs(DataView const& input, size_t nTimesteps) override;
+
+    // Compute score of base scorer and add transition score based on transition type of the request
+    std::optional<ScoreWithTime> computeScoreWithTime(Request const& request) override;
+
+    // Compute scores of base scorer and add transition scores based on transition types of the requests
+    std::optional<ScoresWithTimes> computeScoresWithTimes(std::vector<Request> const& requests) override;
+
+private:
+    Score labelToLabelScore_;
+    Score labelLoopScore_;
+    Score labelToBlankScore_;
+    Score blankToLabelScore_;
+    Score blankLoopScore_;
+    Score initialLabelScore_;
+    Score initialBlankScore_;
+
+    Core::Ref<LabelScorer> baseLabelScorer_;
+
+    Score getTransitionScore(TransitionType transitionType) const;
+};
+
+}  // namespace Nn
+
+#endif  // TRANSITION_LABEL_SCORER_HH

--- a/src/Nn/Module.cc
+++ b/src/Nn/Module.cc
@@ -23,6 +23,7 @@
 #include "LabelScorer/FixedContextOnnxLabelScorer.hh"
 #include "LabelScorer/NoContextOnnxLabelScorer.hh"
 #include "LabelScorer/NoOpLabelScorer.hh"
+#include "LabelScorer/TransitionLabelScorer.hh"
 #include "Statistics.hh"
 
 #ifdef MODULE_NN
@@ -119,6 +120,13 @@ Module_::Module_()
             "fixed-context-onnx",
             [](Core::Configuration const& config) {
                 return Core::ref(new FixedContextOnnxLabelScorer(config));
+            });
+
+    // Returns predefined scores based on the transition type of each score request
+    labelScorerFactory_.registerLabelScorer(
+            "transition",
+            [](Core::Configuration const& config) {
+                return Core::ref(new TransitionLabelScorer(config));
             });
 };
 


### PR DESCRIPTION
This PR adds a new label scorer `TransitionLabelScorer` which wraps a base LabelScorer and adds predefined transition scores to the base scores depending on the transition type of each request. The transition scores are all individually specified as config parameters.