### PR TITLE
Add histogram pruning for SearchV2 algorithms

### DIFF
--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -114,6 +114,12 @@ const Core::ParameterFloat LexiconfreeLabelsyncBeamSearch::paramScoreThreshold(
         "If not set, no score pruning will be done.",
         Core::Type<Score>::max, 0);
 
+const Core::ParameterInt LexiconfreeLabelsyncBeamSearch::paramNumHistogramBins(
+        "num-histogram-bins",
+        "Number of bins for histogram pruning of hypotheses (very minor effect).",
+        100,
+        2);
+
 const Core::ParameterInt LexiconfreeLabelsyncBeamSearch::paramSentenceEndLabelIndex(
         "sentence-end-label-index",
         "Index of the sentence-end label in the lexicon."
@@ -144,6 +150,7 @@ LexiconfreeLabelsyncBeamSearch::LexiconfreeLabelsyncBeamSearch(Core::Configurati
           SearchAlgorithmV2(config),
           maxBeamSize_(paramMaxBeamSize(config)),
           scoreThreshold_(paramScoreThreshold(config)),
+          scoreHistogram_(paramNumHistogramBins(config)),
           lengthNormScale_(paramLengthNormScale(config)),
           maxLabelsPerTimestep_(paramMaxLabelsPerTimestep(config)),
           sentenceEndLabelIndex_(paramSentenceEndLabelIndex(config)),
@@ -376,7 +383,7 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
      * Maybe prune set of possible extensions by score.
      */
     if (useScorePruning_) {
-        scorePruningExtensions();
+        scorePruning(extensions_, scoreThreshold_, extensions_.size());
         if (logStepwiseStatistics_) {
             clog() << Core::XmlFull("num-extensions-after-score-pruning", extensions_.size());
         }
@@ -407,7 +414,7 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
      * Jointly prune terminated and active hypotheses by score
      */
     if (useScorePruning_) {
-        scorePruning();
+        scorePruning(newBeam_, scoreThreshold_, newBeam_.size());
 
         size_t numActive     = numActiveHyps();
         size_t numTerminated = newBeam_.size() - numActive;
@@ -438,7 +445,7 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-active-hyps-after-recombination", numActive);
     }
 
-    beamSizePruning();
+    scorePruning(newBeam_, Core::Type<Score>::max, maxBeamSize_);
 
     numActive     = numActiveHyps();
     numTerminated = newBeam_.size() - numActive;
@@ -612,52 +619,61 @@ void LexiconfreeLabelsyncBeamSearch::logStatistics() const {
     numActiveHypsAfterBeamPruning_.write(clog());
 }
 
-void LexiconfreeLabelsyncBeamSearch::beamSizePruning() {
-    if (newBeam_.size() <= maxBeamSize_) {
+template<typename Element>
+void LexiconfreeLabelsyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
+    if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
+        // Neither relative score pruning nor max beam size pruning triggers
         return;
     }
 
-    // Reorder the hypotheses by associated score value such that the first `maxBeamSize_` elements are the best
-    std::nth_element(newBeam_.begin(), newBeam_.begin() + maxBeamSize_, newBeam_.end());
-    newBeam_.resize(maxBeamSize_);  // Get rid of excessive elements
-}
+    // Find ranges for score histogram and setting absolute threshold
+    Score lowerScore = Core::Type<Score>::max;
+    Score upperScore = Core::Type<Score>::min;
 
-void LexiconfreeLabelsyncBeamSearch::scorePruningExtensions() {
-    if (extensions_.empty()) {
+    for (auto const& hyp : hypotheses) {
+        lowerScore = std::min(lowerScore, hyp.pruningScore());
+        upperScore = std::max(upperScore, hyp.pruningScore());
+    }
+
+    if (lowerScore == upperScore) {
+        // All scores are the same (usually only happens when exactly 1 hyp is active)
+        if (hypotheses.size() > maxBeamSize) {
+            hypotheses.resize(maxBeamSize);
+        }
         return;
     }
 
-    // Compute the pruning threshold
-    auto bestScore        = std::min_element(extensions_.begin(), extensions_.end())->score;
-    auto pruningThreshold = bestScore + scoreThreshold_;
+    Score absoluteThreshold = upperScore;
 
-    // Remove elements with score > pruningThreshold
-    extensions_.erase(
+    // Pruning by relative score threshold
+    if (relativeThreshold != Core::Type<Score>::max) {
+        absoluteThreshold = lowerScore + relativeThreshold;
+    }
+
+    // Pruning by max beam size
+    if (hypotheses.size() > maxBeamSize) {
+        scoreHistogram_.clear();
+        scoreHistogram_.setLimits(lowerScore, upperScore);
+
+        for (auto const& hyp : hypotheses) {
+            scoreHistogram_ += hyp.pruningScore();
+        }
+
+        absoluteThreshold = std::min(absoluteThreshold, scoreHistogram_.quantile(maxBeamSize));
+    }
+
+    if (absoluteThreshold >= upperScore) {
+        // Nothing will be pruned
+        return;
+    }
+
+    // Remove elements with score > absoluteThreshold
+    hypotheses.erase(
             std::remove_if(
-                    extensions_.begin(),
-                    extensions_.end(),
-                    [&](auto const& ext) { return ext.score > pruningThreshold; }),
-            extensions_.end());
-}
-
-void LexiconfreeLabelsyncBeamSearch::scorePruning() {
-    if (newBeam_.empty()) {
-        return;
-    }
-
-    // Compute the pruning threshold
-    auto bestHyp = *std::min_element(
-            newBeam_.begin(),
-            newBeam_.end());
-
-    // Remove elements with score > pruningThreshold
-    auto pruningThreshold = (bestHyp.score + scoreThreshold_) / std::pow(bestHyp.length, lengthNormScale_);
-    newBeam_.erase(
-            std::remove_if(
-                    newBeam_.begin(),
-                    newBeam_.end(),
-                    [&](auto const& hyp) { return hyp.scaledScore > pruningThreshold; }),
-            newBeam_.end());
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [absoluteThreshold](auto const& hyp) { return hyp.pruningScore() > absoluteThreshold; }),
+            hypotheses.end());
 }
 
 void LexiconfreeLabelsyncBeamSearch::recombination() {

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -23,6 +23,7 @@
 #include <Nn/LabelScorer/DataView.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
+#include <Search/Histogram.hh>
 #include <Search/SearchV2.hh>
 #include <Search/Traceback.hh>
 
@@ -42,6 +43,7 @@ class LexiconfreeLabelsyncBeamSearch : public SearchAlgorithmV2 {
 public:
     static const Core::ParameterInt   paramMaxBeamSize;
     static const Core::ParameterFloat paramScoreThreshold;
+    static const Core::ParameterInt   paramNumHistogramBins;
 
     static const Core::ParameterInt   paramSentenceEndLabelIndex;
     static const Core::ParameterBool  paramCacheCleanupInterval;
@@ -78,6 +80,10 @@ protected:
         Nn::LabelScorer::TransitionType  transitionType;  // Type of transition toward `nextToken`
         size_t                           baseHypIndex;    // Index of base hypothesis in global beam
 
+        inline Score pruningScore() const {
+            return score;
+        }
+
         bool operator<(ExtensionCandidate const& other) const {
             return score < other.score;
         }
@@ -98,6 +104,10 @@ protected:
         LabelHypothesis();
         LabelHypothesis(LabelHypothesis const& base, ExtensionCandidate const& extension, Nn::ScoringContextRef const& newScoringContext, float lengthNormScale);
 
+        inline Score pruningScore() const {
+            return scaledScore;
+        }
+
         bool operator<(LabelHypothesis const& other) const {
             return scaledScore < other.scaledScore;
         }
@@ -116,6 +126,7 @@ private:
     size_t         maxBeamSize_;
     bool           useScorePruning_;
     Score          scoreThreshold_;
+    Histogram      scoreHistogram_;
     float          lengthNormScale_;
     float          maxLabelsPerTimestep_;
     Nn::LabelIndex sentenceEndLabelIndex_;
@@ -163,19 +174,11 @@ private:
     void logStatistics() const;
 
     /*
-     * Helper function for pruning of hyps to `maxBeamSize_`
+     * Helper function for acoustic pruning of hypotheses. Calculates an absolute threshold based on best score + relative threshold and
+     * score histogram. Removes all extensions worse than the absolute threshold.
      */
-    void beamSizePruning();
-
-    /*
-     * Helper function for pruning of extensions to `scoreThreshold_`
-     */
-    void scorePruningExtensions();
-
-    /*
-     * Helper function for pruning of hyps to `scoreThreshold_`
-     */
-    void scorePruning();
+    template<typename Element>
+    void scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize);
 
     /*
      * Helper function for recombination of hypotheses with the same scoring context

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -444,22 +444,22 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
             clog() << Core::XmlFull("num-hyps-after-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
         }
         numHypsAfterIntermediatePruning_[scorerIdx] += extensions_.size();
+    }
 
-        // Create new beam from surviving extensions.
-        newBeam_.clear();
-        for (auto const& extension : extensions_) {
-            auto const& baseHyp = beam_[extension.baseHypIndex];
+    // Create new beam from surviving extensions.
+    newBeam_.clear();
+    for (auto const& extension : extensions_) {
+        auto const& baseHyp = beam_[extension.baseHypIndex];
 
-            std::vector<Nn::ScoringContextRef> newScoringContexts;
-            for (size_t scorerIdx = 0ul; scorerIdx < labelScorers_.size(); ++scorerIdx) {
-                newScoringContexts.push_back(labelScorers_[scorerIdx]->extendedScoringContext(
-                        {baseHyp.scoringContexts[scorerIdx],
-                         extension.nextToken,
-                         extension.transitionType}));
-            }
-
-            newBeam_.push_back({baseHyp, extension, newScoringContexts});
+        std::vector<Nn::ScoringContextRef> newScoringContexts;
+        for (size_t scorerIdx = 0ul; scorerIdx < labelScorers_.size(); ++scorerIdx) {
+            newScoringContexts.push_back(labelScorers_[scorerIdx]->extendedScoringContext(
+                    {baseHyp.scoringContexts[scorerIdx],
+                     extension.nextToken,
+                     extension.transitionType}));
         }
+
+        newBeam_.push_back({baseHyp, extension, newScoringContexts});
     }
 
     // For all hypotheses with the same scoring context keep only the best since they will all develop in the same way.

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -609,7 +609,7 @@ Nn::LabelScorer::TransitionType LexiconfreeTimesyncBeamSearch::inferTransitionTy
 }
 
 template<typename Element>
-void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) const {
+void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
     if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
         // Neither relative score pruning nor max beam size pruning triggers
         return;
@@ -665,8 +665,8 @@ void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypothese
             hypotheses.end());
 }
 
-template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>&, Score, size_t) const;
-template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::LabelHypothesis>(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>&, Score, size_t) const;
+template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>&, Score, size_t);
+template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::LabelHypothesis>(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>&, Score, size_t);
 
 void LexiconfreeTimesyncBeamSearch::recombination(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>& hypotheses) {
     // Represents a unique combination of currentToken and scoringContext

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -23,6 +23,7 @@
 #include <Lattice/LatticeAdaptor.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
+#include <Search/Histogram.hh>
 #include <Search/Traceback.hh>
 #include <Search/TracebackHelper.hh>
 
@@ -101,6 +102,12 @@ const Core::ParameterFloatVector LexiconfreeTimesyncBeamSearch::paramScoreThresh
         0,
         Core::Type<Score>::max);
 
+const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramNumHistogramBins(
+        "num-histogram-bins",
+        "Number of bins for histogram pruning of hypotheses (very minor effect).",
+        100,
+        2);
+
 const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramBlankLabelIndex(
         "blank-label-index",
         "Index of the blank label in the lexicon. Can also be inferred from lexicon if it has a lemma with `special='blank'`. If not set, the search will not use blank.",
@@ -152,6 +159,7 @@ const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaximumStableDelayP
 LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
           SearchAlgorithmV2(config),
+          scoreHistogram_(paramNumHistogramBins(config)),
           blankLabelIndex_(paramBlankLabelIndex(config)),
           allowBlankAfterSentenceEnd_(paramAllowBlankAfterSentenceEnd(config)),
           sentenceEndLemma_(),
@@ -173,6 +181,7 @@ LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration
           featureProcessingTime_(),
           scoringTime_(),
           numHypsAfterRecombination_("num-hyps-after-recombination"),
+          numHypsAfterPruning_("num-hyps-after-pruning"),
           numActiveHyps_("num-active-hyps"),
           currentSearchStep_(0ul),
           finishedSegment_(false) {
@@ -195,11 +204,8 @@ LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration
         useScorePruning_.push_back(scoreThresholds_[i] != Core::Type<Score>::max);
     }
 
-    for (size_t i = 1ul; i <= scoreThresholds_.size(); ++i) {
-        numHypsAfterScorePruning_.push_back({"num-hyps-after-score-pruning-" + std::to_string(i)});
-    }
     for (size_t i = 1ul; i <= maxBeamSizes_.size(); ++i) {
-        numHypsAfterBeamPruning_.push_back({"num-hyps-after-beam-pruning-" + std::to_string(i)});
+        numHypsAfterIntermediatePruning_.push_back({"num-hyps-after-intermediate-pruning-" + std::to_string(i)});
     }
 
     useSentenceEnd_ = sentenceEndLabelIndex_ != Nn::invalidLabelIndex;
@@ -429,41 +435,31 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
         /*
          * Prune set of possible extensions by max beam size and possibly also by score.
          */
-
-        if (useScorePruning_[scorerIdx]) {
-            scorePruning(extensions_, scoreThresholds_[scorerIdx]);
-
-            numHypsAfterScorePruning_[scorerIdx] += extensions_.size();
-
-            if (logStepwiseStatistics_) {
-                clog() << Core::XmlFull("num-hyps-after-score-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
-            }
-        }
-
+        size_t maxBeamSize = extensions_.size();
         if (scorerIdx < labelScorers_.size() - 1) {
-            beamSizePruning(extensions_, maxBeamSizes_[scorerIdx]);
-            numHypsAfterBeamPruning_[scorerIdx] += extensions_.size();
+            maxBeamSize = maxBeamSizes_[scorerIdx];
+        }
+        scorePruning(extensions_, scoreThresholds_[scorerIdx], maxBeamSize);
+        if (logStepwiseStatistics_) {
+            clog() << Core::XmlFull("num-hyps-after-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
+        }
+        numHypsAfterIntermediatePruning_[scorerIdx] += extensions_.size();
 
-            if (logStepwiseStatistics_) {
-                clog() << Core::XmlFull("num-hyps-after-beam-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
+        // Create new beam from surviving extensions.
+        newBeam_.clear();
+        for (auto const& extension : extensions_) {
+            auto const& baseHyp = beam_[extension.baseHypIndex];
+
+            std::vector<Nn::ScoringContextRef> newScoringContexts;
+            for (size_t scorerIdx = 0ul; scorerIdx < labelScorers_.size(); ++scorerIdx) {
+                newScoringContexts.push_back(labelScorers_[scorerIdx]->extendedScoringContext(
+                        {baseHyp.scoringContexts[scorerIdx],
+                         extension.nextToken,
+                         extension.transitionType}));
             }
+
+            newBeam_.push_back({baseHyp, extension, newScoringContexts});
         }
-    }
-
-    // Create new beam from surviving extensions.
-    newBeam_.clear();
-    for (auto const& extension : extensions_) {
-        auto const& baseHyp = beam_[extension.baseHypIndex];
-
-        std::vector<Nn::ScoringContextRef> newScoringContexts;
-        for (size_t scorerIdx = 0ul; scorerIdx < labelScorers_.size(); ++scorerIdx) {
-            newScoringContexts.push_back(labelScorers_[scorerIdx]->extendedScoringContext(
-                    {baseHyp.scoringContexts[scorerIdx],
-                     extension.nextToken,
-                     extension.transitionType}));
-        }
-
-        newBeam_.push_back({baseHyp, extension, newScoringContexts});
     }
 
     // For all hypotheses with the same scoring context keep only the best since they will all develop in the same way.
@@ -473,10 +469,10 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-hyps-after-recombination", newBeam_.size());
     }
 
-    beamSizePruning(newBeam_, maxBeamSizes_[labelScorers_.size() - 1]);
-    numHypsAfterBeamPruning_[labelScorers_.size() - 1] += newBeam_.size();
+    scorePruning(newBeam_, Core::Type<Score>::max, maxBeamSizes_[labelScorers_.size() - 1]);
+    numHypsAfterPruning_ += newBeam_.size();
     if (logStepwiseStatistics_) {
-        clog() << Core::XmlFull("num-hyps-after-beam-pruning-" + std::to_string(labelScorers_.size()), newBeam_.size());
+        clog() << Core::XmlFull("num-hyps-after-pruning" + std::to_string(labelScorers_.size()), newBeam_.size());
     }
 
     numActiveHyps_ += newBeam_.size();
@@ -546,13 +542,11 @@ void LexiconfreeTimesyncBeamSearch::resetStatistics() {
     initializationTime_.reset();
     featureProcessingTime_.reset();
     scoringTime_.reset();
-    for (auto& stat : numHypsAfterScorePruning_) {
-        stat.clear();
-    }
-    for (auto& stat : numHypsAfterBeamPruning_) {
+    for (auto& stat : numHypsAfterIntermediatePruning_) {
         stat.clear();
     }
     numHypsAfterRecombination_.clear();
+    numHypsAfterPruning_.clear();
     numActiveHyps_.clear();
 }
 
@@ -562,13 +556,11 @@ void LexiconfreeTimesyncBeamSearch::logStatistics() const {
     clog() << Core::XmlOpen("feature-processing-time") << featureProcessingTime_.elapsedMilliseconds() << Core::XmlClose("feature-processing-time");
     clog() << Core::XmlOpen("scoring-time") << scoringTime_.elapsedMilliseconds() << Core::XmlClose("scoring-time");
     clog() << Core::XmlClose("timing-statistics");
-    for (auto const& stat : numHypsAfterScorePruning_) {
-        stat.write(clog());
-    }
-    for (auto const& stat : numHypsAfterBeamPruning_) {
+    for (auto const& stat : numHypsAfterIntermediatePruning_) {
         stat.write(clog());
     }
     numHypsAfterRecombination_.write(clog());
+    numHypsAfterPruning_.write(clog());
     numActiveHyps_.write(clog());
 }
 
@@ -617,36 +609,64 @@ Nn::LabelScorer::TransitionType LexiconfreeTimesyncBeamSearch::inferTransitionTy
 }
 
 template<typename Element>
-void LexiconfreeTimesyncBeamSearch::beamSizePruning(std::vector<Element>& hypotheses, size_t maxSize) const {
-    if (hypotheses.size() <= maxSize) {
+void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) const {
+    if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
+        // Neither relative score pruning nor max beam size pruning triggers
         return;
     }
 
-    // Reorder the hypotheses by associated score value such that the first `beamSize_` elements are the best
-    std::nth_element(hypotheses.begin(), hypotheses.begin() + maxSize, hypotheses.end());
-    hypotheses.resize(maxSize);  // Get rid of excessive elements
-}
+    // Find ranges for score histogram and setting absolute threshold
+    Score lowerScore = Core::Type<Score>::max;
+    Score upperScore = Core::Type<Score>::min;
 
-template void LexiconfreeTimesyncBeamSearch::beamSizePruning<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>&, size_t) const;
-template void LexiconfreeTimesyncBeamSearch::beamSizePruning<LexiconfreeTimesyncBeamSearch::LabelHypothesis>(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>&, size_t) const;
+    for (auto const& hyp : hypotheses) {
+        lowerScore = std::min(lowerScore, hyp.score);
+        upperScore = std::max(upperScore, hyp.score);
+    }
 
-void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions, Score threshold) const {
-    if (extensions.empty()) {
+    if (lowerScore == upperScore) {
+        // All scores are the same (usually only happens when exactly 1 hyp is active)
+        if (hypotheses.size() > maxBeamSize) {
+            hypotheses.resize(maxBeamSize);
+        }
         return;
     }
 
-    // Compute the pruning threshold
-    auto bestScore        = std::min_element(extensions.begin(), extensions.end())->score;
-    auto pruningThreshold = bestScore + threshold;
+    Score absoluteThreshold = upperScore;
 
-    // Remove elements with score > pruningThreshold
-    extensions.erase(
+    // Pruning by relative score threshold
+    if (relativeThreshold != Core::Type<Score>::max) {
+        absoluteThreshold = lowerScore + relativeThreshold;
+    }
+
+    // Pruning by max beam size
+    if (hypotheses.size() > maxBeamSize) {
+        scoreHistogram_.clear();
+        scoreHistogram_.setLimits(lowerScore, upperScore);
+
+        for (auto const& hyp : hypotheses) {
+            scoreHistogram_ += hyp.score;
+        }
+
+        absoluteThreshold = std::min(absoluteThreshold, scoreHistogram_.quantile(maxBeamSize));
+    }
+
+    if (absoluteThreshold >= upperScore) {
+        // Nothing will be pruned
+        return;
+    }
+
+    // Remove elements with score > absoluteThreshold
+    hypotheses.erase(
             std::remove_if(
-                    extensions.begin(),
-                    extensions.end(),
-                    [=](auto const& ext) { return ext.score > pruningThreshold; }),
-            extensions.end());
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [absoluteThreshold](auto const& hyp) { return hyp.score > absoluteThreshold; }),
+            hypotheses.end());
 }
+
+template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>&, Score, size_t) const;
+template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::LabelHypothesis>(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>&, Score, size_t) const;
 
 void LexiconfreeTimesyncBeamSearch::recombination(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>& hypotheses) {
     // Represents a unique combination of currentToken and scoringContext

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -442,7 +442,7 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
         }
         scorePruning(extensions_, scoreThresholds_[scorerIdx], maxBeamSize);
         if (logStepwiseStatistics_) {
-            clog() << Core::XmlFull("num-hyps-after-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
+            clog() << Core::XmlFull("num-hyps-after-intermediate-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
         }
         numHypsAfterIntermediatePruning_[scorerIdx] += extensions_.size();
 

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -118,7 +118,7 @@ private:
     std::vector<size_t> maxBeamSizes_;
     std::vector<bool>   useScorePruning_;
     std::vector<Score>  scoreThresholds_;
-    mutable Histogram   scoreHistogram_;
+    Histogram           scoreHistogram_;
     bool                useBlank_;
     Nn::LabelIndex      blankLabelIndex_;
     bool                allowBlankAfterSentenceEnd_;
@@ -173,7 +173,7 @@ private:
      * score histogram. Removes all hypotheses with a score > absolute threshold.
      */
     template<typename Element>
-    void scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) const;
+    void scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize);
 
     /*
      * Helper function for recombination of hypotheses with the same scoring context

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -23,6 +23,7 @@
 #include <Nn/LabelScorer/DataView.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
+#include <Search/Histogram.hh>
 #include <Search/SearchV2.hh>
 #include <Search/Traceback.hh>
 
@@ -43,6 +44,7 @@ class LexiconfreeTimesyncBeamSearch : public SearchAlgorithmV2 {
 public:
     static const Core::ParameterIntVector   paramMaxBeamSizes;
     static const Core::ParameterFloatVector paramScoreThresholds;
+    static const Core::ParameterInt         paramNumHistogramBins;
     static const Core::ParameterInt         paramBlankLabelIndex;
     static const Core::ParameterInt         paramSentenceEndLabelIndex;
     static const Core::ParameterBool        paramAllowBlankAfterSentenceEnd;
@@ -114,9 +116,9 @@ protected:
 
 private:
     std::vector<size_t> maxBeamSizes_;
-
     std::vector<bool>   useScorePruning_;
     std::vector<Score>  scoreThresholds_;
+    mutable Histogram   scoreHistogram_;
     bool                useBlank_;
     Nn::LabelIndex      blankLabelIndex_;
     bool                allowBlankAfterSentenceEnd_;
@@ -146,9 +148,9 @@ private:
     Core::StopWatch featureProcessingTime_;
     Core::StopWatch scoringTime_;
 
-    std::vector<Core::Statistics<u32>> numHypsAfterScorePruning_;
+    std::vector<Core::Statistics<u32>> numHypsAfterIntermediatePruning_;
     Core::Statistics<u32>              numHypsAfterRecombination_;
-    std::vector<Core::Statistics<u32>> numHypsAfterBeamPruning_;
+    Core::Statistics<u32>              numHypsAfterPruning_;
     Core::Statistics<u32>              numActiveHyps_;
 
     size_t currentSearchStep_;
@@ -167,15 +169,11 @@ private:
     Nn::LabelScorer::TransitionType inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const;
 
     /*
-     * Helper function for pruning to maxBeamSize_
+     * Helper function for acoustic pruning. Calculates an absolute threshold based on best score + relative threshold and
+     * score histogram. Removes all hypotheses with a score > absolute threshold.
      */
     template<typename Element>
-    void beamSizePruning(std::vector<Element>& hypotheses, size_t maxSize) const;
-
-    /*
-     * Helper function for pruning to scoreThreshold_
-     */
-    void scorePruning(std::vector<LexiconfreeTimesyncBeamSearch::ExtensionCandidate>& extensions, Score threshold) const;
+    void scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) const;
 
     /*
      * Helper function for recombination of hypotheses with the same scoring context

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -125,6 +125,12 @@ const Core::ParameterFloat TreeTimesyncBeamSearch::paramWordEndScoreThreshold(
         If not set, global score pruning will be done and word-end hypotheses will not be pruned separately.",
         Core::Type<Score>::max, 0);
 
+const Core::ParameterInt TreeTimesyncBeamSearch::paramNumHistogramBins(
+        "num-histogram-bins",
+        "Number of bins for histogram pruning of hypotheses (very minor effect).",
+        100,
+        2);
+
 const Core::ParameterBool TreeTimesyncBeamSearch::paramCollapseRepeatedLabels(
         "collapse-repeated-labels",
         "Collapse repeated emission of the same label into one output. If false, every emission is treated like a new output.",
@@ -163,6 +169,7 @@ TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config
           SearchAlgorithmV2(config),
           maxWordEndBeamSize_(paramMaxWordEndBeamSize(config)),
           wordEndScoreThreshold_(paramWordEndScoreThreshold(config)),
+          scoreHistogram_(paramNumHistogramBins(config)),
           blankLabelIndex_(Nn::invalidLabelIndex),
           sentenceEndLabelIndex_(Nn::invalidLabelIndex),
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
@@ -486,19 +493,14 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         /*
          * Prune set of possible within-word extensions by max beam size and possibly also by score.
          */
-        scorePruning(withinWordExtensions_, scoreThresholds_[scorerIdx]);
+        size_t maxBeamSize = withinWordExtensions_.size();
+        if (scorerIdx < labelScorers_.size() - 1) {
+            maxBeamSize = maxBeamSizes_[scorerIdx];
+        }
+        scorePruning(withinWordExtensions_, scoreThresholds_[scorerIdx], maxBeamSize);
         numHypsAfterScorePruning_[scorerIdx] += withinWordExtensions_.size();
         if (logStepwiseStatistics_) {
-            clog() << Core::XmlFull("num-hyps-after-score-pruning-" + std::to_string(scorerIdx + 1), withinWordExtensions_.size());
-        }
-
-        if (scorerIdx < labelScorers_.size() - 1) {
-            beamSizePruning(withinWordExtensions_, maxBeamSizes_[scorerIdx]);
-            numHypsAfterBeamPruning_[scorerIdx] += withinWordExtensions_.size();
-
-            if (logStepwiseStatistics_) {
-                clog() << Core::XmlFull("num-hyps-after-beam-pruning-" + std::to_string(scorerIdx + 1), withinWordExtensions_.size());
-            }
+            clog() << Core::XmlFull("num-hyps-after-pruning-" + std::to_string(scorerIdx + 1), withinWordExtensions_.size());
         }
     }
 
@@ -526,7 +528,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-hyps-after-recombination", newBeam_.size());
     }
 
-    beamSizePruning(newBeam_, maxBeamSizes_[labelScorers_.size() - 1]);
+    scorePruning(newBeam_, Core::Type<Score>::max, maxBeamSizes_[labelScorers_.size() - 1]);
     numHypsAfterBeamPruning_[labelScorers_.size() - 1] += newBeam_.size();
     if (logStepwiseStatistics_) {
         clog() << Core::XmlFull("num-hyps-after-beam-pruning-" + std::to_string(labelScorers_.size()), newBeam_.size());
@@ -578,7 +580,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
     /*
      * Prune set of word-end extensions by max beam size and possibly also by score.
      */
-    scorePruning(wordEndExtensions_, wordEndScoreThreshold_);
+    scorePruning(wordEndExtensions_, wordEndScoreThreshold_, wordEndExtensions_.size());
     numWordEndHypsAfterScorePruning_ += wordEndExtensions_.size();
     if (logStepwiseStatistics_) {
         clog() << Core::XmlFull("num-word-end-hyps-after-score-pruning", wordEndExtensions_.size());
@@ -607,7 +609,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-word-end-hyps-after-recombination", wordEndHypotheses_.size());
     }
 
-    beamSizePruning(wordEndHypotheses_, maxWordEndBeamSize_);
+    scorePruning(wordEndHypotheses_, Core::Type<Score>::max, maxWordEndBeamSize_);
     numWordEndHypsAfterBeamPruning_ += wordEndHypotheses_.size();
     if (logStepwiseStatistics_) {
         clog() << Core::XmlFull("num-word-end-hyps-after-beam-pruning", wordEndHypotheses_.size());
@@ -807,40 +809,64 @@ Nn::LabelScorer::TransitionType TreeTimesyncBeamSearch::inferTransitionType(Nn::
 }
 
 template<typename Element>
-void TreeTimesyncBeamSearch::beamSizePruning(std::vector<Element>& hypotheses, size_t maxBeamSize) const {
-    if (hypotheses.size() <= maxBeamSize) {
+void TreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
+    if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
+        // Neither relative score pruning nor max beam size pruning triggers
         return;
     }
 
-    // Sort the hypotheses by associated score value such that the first `maxBeamSize` elements are the best
-    std::nth_element(hypotheses.begin(), hypotheses.begin() + maxBeamSize, hypotheses.end());
-    hypotheses.resize(maxBeamSize);  // Get rid of excessive elements
-}
+    // Find ranges for score histogram and setting absolute threshold
+    Score lowerScore = Core::Type<Score>::max;
+    Score upperScore = Core::Type<Score>::min;
 
-template void TreeTimesyncBeamSearch::beamSizePruning<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>&, size_t) const;
-template void TreeTimesyncBeamSearch::beamSizePruning<TreeTimesyncBeamSearch::WordEndExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WordEndExtensionCandidate>&, size_t) const;
+    for (auto const& hyp : hypotheses) {
+        lowerScore = std::min(lowerScore, hyp.score);
+        upperScore = std::max(upperScore, hyp.score);
+    }
 
-template<typename Element>
-void TreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hyps, Score scoreThreshold) const {
-    if (hyps.empty() or scoreThreshold == Core::Type<Score>::max) {
+    if (lowerScore == upperScore) {
+        // All scores are the same (usually only happens when exactly 1 hyp is active)
+        if (hypotheses.size() > maxBeamSize) {
+            hypotheses.resize(maxBeamSize);
+        }
         return;
     }
 
-    // Compute the pruning threshold
-    auto bestScore        = std::min_element(hyps.begin(), hyps.end())->score;
-    auto pruningThreshold = bestScore + scoreThreshold;
+    Score absoluteThreshold = upperScore;
 
-    // Remove elements with score > pruningThreshold
-    hyps.erase(
+    // Pruning by relative score threshold
+    if (relativeThreshold != Core::Type<Score>::max) {
+        absoluteThreshold = lowerScore + relativeThreshold;
+    }
+
+    // Pruning by max beam size
+    if (hypotheses.size() > maxBeamSize) {
+        scoreHistogram_.clear();
+        scoreHistogram_.setLimits(lowerScore, upperScore);
+
+        for (auto const& hyp : hypotheses) {
+            scoreHistogram_ += hyp.score;
+        }
+
+        absoluteThreshold = std::min(absoluteThreshold, scoreHistogram_.quantile(maxBeamSize));
+    }
+
+    if (absoluteThreshold >= upperScore) {
+        // Nothing will be pruned
+        return;
+    }
+
+    // Remove elements with score > absoluteThreshold
+    hypotheses.erase(
             std::remove_if(
-                    hyps.begin(),
-                    hyps.end(),
-                    [=](auto const& ext) { return ext.score > pruningThreshold; }),
-            hyps.end());
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [absoluteThreshold](auto const& hyp) { return hyp.score > absoluteThreshold; }),
+            hypotheses.end());
 }
 
-template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>&, Score) const;
-template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::WordEndExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WordEndExtensionCandidate>&, Score) const;
+template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WithinWordExtensionCandidate>&, Score, size_t);
+template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::WordEndExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WordEndExtensionCandidate>&, Score, size_t);
 
 void TreeTimesyncBeamSearch::recombination(std::vector<TreeTimesyncBeamSearch::LabelHypothesis>& hypotheses, bool createTraceSiblings) {
     // Represents a unique combination of StateId, ScoringContext and LmHistory

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -607,7 +607,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
     }
 
     /*
-     * Prune set of word-end extensions by max beam size and possibly also by score.
+     * Prune set of word-end extensions by score.
      */
     scorePruning(wordEndExtensions_, wordEndScoreThreshold_, wordEndExtensions_.size());
     numWordEndHypsAfterScorePruning_ += wordEndExtensions_.size();
@@ -638,6 +638,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         clog() << Core::XmlFull("num-word-end-hyps-after-recombination", wordEndHypotheses_.size());
     }
 
+    // Prune set of word-end hypotheses by max beam size.
     scorePruning(wordEndHypotheses_, Core::Type<Score>::max, maxWordEndBeamSize_);
     numWordEndHypsAfterBeamPruning_ += wordEndHypotheses_.size();
     if (logStepwiseStatistics_) {

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -23,6 +23,7 @@
 #include <Nn/LabelScorer/DataView.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
+#include <Search/Histogram.hh>
 #include <Search/PersistentStateTree.hh>
 #include <Search/SearchV2.hh>
 #include <Search/Traceback.hh>
@@ -48,6 +49,7 @@ public:
     static const Core::ParameterInt         paramMaxWordEndBeamSize;
     static const Core::ParameterFloatVector paramScoreThresholds;
     static const Core::ParameterFloat       paramWordEndScoreThreshold;
+    static const Core::ParameterInt         paramNumHistogramBins;
     static const Core::ParameterBool        paramCollapseRepeatedLabels;
     static const Core::ParameterBool        paramSentenceEndFallBack;
     static const Core::ParameterBool        paramLogStepwiseStatistics;
@@ -138,6 +140,7 @@ private:
     size_t              maxWordEndBeamSize_;
     std::vector<Score>  scoreThresholds_;
     Score               wordEndScoreThreshold_;
+    Histogram           scoreHistogram_;
     Nn::LabelIndex      blankLabelIndex_;
     Nn::LabelIndex      sentenceEndLabelIndex_;
     size_t              cacheCleanupInterval_;
@@ -201,16 +204,11 @@ private:
     Nn::LabelScorer::TransitionType inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const;
 
     /*
-     * Helper function for pruning to maxBeamSize
+     * Helper function for acoustic pruning. Calculates an absolute threshold based on best score + relative threshold and
+     * score histogram. Removes all hypotheses with a score > absolute threshold.
      */
     template<typename Element>
-    void beamSizePruning(std::vector<Element>& hypotheses, size_t maxBeamSize) const;
-
-    /*
-     * Helper function for pruning to scoreThreshold
-     */
-    template<typename Element>
-    void scorePruning(std::vector<Element>& hyps, Score scoreThreshold) const;
+    void scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize);
 
     /*
      * Helper function for recombination of hypotheses at the same point in the tree with the same scoring context and LM history.

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -206,7 +206,7 @@ private:
     Nn::TransitionType inferTransitionType(Nn::LabelIndex prevLabel, Nn::LabelIndex nextLabel) const;
 
     /*
-     * Helper function for acoustic pruning. Calculates an absolute threshold based on best score + relative threshold and
+     * Helper function for pruning. Calculates an absolute threshold based on best score + relative threshold and
      * score histogram. Removes all hypotheses with a score > absolute threshold.
      */
     template<typename Element>


### PR DESCRIPTION
This PR replaces the beam-size-pruning using `std::nth_element` with histogram pruning. The `beamSizePruning` and `scorePruning` functions of `LexiconfreeTimesyncBeamSearch`, `LexiconfreeLabelsyncBeamSearch` and `TreeTimesyncBeamSearch` have been combined into one function that can do both at once by incorporating the histogram.

The advantage in terms of speed is only minor; I measured around 1-2% search RTF reduction.