### PR TITLE
Make special lemma "silence" optional in acoustic model

### DIFF
--- a/src/Am/AdaptationTree.cc
+++ b/src/Am/AdaptationTree.cc
@@ -29,6 +29,7 @@ AdaptationTree::AdaptationTree(const Core::Configuration&     c,
                                Bliss::Phoneme::Id             silencePhoneme)
         : Core::Component(c),
           treeDumpChannel_(config, "dump-tree") {
+    verify(silencePhoneme != Bliss::Phoneme::invalidId);
     numberOfBaseClasses_ = paramNumberOfBaseClasses(config);
     log("number of base classe for MLLR adaptation: ") << numberOfBaseClasses_;
 

--- a/src/Am/ClassicAcousticModel.cc
+++ b/src/Am/ClassicAcousticModel.cc
@@ -49,7 +49,7 @@ void ClassicAcousticModel::determineSilenceAllophoneStateIndex() {
             silenceAllophoneStateIndex_ = allophoneStateAlphabet()->index(&allo, 0);
         }
         else {
-            error("Could not determine silence allophone state index.");
+            error("Could not determine silence allophone state index. Probably, silence as no/an empty pronunciation in the lexicon.");
             silenceAllophoneStateIndex_ = Fsa::InvalidLabelId;
         }
     }

--- a/src/Am/ClassicAcousticModel.cc
+++ b/src/Am/ClassicAcousticModel.cc
@@ -39,31 +39,43 @@ void ClassicAcousticModel::determineSilencePhoneme() {
 }
 
 void ClassicAcousticModel::determineSilenceAllophoneStateIndex() {
-    LexiconUtilities            lexiconUtilities(config, lexiconRef_);
-    const Bliss::Pronunciation* silencePronunciation =
-            lexiconUtilities.determineSilencePronunciation()->pronunciation();
-    if (silencePronunciation) {
-        Allophone allo(stateModelRef_->phonology()(*silencePronunciation, 0),
-                       Allophone::isInitialPhone | Allophone::isFinalPhone);
-        silenceAllophoneStateIndex_ = allophoneStateAlphabet()->index(&allo, 0);
+    LexiconUtilities                 lexiconUtilities(config, lexiconRef_);
+    const Bliss::LemmaPronunciation* silenceLemmaPronunciation = lexiconUtilities.determineSilencePronunciation();
+    if (silenceLemmaPronunciation != &(Bliss::LemmaPronunciation::invalidPronunciation())) {
+        const Bliss::Pronunciation* silencePronunciation = silenceLemmaPronunciation->pronunciation();
+        if (silencePronunciation) {
+            Allophone allo(stateModelRef_->phonology()(*silencePronunciation, 0),
+                           Allophone::isInitialPhone | Allophone::isFinalPhone);
+            silenceAllophoneStateIndex_ = allophoneStateAlphabet()->index(&allo, 0);
+        }
+        else {
+            error("Could not determine silence allophone state index.");
+            silenceAllophoneStateIndex_ = Fsa::InvalidLabelId;
+        }
     }
     else {
-        error("Could not determine silence allophone state index.");
+        warning("Could not determine silence allophone state index.");
         silenceAllophoneStateIndex_ = Fsa::InvalidLabelId;
     }
 }
 
 AllophoneStateIndex ClassicAcousticModel::blankAllophoneStateIndex() const {
-    LexiconUtilities            lexiconUtilities(config, lexiconRef_);
-    const Bliss::Pronunciation* blankPronunciation =
-            lexiconUtilities.determineBlankPronunciation()->pronunciation();
-    if (blankPronunciation) {
-        Allophone allo(stateModelRef_->phonology()(*blankPronunciation, 0),
-                       Allophone::isInitialPhone | Allophone::isFinalPhone);
-        return allophoneStateAlphabet()->index(&allo, 0);
+    LexiconUtilities                 lexiconUtilities(config, lexiconRef_);
+    const Bliss::LemmaPronunciation* blankLemmaPronunciation = lexiconUtilities.determineBlankPronunciation();
+    if (blankLemmaPronunciation != &(Bliss::LemmaPronunciation::invalidPronunciation())) {
+        const Bliss::Pronunciation* blankPronunciation = blankLemmaPronunciation->pronunciation();
+        if (blankPronunciation) {
+            Allophone allo(stateModelRef_->phonology()(*blankPronunciation, 0),
+                           Allophone::isInitialPhone | Allophone::isFinalPhone);
+            return allophoneStateAlphabet()->index(&allo, 0);
+        }
+        else {
+            error("Could not determine blank allophone state index.");
+            return Fsa::InvalidLabelId;
+        }
     }
     else {
-        error("Could not determine blank allophone state index.");
+        warning("Could not determine blank allophone state index.");
         return Fsa::InvalidLabelId;
     }
 }

--- a/src/Am/ClassicAcousticModel.hh
+++ b/src/Am/ClassicAcousticModel.hh
@@ -89,7 +89,6 @@ public:
         return silence_;
     }
     virtual AllophoneStateIndex silenceAllophoneStateIndex() const {
-        verify(silenceAllophoneStateIndex_ != Fsa::InvalidLabelId);
         return silenceAllophoneStateIndex_;
     }
 

--- a/src/Am/ClassicAcousticModel.hh
+++ b/src/Am/ClassicAcousticModel.hh
@@ -89,6 +89,7 @@ public:
         return silence_;
     }
     virtual AllophoneStateIndex silenceAllophoneStateIndex() const {
+        verify(silenceAllophoneStateIndex_ != Fsa::InvalidLabelId);
         return silenceAllophoneStateIndex_;
     }
 
@@ -142,7 +143,7 @@ public:
             return transitionModel_->classify(phone, subState);
     }
     virtual StateTransitionIndex stateTransitionIndex(AllophoneStateIndex e, s8 subState = 0) const {
-        if (e == silenceAllophoneStateIndex())
+        if (silenceAllophoneStateIndex_ != Fsa::InvalidLabelId and e == silenceAllophoneStateIndex_)
             return TransitionModel::silence;
         else
             return transitionModel_->classifyIndex(e, subState);

--- a/src/Am/ClassicHmmTopologySet.hh
+++ b/src/Am/ClassicHmmTopologySet.hh
@@ -58,11 +58,14 @@ private:
     bool isAcrossWordModelEnabled_;
 
 public:
-    ClassicHmmTopologySet(const Core::Configuration&, Bliss::Phoneme::Id silenceId);
+    ClassicHmmTopologySet(const Core::Configuration&, Bliss::Phoneme::Id silenceId = Bliss::Phoneme::invalidId);
 
     void getDependencies(Core::DependencySet&) const;
 
     const ClassicHmmTopology* get(Bliss::Phoneme::Id phoneme) const {
+        if (silenceId_ == Bliss::Phoneme::invalidId) {
+            return &default_;
+        }
         return (phoneme != silenceId_ ? &default_ : &silence_);
     }
     const ClassicHmmTopology& getDefault() const {

--- a/src/Am/Utilities.cc
+++ b/src/Am/Utilities.cc
@@ -48,7 +48,7 @@ Bliss::Phoneme::Id LexiconUtilities::determineSilencePhoneme() const {
             else {
                 result = (*silencePronunciation)[0];
                 if (silencePronunciation->length() > 1)
-                    error("Silence pronunciation multiple phonemes. Using only /%s/",
+                    error("Silence pronunciation has multiple phonemes. Using only /%s/",
                           lexicon_->phonemeInventory()->phoneme(result)->symbol().str());
             }
         }

--- a/src/Bliss/Lexicon.hh
+++ b/src/Bliss/Lexicon.hh
@@ -106,6 +106,11 @@ public:
     const LemmaPronunciation* nextForThisPronunciation() const {
         return nextForThisPronunciation_;
     }
+
+    static const LemmaPronunciation& invalidPronunciation() {
+        static LemmaPronunciation invalidInstance(LemmaPronunciation::invalidId);
+        return invalidInstance;
+    }
 };
 
 /**

--- a/src/Bliss/Phoneme.hh
+++ b/src/Bliss/Phoneme.hh
@@ -119,7 +119,8 @@ class Phoneme : public Token {
 public:
     typedef u16                    Id;
     typedef Bliss::u16_char_traits Id_char_traits;
-    static const Id                term = 0;
+    static const Id                term      = 0;
+    static constexpr Id            invalidId = -1;
 
 private:
     bool isContextDependent_;

--- a/src/Nn/BufferedAlignedFeatureProcessor.cc
+++ b/src/Nn/BufferedAlignedFeatureProcessor.cc
@@ -66,6 +66,7 @@ void BufferedAlignedFeatureProcessor<T>::initAcousticModel() {
     modelCombination.load();
     acousticModel_ = modelCombination.acousticModel();
     /* set silence */
+    verify(acousticModel_->silence() != Bliss::Phoneme::invalidId);
     Am::Allophone silenceAllophone(acousticModel_->silence(), Am::Allophone::isInitialPhone | Am::Allophone::isFinalPhone);
     silence_ = classIndex(acousticModel_->allophoneStateAlphabet()->index(&silenceAllophone, 0));
     this->log("silence index is ") << silence_;

--- a/src/Nn/PythonControl.cc
+++ b/src/Nn/PythonControl.cc
@@ -687,6 +687,7 @@ struct PythonControl::Internal : public Core::Component {
         else {
             _initAcousticModel();
             silenceAllophoneStateIdx = acousticModel_->silenceAllophoneStateIndex();
+            verify(silenceAllophoneStateIdx != Fsa::InvalidLabelId);
         }
 
         std::shared_ptr<Core::Archive> a = getCacheArchive(cache_filename_c);

--- a/src/Nn/SegmentwiseNnTrainer.cc
+++ b/src/Nn/SegmentwiseNnTrainer.cc
@@ -406,6 +406,7 @@ void SegmentwiseNnTrainer<T>::setClassWeights() {
         NeuralNetworkTrainer<f32>::weightedAccumulation_ = true;
     }
     else if (silenceWeight != -1.0) {
+        verify(this->acousticModel()->silence() != Bliss::Phoneme::invalidId);
         Am::Allophone silenceAllophone(this->acousticModel()->silence(), Am::Allophone::isInitialPhone | Am::Allophone::isFinalPhone);
         u32           silence = this->acousticModel()->emissionIndex(this->acousticModel()->allophoneStateAlphabet()->index(&silenceAllophone, 0));
         this->log("silence index is ") << silence;

--- a/src/Search/LinearSearch.cc
+++ b/src/Search/LinearSearch.cc
@@ -35,6 +35,8 @@ LinearSearch::Pronunciation::Pronunciation(const Bliss::LemmaPronunciation* cons
     const Am::Phonology&        phonology = *(acousticModel->phonology());
     isRegularWord_                        = isRegularWordPrivate();
 
+    verify(acousticModel->silence() != Bliss::Phoneme::invalidId);
+
     for (u32 a = 0; a < pron->length(); a++) {
         const Am::Allophone* allo = 0;
 

--- a/src/Search/StateTree.cc
+++ b/src/Search/StateTree.cc
@@ -1058,7 +1058,10 @@ void StateTree::buildCoarticulatedRootStates(Bliss::LexiconRef lexicon) {
         ciRoot_ = states_.size();
         Am::LexiconUtilities lexiconUtilities(getConfiguration(), lexicon);
         boundaryPhonemes.initial = lexiconUtilities.determineSilencePhoneme();
-        boundaryPhonemes.final   = Bliss::Phoneme::term;
+        if (boundaryPhonemes.initial == Bliss::Phoneme::invalidId) {
+            criticalError("Failed to determine silence phoneme.");
+        }
+        boundaryPhonemes.final = Bliss::Phoneme::term;
         verify(cs.boundaryPhonemes.size() == ciRoot_);
         cs.boundaryPhonemes.push_back(boundaryPhonemes);
         BatchRequest* request = new BatchRequest(this, ciRoot_);

--- a/src/Search/TreeBuilder.cc
+++ b/src/Search/TreeBuilder.cc
@@ -1231,7 +1231,8 @@ CtcTreeBuilder::CtcTreeBuilder(Core::Configuration config, const Bliss::Lexicon&
     }
 
     // Set the StateDesc for blank
-    blankAllophoneStateIndex_       = acousticModel_.blankAllophoneStateIndex();
+    blankAllophoneStateIndex_ = acousticModel_.blankAllophoneStateIndex();
+    verify(blankAllophoneStateIndex_ != Fsa::InvalidLabelId);
     blankDesc_.acousticModel        = acousticModel_.emissionIndex(blankAllophoneStateIndex_);
     blankDesc_.transitionModelIndex = acousticModel_.stateTransitionIndex(blankAllophoneStateIndex_);
     require_lt(blankDesc_.transitionModelIndex, Core::Type<StateTree::StateDesc::TransitionModelIndex>::max);

--- a/src/Search/TreeBuilder.cc
+++ b/src/Search/TreeBuilder.cc
@@ -114,6 +114,8 @@ MinimizedTreeBuilder::MinimizedTreeBuilder(Core::Configuration config, const Bli
           repeatSilence_(paramRepeatSilence(config)),
           minimizeIterations_(paramMinimizeIterations(config)),
           reverse_(isBackwardRecognition(config)) {
+    require(lexicon.specialLemma("silence") != nullptr);
+
     if (allowCrossWordSkips_) {
         Score skipPenalty    = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::skip);
         Score forwardPenalty = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::forward);

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -184,16 +184,6 @@ bool TreeTimesyncBeamSearch::setModelCombination(Speech::ModelCombination const&
     acousticModel_ = modelCombination.acousticModel();
     languageModel_ = modelCombination.languageModel();
 
-    if (lexicon_->specialLemma("blank")) {
-        blankLabelIndex_ = acousticModel_->emissionIndex(acousticModel_->blankAllophoneStateIndex());
-        useBlank_        = true;
-        log() << "Use blank label with index " << blankLabelIndex_;
-    }
-    else {
-        blankLabelIndex_ = Nn::invalidLabelIndex;
-        useBlank_        = false;
-    }
-
     // Build the search tree
     log() << "Start building search tree";
     network_ = Core::ref(new PersistentStateTree(
@@ -211,6 +201,16 @@ bool TreeTimesyncBeamSearch::setModelCombination(Speech::ModelCombination const&
 
     std::unique_ptr<AbstractTreeBuilder> builder = Search::Module::instance().createTreeBuilder(config, *lexicon_, *acousticModel_, *network_);
     builder->build();
+
+    if (lexicon_->specialLemma("blank")) {
+        blankLabelIndex_ = acousticModel_->emissionIndex(acousticModel_->blankAllophoneStateIndex());
+        useBlank_        = true;
+        log() << "Use blank label with index " << blankLabelIndex_;
+    }
+    else {
+        blankLabelIndex_ = Nn::invalidLabelIndex;
+        useBlank_        = false;
+    }
 
     // Create look-ups for state successors and exits of each state
     createSuccessorLookups();

--- a/src/Speech/AdvancedAccuracyFsaBuilder.cc
+++ b/src/Speech/AdvancedAccuracyFsaBuilder.cc
@@ -191,13 +191,13 @@ OrthographyFrameStateAccuracyLatticeBuilder::Functor
         std::vector<std::string> shortPausesLemmata = paramShortPausesLemmata(config);
         if (!shortPausesLemmata.empty()) {
             if (shortPausesLemmata.size() == 1) {
+                require(lexicon_->specialLemma("silence") != nullptr);
                 std::string silence(shortPausesLemmata.front());
                 Core::normalizeWhitespace(silence);
                 log("Append short pause lemma \"") << silence << "\"";
                 const Bliss::Lemma* lemma = lexicon_->lemma(silence);
                 if (lemma == lexicon_->specialLemma("silence")) {
                     const Fsa::LabelId silAlloStateId = alignmentGenerator_->acousticModel()->silenceAllophoneStateIndex();
-                    verify(silAlloStateId != Fsa::InvalidLabelId);
                     shortPauses_.insert(silAlloStateId);
                 }
                 else {

--- a/src/Speech/AdvancedAccuracyFsaBuilder.cc
+++ b/src/Speech/AdvancedAccuracyFsaBuilder.cc
@@ -197,6 +197,7 @@ OrthographyFrameStateAccuracyLatticeBuilder::Functor
                 const Bliss::Lemma* lemma = lexicon_->lemma(silence);
                 if (lemma == lexicon_->specialLemma("silence")) {
                     const Fsa::LabelId silAlloStateId = alignmentGenerator_->acousticModel()->silenceAllophoneStateIndex();
+                    verify(silAlloStateId != Fsa::InvalidLabelId);
                     shortPauses_.insert(silAlloStateId);
                 }
                 else {

--- a/src/Speech/AlignmentWithLinearSegmentation.cc
+++ b/src/Speech/AlignmentWithLinearSegmentation.cc
@@ -392,7 +392,9 @@ void AlignmentWithLinearSegmentationNode::initialize() {
     modelCache_ = new FsaCache(select("model-cache"), Fsa::storeStates);
     modelCache_->setDependencies(dependencies);
 
-    segmenter_.setSilence(modelCombination.acousticModel()->silenceAllophoneStateIndex());
+    const Fsa::LabelId silAlloStateId = modelCombination.acousticModel()->silenceAllophoneStateIndex();
+    verify(silAlloStateId != Fsa::InvalidLabelId);
+    segmenter_.setSilence(silAlloStateId);
 
     needInit_ = false;
 }

--- a/src/Speech/AlignmentWithLinearSegmentation.cc
+++ b/src/Speech/AlignmentWithLinearSegmentation.cc
@@ -392,8 +392,7 @@ void AlignmentWithLinearSegmentationNode::initialize() {
     modelCache_ = new FsaCache(select("model-cache"), Fsa::storeStates);
     modelCache_->setDependencies(dependencies);
 
-    const Fsa::LabelId silAlloStateId = modelCombination.acousticModel()->silenceAllophoneStateIndex();
-    segmenter_.setSilence(silAlloStateId);
+    segmenter_.setSilence(modelCombination.acousticModel()->silenceAllophoneStateIndex());
 
     needInit_ = false;
 }

--- a/src/Speech/AlignmentWithLinearSegmentation.cc
+++ b/src/Speech/AlignmentWithLinearSegmentation.cc
@@ -393,7 +393,6 @@ void AlignmentWithLinearSegmentationNode::initialize() {
     modelCache_->setDependencies(dependencies);
 
     const Fsa::LabelId silAlloStateId = modelCombination.acousticModel()->silenceAllophoneStateIndex();
-    verify(silAlloStateId != Fsa::InvalidLabelId);
     segmenter_.setSilence(silAlloStateId);
 
     needInit_ = false;

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -378,7 +378,7 @@ Fsa::ConstAutomatonRef HMMTopologyGraphBuilder::buildTransducer(Fsa::ConstAutoma
 }
 
 Fsa::ConstAutomatonRef HMMTopologyGraphBuilder::applyMinimumDuration(Fsa::ConstAutomatonRef model) {
-    Fsa::LabelId                    silenceId  = acousticModel_->silenceAllophoneStateIndex();
+    Fsa::LabelId silenceId = acousticModel_->silenceAllophoneStateIndex();
     verify(silenceId != Fsa::InvalidLabelId);
     Core::Ref<Fsa::StaticAutomaton> automaton  = Fsa::staticCopy(model);
     Fsa::ConstAlphabetRef           inAlphabet = automaton->getInputAlphabet();

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -434,7 +434,9 @@ CTCTopologyGraphBuilder::CTCTopologyGraphBuilder(const Core::Configuration&     
     log() << "blank allophone id " << blankId_;
     // silence is allowed but not necessarily used
     silenceId_ = acousticModel_->silenceAllophoneStateIndex();
-    verify(silenceId_ != Fsa::InvalidLabelId);
+    if (silenceId_ == Fsa::InvalidLabelId) {
+        warning("No silence allophone state found.");
+    }
 }
 
 void CTCTopologyGraphBuilder::checkTransitionModel() {

--- a/src/Speech/AllophoneStateGraphBuilder.cc
+++ b/src/Speech/AllophoneStateGraphBuilder.cc
@@ -379,6 +379,7 @@ Fsa::ConstAutomatonRef HMMTopologyGraphBuilder::buildTransducer(Fsa::ConstAutoma
 
 Fsa::ConstAutomatonRef HMMTopologyGraphBuilder::applyMinimumDuration(Fsa::ConstAutomatonRef model) {
     Fsa::LabelId                    silenceId  = acousticModel_->silenceAllophoneStateIndex();
+    verify(silenceId != Fsa::InvalidLabelId);
     Core::Ref<Fsa::StaticAutomaton> automaton  = Fsa::staticCopy(model);
     Fsa::ConstAlphabetRef           inAlphabet = automaton->getInputAlphabet();
 
@@ -433,6 +434,7 @@ CTCTopologyGraphBuilder::CTCTopologyGraphBuilder(const Core::Configuration&     
     log() << "blank allophone id " << blankId_;
     // silence is allowed but not necessarily used
     silenceId_ = acousticModel_->silenceAllophoneStateIndex();
+    verify(silenceId_ != Fsa::InvalidLabelId);
 }
 
 void CTCTopologyGraphBuilder::checkTransitionModel() {


### PR DESCRIPTION
Up to now, the acoustic model always required a special lemma silence to be present in the lexicon. As I found this annoying, I dug a bit deeper and changed several things to make silence optional.

This mainly involved introducing an invalid phoneme ID and an invalid lemma pronunciation, which can be returned instead of directly throwing an error. We can then check for an invalid ID/pronunciation only when silence is actually required.

I'm aware that these changes are somewhat inelegant in parts, but achieving good code style would likely require a major refactoring of the acoustic model implementation. I did my best to ensure I didn’t break anything, but I would be thankful if you could double-check.