### PR TITLE
Modify TreeTimesyncBeamSearch: don't force LM to ignore blank and silence

### DIFF
--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -428,7 +428,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
                                                     hypIndex};
 
                 const Bliss::SyntacticTokenSequence sts = lemma->syntacticTokenSequence();
-                if (not(sts.size() == 0)) {
+                if (sts.size() != 0) {
                     require(sts.size() == 1);
                     const Bliss::SyntacticToken* st = sts.front();
 
@@ -456,7 +456,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
     for (auto& extension : extensions_) {
         const Bliss::Lemma*                 lemma = extension.pron->lemma();
         const Bliss::SyntacticTokenSequence sts   = lemma->syntacticTokenSequence();
-        if (not(sts.size() == 0)) {
+        if (sts.size() != 0) {
             require(sts.size() == 1);
             const Bliss::SyntacticToken* st = sts.front();
             extension.lmHistory             = languageModel_->extendedHistory(extension.lmHistory, st);


### PR DESCRIPTION
In the TreeTimesyncBeamSearch, we had a hardcoded check to force the LM to ignore the blank and silence lemma. There are however use cases where blank or silence are part of the LM as well. Therefore, we removed this hardcoded check and only check if the syntactic token sequence is not empty.
This also means that in the special lemmas blank and silence, the user needs to set `<synt/>` in the lexicon, otherwise the LM will score these lemmas. As this can easily happen by mistake, we added a warning for that.