### PR TITLE
Introduce finalizeScoringContext function for updating hidden states

### DIFF
--- a/src/Nn/LabelScorer/CombineLabelScorer.hh
+++ b/src/Nn/LabelScorer/CombineLabelScorer.hh
@@ -48,6 +48,7 @@ public:
 
     // Combine extended ScoringContexts from all sub-scorers
     ScoringContextRef extendedScoringContext(Request const& request) override;
+    ScoringContextRef finalizeScoringContext(Request const& request) override;
 
     // Cleanup all sub-scorers
     void cleanupCaches(Core::CollapsedVector<ScoringContextRef> const& activeContexts) override;

--- a/src/Nn/LabelScorer/FullInputStatefulOnnxLabelScorer.hh
+++ b/src/Nn/LabelScorer/FullInputStatefulOnnxLabelScorer.hh
@@ -75,6 +75,7 @@ public:
 
     // Forward hidden-state through state-updater ONNX model
     Core::Ref<const ScoringContext> extendedScoringContext(LabelScorer::Request const& request) override;
+    Core::Ref<const ScoringContext> finalizeScoringContext(LabelScorer::Request const& request) override;
 
     // Add a single encoder outputs to buffer
     void addInput(DataView const& input) override;

--- a/src/Nn/LabelScorer/LabelScorer.cc
+++ b/src/Nn/LabelScorer/LabelScorer.cc
@@ -27,6 +27,10 @@ void LabelScorer::addInputs(DataView const& input, size_t nTimesteps) {
     }
 }
 
+ScoringContextRef LabelScorer::finalizeScoringContext(LabelScorer::Request const& request) {
+    return request.context;
+}
+
 std::optional<LabelScorer::ScoresWithTimes> LabelScorer::computeScoresWithTimes(std::vector<LabelScorer::Request> const& requests) {
     // By default, just loop over the non-batched `computeScoreWithTime` and collect the results
     ScoresWithTimes result;

--- a/src/Nn/LabelScorer/LabelScorer.hh
+++ b/src/Nn/LabelScorer/LabelScorer.hh
@@ -119,6 +119,8 @@ public:
 
     // Creates a copy of the context in the request that is extended using the given token and transition type
     virtual ScoringContextRef extendedScoringContext(Request const& request) = 0;
+    // Compute new hidden states (e.g. in the FullInputStatefulOnnxLabelScorer)
+    virtual ScoringContextRef finalizeScoringContext(Request const& request);
 
     // Given a collection of currently active contexts, this function can clean up values in any internal caches
     // or buffers that are saved for scoring contexts which no longer are active.

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -88,13 +88,14 @@ protected:
      * Struct containing all information about a single hypothesis in the beam
      */
     struct LabelHypothesis {
-        Nn::ScoringContextRef   scoringContext;  // Context to compute scores based on this hypothesis
-        Nn::LabelIndex          currentToken;    // Most recent token in associated label sequence (useful to infer transition type)
-        size_t                  length;          // Number of tokens in hypothesis for length normalization
-        Score                   score;           // Full score of hypothesis
-        Score                   scaledScore;     // Length-normalized score of hypothesis
-        Core::Ref<LatticeTrace> trace;           // Associated trace for traceback or lattice building off of hypothesis
-        bool                    isActive;        // Indicates whether the hypothesis has not produced a sentence-end label yet
+        Nn::ScoringContextRef           scoringContext;        // Context to compute scores based on this hypothesis
+        Nn::LabelIndex                  currentToken;          // Most recent token in associated label sequence (useful to infer transition type)
+        size_t                          length;                // Number of tokens in hypothesis for length normalization
+        Score                           score;                 // Full score of hypothesis
+        Score                           scaledScore;           // Length-normalized score of hypothesis
+        Core::Ref<LatticeTrace>         trace;                 // Associated trace for traceback or lattice building off of hypothesis
+        bool                            isActive;              // Indicates whether the hypothesis has not produced a sentence-end label yet
+        Nn::LabelScorer::TransitionType recentTransitionType;  // Type of most recently taken transition
 
         LabelHypothesis();
         LabelHypothesis(LabelHypothesis const& base, ExtensionCandidate const& extension, Nn::ScoringContextRef const& newScoringContext, float lengthNormScale);

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -50,7 +50,8 @@ LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
           currentToken(extension.nextToken),
           timeframe(base.timeframe),
           score(extension.score),
-          trace(base.trace) {
+          trace(base.trace),
+          recentTransitionType(extension.transitionType) {
     switch (extension.transitionType) {
         case Nn::LabelScorer::TransitionType::BLANK_TO_LABEL:
         case Nn::LabelScorer::TransitionType::LABEL_TO_BLANK:
@@ -417,6 +418,15 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
     numHypsAfterBeamPruning_ += newBeam_.size();
     if (logStepwiseStatistics_) {
         clog() << Core::XmlFull("num-hyps-after-beam-pruning", newBeam_.size());
+    }
+
+    for (auto& hyp : newBeam_) {
+        auto newScoringContext = labelScorer_->finalizeScoringContext(
+                {hyp.scoringContext,
+                 hyp.currentToken,
+                 hyp.recentTransitionType});
+
+        hyp.scoringContext = newScoringContext;
     }
 
     beam_.swap(newBeam_);

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -88,12 +88,13 @@ protected:
      * Struct containing all information about a single hypothesis in the beam
      */
     struct LabelHypothesis {
-        Nn::ScoringContextRef            scoringContext;  // Context to compute scores based on this hypothesis
-        Bliss::LemmaPronunciation const* currentPron;     // Pronunciation of the currently ongoing lemma
-        Nn::LabelIndex                   currentToken;    // Most recent token in associated label sequence (useful to infer transition type)
-        Search::TimeframeIndex           timeframe;       // Timestamp of `currentToken` for traceback
-        Score                            score;           // Full score of hypothesis
-        Core::Ref<LatticeTrace>          trace;           // Associated trace for traceback or lattice building off of hypothesis
+        Nn::ScoringContextRef            scoringContext;        // Context to compute scores based on this hypothesis
+        Bliss::LemmaPronunciation const* currentPron;           // Pronunciation of the currently ongoing lemma
+        Nn::LabelIndex                   currentToken;          // Most recent token in associated label sequence (useful to infer transition type)
+        Search::TimeframeIndex           timeframe;             // Timestamp of `currentToken` for traceback
+        Score                            score;                 // Full score of hypothesis
+        Core::Ref<LatticeTrace>          trace;                 // Associated trace for traceback or lattice building off of hypothesis
+        Nn::LabelScorer::TransitionType  recentTransitionType;  // Type of most recently taken transition
 
         LabelHypothesis();
         LabelHypothesis(LabelHypothesis const& base, ExtensionCandidate const& extension, Nn::ScoringContextRef const& newScoringContext);

--- a/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
+++ b/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
@@ -58,7 +58,8 @@ TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
           score(extension.score),
           scaledScore(extension.scaledScore),
           trace(base.trace),
-          isActive(extension.transitionType != Nn::LabelScorer::TransitionType::SENTENCE_END) {
+          isActive(extension.transitionType != Nn::LabelScorer::TransitionType::SENTENCE_END),
+          recentTransitionType(extension.transitionType) {
 }
 
 TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
@@ -423,6 +424,15 @@ bool TreeLabelsyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-hyps-after-beam-pruning", withinWordHypotheses_.size());
     }
     numHypsAfterBeamPruning_ += withinWordHypotheses_.size();
+
+    for (auto& hyp : newBeam_) {
+        auto newScoringContext = labelScorer_->finalizeScoringContext(
+                {hyp.scoringContext,
+                 hyp.currentToken,
+                 hyp.recentTransitionType});
+
+        hyp.scoringContext = newScoringContext;
+    }
 
     /*
      * Word-end hypotheses

--- a/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.hh
+++ b/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.hh
@@ -66,16 +66,17 @@ protected:
      * Struct containing all information about a single hypothesis in the beam
      */
     struct LabelHypothesis {
-        Nn::ScoringContextRef   scoringContext;  // Context to compute scores based on this hypothesis
-        Nn::LabelIndex          currentToken;    // Most recent token in associated label sequence (useful to infer transition type)
-        StateId                 currentState;    // Current state in the search tree
-        Lm::History             lmHistory;       // Language model history
-        size_t                  length;          // Number of tokens in hypothesis for length normalization
-        Speech::TimeframeIndex  time;            // Timeframe of current token
-        Score                   score;           // Full score of hypothesis
-        Score                   scaledScore;     // Length-normalized score of hypothesis
-        Core::Ref<LatticeTrace> trace;           // Associated trace for traceback or lattice building off of hypothesis
-        bool                    isActive;        // Indicates whether the hypothesis has not produced a sentence-end label yet
+        Nn::ScoringContextRef           scoringContext;        // Context to compute scores based on this hypothesis
+        Nn::LabelIndex                  currentToken;          // Most recent token in associated label sequence (useful to infer transition type)
+        StateId                         currentState;          // Current state in the search tree
+        Lm::History                     lmHistory;             // Language model history
+        size_t                          length;                // Number of tokens in hypothesis for length normalization
+        Speech::TimeframeIndex          time;                  // Timeframe of current token
+        Score                           score;                 // Full score of hypothesis
+        Score                           scaledScore;           // Length-normalized score of hypothesis
+        Core::Ref<LatticeTrace>         trace;                 // Associated trace for traceback or lattice building off of hypothesis
+        bool                            isActive;              // Indicates whether the hypothesis has not produced a sentence-end label yet
+        Nn::LabelScorer::TransitionType recentTransitionType;  // Type of most recently taken transition
 
         LabelHypothesis();
 

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -462,6 +462,15 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-hyps-after-beam-pruning", newBeam_.size());
     }
 
+    for (auto& hyp : newBeam_) {
+        auto newScoringContext = labelScorer_->finalizeScoringContext(
+                {hyp.scoringContext,
+                 hyp.currentToken,
+                 hyp.recentTransitionType});
+
+        hyp.scoringContext = newScoringContext;
+    }
+
     /*
      * Expand hypotheses to word-end hypotheses and incorporate the language model
      */


### PR DESCRIPTION
The function `finalizeScoringContext()` is added to the LabelScorer. Default implementation just returns the context of the request. The `FullInputStatefulOnnxLabelScorer` won't update the hidden state in `extendedScoringContext()` anymore, but only append the new token to the sequence. The hidden state update is now done in `finalizeScoringContext()`. In the search algorithms, the order is now:

1. Score Pruning
2. Extended Scoring Context
3. Recombination
4. Beam Size Pruning
5. Finalize Scoring Context

The code could be a bit nicer with a flag "updateHiddenStates" in `extendedScoringContext()` or similar, instead of introducing a new, separate function, but it works for now. Not tested with the labelsync searches yet.