### PR TITLE
Update build config: use C++20 standard

### DIFF
--- a/apptainer/2023-05-08_tensorflow-2.8_v1/makefiles/config/cc-gcc.make
+++ b/apptainer/2023-05-08_tensorflow-2.8_v1/makefiles/config/cc-gcc.make
@@ -26,7 +26,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas -Werror=return-type
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall

--- a/apptainer/2023-08-09_tensorflow-2.8_onnx-1.15_v1/makefiles/config/cc-gcc.make
+++ b/apptainer/2023-08-09_tensorflow-2.8_onnx-1.15_v1/makefiles/config/cc-gcc.make
@@ -26,7 +26,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas -Werror=return-type
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -fPIC

--- a/apptainer/2023-11-08_tensorflow-2.14_v1/makefiles/config/cc-gcc.make
+++ b/apptainer/2023-11-08_tensorflow-2.14_v1/makefiles/config/cc-gcc.make
@@ -27,7 +27,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas -Werror=return-type
 CCFLAGS		+= -Wall
 CCFLAGS		+= -Wno-long-long

--- a/apptainer/2025-04-23_tensorflow-2.17_onnx-1.20_v1/makefiles/config/cc-gcc.make
+++ b/apptainer/2025-04-23_tensorflow-2.17_onnx-1.20_v1/makefiles/config/cc-gcc.make
@@ -27,7 +27,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall

--- a/apptainer/2025-04-23_tensorflow-2.17_onnx-1.20_v2/makefiles/config/cc-gcc.make
+++ b/apptainer/2025-04-23_tensorflow-2.17_onnx-1.20_v2/makefiles/config/cc-gcc.make
@@ -27,7 +27,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall

--- a/config/cc-gcc.make
+++ b/config/cc-gcc.make
@@ -27,7 +27,7 @@ CCFLAGS		+= -pipe
 CCFLAGS		+= -funsigned-char
 CCFLAGS		+= -fno-exceptions
 CFLAGS		+= -std=c99
-CXXFLAGS	+= -std=c++17
+CXXFLAGS	+= -std=c++20
 CXXFLAGS	+= -Wno-unknown-pragmas -Werror=return-type
 #CCFLAGS	+= -pedantic
 CCFLAGS		+= -Wall


### PR DESCRIPTION
This simply changes `-std=c++17` to `-std=c++20` for compilation. C++20 features are used in #138. Alternatively, we could also directly jump to C++23 because why not.