### PR TITLE
Add Onnx::ChunkedOnnxEncoder

### DIFF
--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -49,7 +49,7 @@ public:
     virtual void reset();
 
     // Signal that no more features are expected for the current segment.
-    virtual void signalNoMoreFeatures();
+    void signalNoMoreFeatures();
 
     // Add a single input feature
     virtual void addInput(DataView const& input);

--- a/src/Nn/LabelScorer/Encoder.hh
+++ b/src/Nn/LabelScorer/Encoder.hh
@@ -49,7 +49,7 @@ public:
     virtual void reset();
 
     // Signal that no more features are expected for the current segment.
-    void signalNoMoreFeatures();
+    virtual void signalNoMoreFeatures();
 
     // Add a single input feature
     virtual void addInput(DataView const& input);

--- a/src/Onnx/Module.cc
+++ b/src/Onnx/Module.cc
@@ -27,6 +27,13 @@ Module_::Module_() {
             [](Core::Configuration const& config, Nn::EncoderModelCache& modelCache) {
                 return Core::ref(new OnnxEncoder(config, modelCache));
             });
+
+    // Forward encoder inputs through an onnx model in a chunk-wise manner
+    Nn::Module::instance().encoderFactory().registerEncoder(
+            "chunked-onnx",
+            [](Core::Configuration const& config, Nn::EncoderModelCache& modelCache) {
+                return Core::ref(new ChunkedOnnxEncoder(config, modelCache));
+            });
 }
 
 }  // namespace Onnx

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -192,6 +192,8 @@ const Core::Choice ChunkedOnnxEncoder::interpolationModeChoice(
         "no-interpolation", InterpolationMode::NoInterpolation,
         "linear", InterpolationMode::Linear,
         "linear-renorm", InterpolationMode::LinearRenorm,
+        "log-linear", InterpolationMode::LogLinear,
+        "log-linear-renorm", InterpolationMode::LogLinearRenorm,
         "neglog-linear", InterpolationMode::NegLogLinear,
         "neglog-linear-renorm", InterpolationMode::NegLogLinearRenorm,
         Core::Choice::endMark());
@@ -321,12 +323,19 @@ void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::Interpolati
                     accumulator.get(),
                     [this](f32 value) { return value / totalWeight; });
             break;
+        case InterpolationMode::LogLinearRenorm:
+            std::transform(
+                    accumulator.get(),
+                    accumulator.get() + accumulatorSize,
+                    accumulator.get(),
+                    [this](f32 value) { return value - totalWeight; });
+            break;
         case InterpolationMode::NegLogLinearRenorm:
             std::transform(
                     accumulator.get(),
                     accumulator.get() + accumulatorSize,
                     accumulator.get(),
-                    [this](f32 value) { return value + std::log(totalWeight); });
+                    [this](f32 value) { return value + totalWeight; });
             break;
         default:
             break;
@@ -378,12 +387,25 @@ void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
         }
     }
 
-    if (interpolationMode_ == InterpolationMode::NegLogLinear or interpolationMode_ == InterpolationMode::NegLogLinearRenorm) {
-        std::transform(
-                window_.begin(),
-                window_.end(),
-                window_.begin(),
-                [](f32 value) { return -std::log(value); });
+    switch (interpolationMode_) {
+        case InterpolationMode::LogLinear:
+        case InterpolationMode::LogLinearRenorm:
+            std::transform(
+                    window_.begin(),
+                    window_.end(),
+                    window_.begin(),
+                    [](f32 value) { return std::log(value); });
+            break;
+        case InterpolationMode::NegLogLinear:
+        case InterpolationMode::NegLogLinearRenorm:
+            std::transform(
+                    window_.begin(),
+                    window_.end(),
+                    window_.begin(),
+                    [](f32 value) { return -std::log(value); });
+            break;
+        default:
+            break;
     }
 }
 
@@ -404,7 +426,7 @@ void ChunkedOnnxEncoder::flushPendingOutputsUpTo(size_t inputStart) {
 }
 
 void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weight) {
-    bool negLogInterpolation = interpolationMode_ == InterpolationMode::NegLogLinear or interpolationMode_ == InterpolationMode::NegLogLinearRenorm;
+    verify(interpolationMode_ != InterpolationMode::NoInterpolation);
 
     // Check if matching output is already pending
     auto [it, inserted] = pendingOutputs_.emplace(
@@ -419,9 +441,22 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
     if (inserted) {
         // No matching output exists, so initialize the accumulator with the weighted encoding
         pendingOutput.inputEnd = data.input_end;
-        auto weightingFunction = negLogInterpolation
-                                         ? std::function<f32(f32)>([weight](f32 value) { return weight + value; })
-                                         : std::function<f32(f32)>([weight](f32 value) { return weight * value; });
+        std::function<f32(f32)> weightingFunction;
+        switch (interpolationMode_) {
+            case InterpolationMode::Linear:
+            case InterpolationMode::LinearRenorm:
+                weightingFunction = std::function<f32(f32)>([weight](f32 value) { return weight * value; });
+                break;
+            case InterpolationMode::LogLinear:
+            case InterpolationMode::LogLinearRenorm:
+            case InterpolationMode::NegLogLinear:
+            case InterpolationMode::NegLogLinearRenorm:
+                weightingFunction = std::function<f32(f32)>([weight](f32 value) { return weight + value; });
+                break;
+            default:
+                error("Encountered unexpected interpolation mode");
+                break;
+        }
         std::transform(
                 data.encoding.data(),
                 data.encoding.data() + data.encoding.size(),
@@ -432,9 +467,28 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
     }
 
     // A matching output exists, so we combine it with the weighted encoding
-    auto interpolationFunction = negLogInterpolation
-                                         ? std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return Math::scoreSum(accumValue, encodingValue + weight); })
-                                         : std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return accumValue + encodingValue * weight; });
+    std::function<f32(f32, f32)> interpolationFunction;
+    switch (interpolationMode_) {
+        case InterpolationMode::Linear:
+        case InterpolationMode::LinearRenorm:
+            interpolationFunction = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return accumValue + encodingValue * weight; });
+            pendingOutput.totalWeight += weight;
+            break;
+        case InterpolationMode::LogLinear:
+        case InterpolationMode::LogLinearRenorm:
+            interpolationFunction     = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return -Math::scoreSum(-accumValue, -(encodingValue + weight)); });
+            pendingOutput.totalWeight = -Math::scoreSum(-pendingOutput.totalWeight, -weight);
+            break;
+        case InterpolationMode::NegLogLinear:
+        case InterpolationMode::NegLogLinearRenorm:
+            interpolationFunction     = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return Math::scoreSum(accumValue, encodingValue + weight); });
+            pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
+            break;
+        default:
+            error("Encountered unexpected interpolation mode");
+            break;
+    }
+
     require(pendingOutput.accumulatorSize == data.encoding.size());
     std::transform(
             pendingOutput.accumulator.get(),
@@ -442,13 +496,6 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
             data.encoding.data(),
             pendingOutput.accumulator.get(),
             interpolationFunction);
-
-    if (negLogInterpolation) {
-        pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
-    }
-    else {
-        pendingOutput.totalWeight += weight;
-    }
 }
 
 }  // namespace Onnx

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -17,6 +17,12 @@
 
 namespace Onnx {
 
+/*
+ * ============================
+ * ======= OnnxEncoder ========
+ * ============================
+ */
+
 const std::vector<IOSpecification> encoderIoSpec = {
         IOSpecification{
                 "features",
@@ -65,62 +71,181 @@ void OnnxEncoder::reset() {
     stateManager_->setInitialStates(stateVariables_);
 }
 
+OnnxEncoder::SessionRunResult OnnxEncoder::runSession(size_t inputStartIndex, size_t nInputs) {
+    verify(inputStartIndex + nInputs <= inputBuffer_.size());
+    verify(nInputs > 0ul);
+
+    std::vector<std::pair<std::string, Value>> sessionInputs;
+    std::vector<std::string>                   outputNames{{outputName_}};
+
+    size_t F = inputBuffer_[inputStartIndex].size();
+
+    // Create session inputs
+    std::vector<int64_t> featureShape = {1l, static_cast<int64_t>(nInputs), static_cast<int64_t>(F)};
+    Value                value        = Value::createEmpty<f32>(featureShape);
+
+    for (size_t t = 0ul; t < nInputs; ++t) {
+        std::copy(inputBuffer_[inputStartIndex + t].data(), inputBuffer_[inputStartIndex + t].data() + F, value.data<f32>(0, t));
+    }
+    sessionInputs.emplace_back(featuresName_, std::move(value));
+
+    if (featuresSizeName_ != "") {
+        sessionInputs.emplace_back(featuresSizeName_, Value::create(std::vector<s32>{static_cast<int>(nInputs)}));
+    }
+
+    stateManager_->extendFeedDict(sessionInputs, stateVariables_);
+    stateManager_->extendTargets(outputNames, stateVariables_);
+
+    // Run session
+    std::vector<Value> sessionOutputs;
+    onnxModel_->session.run(std::move(sessionInputs), outputNames, sessionOutputs);
+
+    // Retrieve outputs
+    size_t T_out      = sessionOutputs.front().dimSize(1);
+    size_t outputSize = sessionOutputs.front().dimSize(2);
+
+    Nn::DataView outputView(std::move(sessionOutputs.front()));
+
+    std::vector<Value> outputStates;
+    for (size_t i = 1ul; i < sessionOutputs.size(); ++i) {
+        outputStates.emplace_back(std::move(sessionOutputs[i]));
+    }
+    stateManager_->updateStates(outputStates);
+
+    return {.outputView = std::move(outputView), .nOutputs = T_out, .outputSize = outputSize};
+}
+
 void OnnxEncoder::encode() {
     if (inputBuffer_.empty()) {
         return;
     }
 
-    // Create session inputs/outputs
-    std::vector<std::pair<std::string, Value>> session_inputs;
-    std::vector<std::string>                   output_names{{outputName_}};
+    size_t nInputs = inputBuffer_.size();
 
-    size_t T_in = inputBuffer_.size();
-    size_t F    = inputBuffer_.front().size();
+    auto [outputView, nOutputs, outputSize] = runSession(0ul, nInputs);
 
-    std::vector<int64_t> feature_shape = {1l, static_cast<int64_t>(T_in), static_cast<int64_t>(F)};
+    size_t inputsPerOutput = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (nInputs / nOutputs + (nInputs % nOutputs != 0ul));
+    size_t inputStep       = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
+    size_t startInput      = 0ul;
 
-    Value value = Value::createEmpty<f32>(feature_shape);
-
-    for (size_t t = 0ul; t < T_in; ++t) {
-        std::copy(inputBuffer_[t].data(), inputBuffer_[t].data() + F, value.data<f32>(0, t));
+    for (size_t t = 0ul; t < nOutputs; ++t) {
+        size_t endInput = std::min(startInput + inputsPerOutput, nInputs);
+        outputBuffer_.push_back(
+                Nn::EncodedSpan{
+                        .encoding    = {outputView, outputSize, t * outputSize},
+                        .input_start = startInput,
+                        .input_end   = endInput});
+        startInput = std::min(startInput + inputStep, std::max(nInputs, 1ul) - 1ul);
     }
-    session_inputs.emplace_back(std::make_pair(featuresName_, std::move(value)));
+}
 
-    // features-size is an optional input
-    if (featuresSizeName_ != "") {
-        session_inputs.emplace_back(std::make_pair(featuresSizeName_, Value::create(std::vector<s32>{static_cast<int>(T_in)})));
+/*
+ * ============================
+ * ==== ChunkedOnnxEncoder ====
+ * ============================
+ */
+
+const Core::ParameterInt ChunkedOnnxEncoder::paramChunkSize(
+        "chunk-size",
+        "The number of central input features processed in one chunk.",
+        1,
+        1);
+
+const Core::ParameterInt ChunkedOnnxEncoder::paramStepSize(
+        "step-size",
+        "The shift in central input features between two consecutive chunks.",
+        1,
+        1);
+
+const Core::ParameterInt ChunkedOnnxEncoder::paramLeftPadding(
+        "left-padding",
+        "The number of input features of left context to prepend to each chunk.",
+        0,
+        0);
+
+const Core::ParameterInt ChunkedOnnxEncoder::paramRightPadding(
+        "right-padding",
+        "The number of input features of right context to append to each chunk.",
+        0,
+        0);
+
+ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::EncoderModelCache& cachedModel)
+        : Core::Component(config),
+          Precursor(config, cachedModel),
+          chunkSize_(paramChunkSize(config)),
+          stepSize_(paramStepSize(config)),
+          leftPadding_(paramLeftPadding(config)),
+          rightPadding_(paramRightPadding(config)),
+          chunkCenterStart_(0ul),
+          numDiscardedFeatures_(0ul) {
+    if (not stateVariables_.empty()) {
+        // With overlap, state variable outputs of the previous chunk don't work as inputs for the next chunk
+        error() << "ChunkedOnnxEncoder does not support state variables.";
+    }
+}
+
+void ChunkedOnnxEncoder::reset() {
+    Precursor::reset();
+    chunkCenterStart_     = 0ul;
+    numDiscardedFeatures_ = 0ul;
+}
+
+bool ChunkedOnnxEncoder::canEncode() const {
+    size_t availableEnd = numDiscardedFeatures_ + inputBuffer_.size();
+
+    if (not expectMoreFeatures_) {
+        return availableEnd > chunkCenterStart_;
     }
 
-    // input and output states
-    stateManager_->extendFeedDict(session_inputs, stateVariables_);
-    stateManager_->extendTargets(output_names, stateVariables_);
+    return availableEnd >= chunkCenterStart_ + chunkSize_ + rightPadding_;
+}
 
-    // Run session
-    std::vector<Value> session_outputs;
-    onnxModel_->session.run(std::move(session_inputs), output_names, session_outputs);
+void ChunkedOnnxEncoder::encode() {
+    size_t availableEnd = numDiscardedFeatures_ + inputBuffer_.size();
 
-    // Put outputs into buffer
-    size_t T_out       = session_outputs.front().dimSize(1);
-    size_t output_size = session_outputs.front().dimSize(2);
+    size_t chunkStart     = chunkCenterStart_ > leftPadding_ ? chunkCenterStart_ - leftPadding_ : 0ul;
+    size_t chunkCenterEnd = std::min(chunkCenterStart_ + chunkSize_, availableEnd);
+    size_t chunkEnd       = std::min(chunkCenterEnd + rightPadding_, availableEnd);
 
-    // Make "global" DataView from output value so that feature slice DataViews can be created from it that ref-count the original value
-    Nn::DataView onnx_output_view(std::move(session_outputs.front()));
+    // If we need to access e.g. feature 17 and so far 10 features have been discarded,
+    // feature 17 will be in inputBuffer_[7]
+    size_t inputStartIndex = chunkStart - numDiscardedFeatures_;
+    size_t nInputs         = chunkEnd - chunkStart;
 
-    size_t outputs_per_input = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (T_in / T_out + (T_in % T_out != 0));
-    size_t input_step        = (inputStepSize_ != 0ul) ? inputStepSize_ : outputs_per_input;
-    size_t start_input       = 0ul;
-    for (size_t t = 0ul; t < T_out; ++t) {
-        size_t end_input = std::min(start_input + outputs_per_input, T_in);
-        outputBuffer_.push_back(Nn::EncodedSpan{{onnx_output_view, output_size, t * output_size}, start_input, end_input});
-        start_input = std::min(start_input + input_step, std::max(T_in, 1ul) - 1ul);
+    auto [outputView, nOutputs, outputSize] = runSession(inputStartIndex, nInputs);
+
+    size_t inputsPerOutput = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (nInputs / nOutputs + (nInputs % nOutputs != 0ul));
+    size_t inputStep       = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
+
+    // Buffer all outputs for which the start input lies inside the interval [chunkCenterStart_, chunkCenterEnd)
+    // The rest corresponds to the padding frames and gets skipped
+    size_t startInput = chunkStart;
+    for (size_t t = 0ul; t < nOutputs; ++t) {
+        size_t endInput = std::min(startInput + inputsPerOutput, availableEnd);
+        if (startInput >= chunkCenterStart_) {
+            outputBuffer_.push_back(
+                    Nn::EncodedSpan{
+                            .encoding    = {outputView, outputSize, t * outputSize},
+                            .input_start = startInput,
+                            .input_end   = endInput});
+        }
+        startInput += inputStep;
+
+        if (startInput >= chunkCenterEnd) {
+            break;
+        }
     }
 
-    // Get new states
-    std::vector<Value> output_states;
-    for (size_t i = 1ul; i < session_outputs.size(); i++) {  // other model outputs
-        output_states.emplace_back(std::move(session_outputs[i]));
-    }
-    stateManager_->updateStates(output_states);
+    // Move to next chunk after encoding
+    chunkCenterStart_ += stepSize_;
+}
+
+void ChunkedOnnxEncoder::postEncodeCleanup() {
+    size_t firstNeededIndex = chunkCenterStart_ > leftPadding_ ? chunkCenterStart_ - leftPadding_ : 0ul;
+    size_t numToDiscard     = std::min(firstNeededIndex - numDiscardedFeatures_, inputBuffer_.size());
+
+    inputBuffer_.erase(inputBuffer_.begin(), inputBuffer_.begin() + numToDiscard);
+    numDiscardedFeatures_ += numToDiscard;
 }
 
 }  // namespace Onnx

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -177,12 +177,7 @@ ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::En
           leftPadding_(paramLeftPadding(config)),
           rightPadding_(paramRightPadding(config)),
           chunkCenterStart_(0ul),
-          numDiscardedFeatures_(0ul) {
-    if (not stateVariables_.empty()) {
-        // With overlap, state variable outputs of the previous chunk don't work as inputs for the next chunk
-        error() << "ChunkedOnnxEncoder does not support state variables.";
-    }
-}
+          numDiscardedFeatures_(0ul) {}
 
 void ChunkedOnnxEncoder::reset() {
     Precursor::reset();

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -71,7 +71,7 @@ void OnnxEncoder::reset() {
     stateManager_->setInitialStates(stateVariables_);
 }
 
-OnnxEncoder::SessionRunResult OnnxEncoder::runSession(size_t inputStartIndex, size_t nInputs) {
+OnnxEncoder::SessionRunResult OnnxEncoder::runSession(size_t inputStartIndex, size_t nInputs, size_t leftZeroPadding, size_t rightZeroPadding) {
     verify(inputStartIndex + nInputs <= inputBuffer_.size());
     verify(nInputs > 0ul);
 
@@ -81,12 +81,14 @@ OnnxEncoder::SessionRunResult OnnxEncoder::runSession(size_t inputStartIndex, si
     size_t F = inputBuffer_[inputStartIndex].size();
 
     // Create session inputs
-    std::vector<int64_t> featureShape = {1l, static_cast<int64_t>(nInputs), static_cast<int64_t>(F)};
+    std::vector<int64_t> featureShape = {1l, static_cast<int64_t>(leftZeroPadding + nInputs + rightZeroPadding), static_cast<int64_t>(F)};
     Value                value        = Value::createEmpty<f32>(featureShape);
 
-    for (size_t t = 0ul; t < nInputs; ++t) {
-        std::copy(inputBuffer_[inputStartIndex + t].data(), inputBuffer_[inputStartIndex + t].data() + F, value.data<f32>(0, t));
+    std::fill(value.data<f32>(0, 0), value.data<f32>(0, leftZeroPadding), 0.0f);
+    for (size_t t = leftZeroPadding; t < leftZeroPadding + nInputs; ++t) {
+        std::copy(inputBuffer_[inputStartIndex + t - leftZeroPadding].data(), inputBuffer_[inputStartIndex + t - leftZeroPadding].data() + F, value.data<f32>(0, t));
     }
+    std::fill(value.data<f32>(0, leftZeroPadding + nInputs), value.data<f32>(0, leftZeroPadding + nInputs + rightZeroPadding), 0.0f);
     sessionInputs.emplace_back(featuresName_, std::move(value));
 
     if (featuresSizeName_ != "") {
@@ -208,8 +210,6 @@ ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::En
           leftPadding_(paramLeftPadding(config)),
           rightPadding_(paramRightPadding(config)),
           zeroPadding_(paramZeroPadding(config)),
-          leftZeroPaddingAdded_(false),
-          rightZeroPaddingAdded_(false),
           interpolationMode_(static_cast<InterpolationMode>(paramInterpolationMode(config))),
           chunkCenterStart_(0ul),
           numDiscardedFeatures_(0ul),
@@ -217,44 +217,14 @@ ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::En
     if (inputsPerOutput_ > chunkSize_) {
         error("Chunk size must be large enough to produce at least one output");
     }
-    require(inputsPerOutput_ <= chunkSize_);
     initWindow(static_cast<WindowType>(paramWindowType(config)));
 }
 
 void ChunkedOnnxEncoder::reset() {
     Precursor::reset();
-    chunkCenterStart_      = 0ul;
-    numDiscardedFeatures_  = 0ul;
-    leftZeroPaddingAdded_  = false;
-    rightZeroPaddingAdded_ = false;
+    chunkCenterStart_     = 0ul;
+    numDiscardedFeatures_ = 0ul;
     pendingOutputs_.clear();
-}
-
-void ChunkedOnnxEncoder::signalNoMoreFeatures() {
-    Precursor::signalNoMoreFeatures();
-    if (not rightZeroPaddingAdded_) {
-        rightZeroPaddingAdded_ = true;
-        if (inputBuffer_.empty()) {
-            return;
-        }
-        auto inputSize  = inputBuffer_.begin()->size();
-        auto zeroVector = Core::tsRef(new Mm::Feature::Vector(inputSize));
-        for (size_t i = 0ul; i < rightPadding_; ++i) {
-            Precursor::addInput({zeroVector});
-        }
-    }
-}
-
-void ChunkedOnnxEncoder::addInput(Nn::DataView const& input) {
-    if (not leftZeroPaddingAdded_) {
-        leftZeroPaddingAdded_ = true;
-        auto inputSize        = input.size();
-        auto zeroVector       = Core::tsRef(new Mm::Feature::Vector(inputSize));
-        for (size_t i = 0ul; i < leftPadding_; ++i) {
-            Precursor::addInput({zeroVector});
-        }
-    }
-    Precursor::addInput(input);
 }
 
 bool ChunkedOnnxEncoder::canEncode() const {
@@ -270,16 +240,27 @@ bool ChunkedOnnxEncoder::canEncode() const {
 void ChunkedOnnxEncoder::encode() {
     size_t availableEnd = numDiscardedFeatures_ + inputBuffer_.size();
 
+    // Figure out which inputs need to be supplied to the session and which parts belong to the chunk center
+    // If zero-padding is enabled, also count how many zero-features need to be prepended or appended to the session input
     size_t chunkStart     = chunkCenterStart_ > leftPadding_ ? chunkCenterStart_ - leftPadding_ : 0ul;
     size_t chunkCenterEnd = std::min(chunkCenterStart_ + chunkSize_, availableEnd);
     size_t chunkEnd       = std::min(chunkCenterEnd + rightPadding_, availableEnd);
+
+    size_t prependZeroCount = 0ul;
+    if (zeroPadding_ and leftPadding_ > chunkCenterStart_ - chunkStart) {
+        prependZeroCount = leftPadding_ - (chunkCenterStart_ - chunkStart);
+    }
+    size_t appendZeroCount = 0ul;
+    if (zeroPadding_ and rightPadding_ > chunkEnd - chunkCenterEnd) {
+        appendZeroCount = rightPadding_ - (chunkEnd - chunkCenterEnd);
+    }
 
     // If we need to access e.g. feature 17 and so far 10 features have been discarded,
     // feature 17 will be in inputBuffer_[7]
     size_t inputStartIndex = chunkStart - numDiscardedFeatures_;
     size_t nInputs         = chunkEnd - chunkStart;
 
-    auto [outputView, nOutputs, outputSize] = runSession(inputStartIndex, nInputs);
+    auto [outputView, nOutputs, outputSize] = runSession(inputStartIndex, nInputs, prependZeroCount, appendZeroCount);
 
     size_t inputsPerOutput = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (nInputs / nOutputs + (nInputs % nOutputs != 0ul));
     size_t inputStep       = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
@@ -291,11 +272,16 @@ void ChunkedOnnxEncoder::encode() {
     for (size_t t = 0ul; t < nOutputs; ++t) {
         size_t endInput = std::min(startInput + inputsPerOutput, availableEnd);
         if (startInput >= chunkCenterStart_) {
-            accumulatePendingOutput(Nn::EncodedSpan{
-                                            .encoding    = {outputView, outputSize, t * outputSize},
-                                            .input_start = startInput,
-                                            .input_end   = endInput},
-                                    *weightIterator);
+            Nn::EncodedSpan output{
+                    .encoding    = {outputView, outputSize, t * outputSize},
+                    .input_start = startInput,
+                    .input_end   = endInput};
+            if (interpolationMode_ == InterpolationMode::NoInterpolation) {
+                outputBuffer_.push_back(output);
+            }
+            else {
+                accumulatePendingOutput(output, *weightIterator);
+            }
             ++weightIterator;
         }
         startInput += inputStep;
@@ -308,12 +294,13 @@ void ChunkedOnnxEncoder::encode() {
     bool isLastChunk  = not expectMoreFeatures_ and chunkCenterEnd == availableEnd;
     chunkCenterStart_ = isLastChunk ? availableEnd : chunkCenterStart_ + stepSize_;
 
-    if (interpolationMode_ == InterpolationMode::NoInterpolation or isLastChunk) {
-        // Flush everything
-        flushPendingOutputsUpTo(Core::Type<size_t>::max);
-    }
-    else {
-        flushPendingOutputsUpTo(chunkCenterStart_);
+    if (interpolationMode_ != InterpolationMode::NoInterpolation) {
+        if (isLastChunk) {
+            flushPendingOutputsUpTo(Core::Type<size_t>::max);
+        }
+        else {
+            flushPendingOutputsUpTo(chunkCenterStart_);
+        }
     }
 }
 
@@ -326,7 +313,6 @@ void ChunkedOnnxEncoder::postEncodeCleanup() {
 }
 
 void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::InterpolationMode mode) {
-    // Maybe renormalize based on totalWeight
     switch (mode) {
         case InterpolationMode::LinearRenorm:
             std::transform(
@@ -340,7 +326,7 @@ void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::Interpolati
                     accumulator.get(),
                     accumulator.get() + accumulatorSize,
                     accumulator.get(),
-                    [this](f32 value) { return value - totalWeight; });
+                    [this](f32 value) { return value + std::log(totalWeight); });
             break;
         default:
             break;
@@ -348,11 +334,11 @@ void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::Interpolati
 }
 
 void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
-    if (inputStepSize_ == 0) {
-        // We can't calculate the true window size based on the chunk size if the parameter hasn't been set
+    if (inputStepSize_ == 0ul) {
+        // We can't calculate the true window size based on the chunk size if the parameter hasn't been set.
         if (interpolationMode_ == InterpolationMode::NoInterpolation or windowType == WindowType::None) {
             // If the weights don't depend on the window size, we don't care about the true window size and just
-            // resize it with an upper bound
+            // resize it with an upper bound.
             window_.resize(chunkSize_);
         }
         else {
@@ -366,35 +352,45 @@ void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
 
     switch (windowType) {
         case WindowType::None:
-            std::fill(window_.begin(), window_.end(), 1.0);
+            std::fill(window_.begin(), window_.end(), 1.0f);
             break;
-        case WindowType::Triangular:
+        case WindowType::Triangular: {
+            f32 len = window_.size() + 1;
             for (size_t t = 0ul; t < window_.size() / 2; ++t) {
-                window_[t] = static_cast<double>(t + 1) / window_.size();
+                window_[t] = static_cast<f32>(t + 1) / len;
             }
             for (size_t t = window_.size() / 2; t < window_.size(); ++t) {
-                window_[t] = 1.0 - static_cast<double>(t + 1) / window_.size();
+                window_[t] = 1.0 - static_cast<f32>(t + 1) / len;
             }
             break;
-        case WindowType::Hamming:
-            const double alpha = 0.54;
+        }
+        case WindowType::Hamming: {
+            if (window_.size() == 1ul) {
+                window_.front() = 1.0f;
+                break;
+            }
+            f32 const alpha = 0.54;
+            f32 const pi    = std::acos(-1.0);
             for (size_t n = 0ul; n < window_.size(); ++n) {
-                window_[n] = alpha - (1.0 - alpha) * std::cos((2.0 * M_PI * static_cast<double>(n)) / window_.size());
+                window_[n] = alpha - (1.0 - alpha) * std::cos((2.0 * pi * static_cast<f32>(n)) / static_cast<f32>(window_.size() - 1ul));
             }
             break;
+        }
     }
 
     if (interpolationMode_ == InterpolationMode::NegLogLinear or interpolationMode_ == InterpolationMode::NegLogLinearRenorm) {
-        std::transform(window_.begin(), window_.end(), window_.begin(), [](f32 weight) { return -std::log(weight); });
+        std::transform(
+                window_.begin(),
+                window_.end(),
+                window_.begin(),
+                [](f32 value) { return -std::log(value); });
     }
 }
 
 void ChunkedOnnxEncoder::flushPendingOutputsUpTo(size_t inputStart) {
-    for (auto it = pendingOutputs_.begin(); it != pendingOutputs_.end(); ++it) {
-        if (it->first >= inputStart) {
-            break;
-        }
-        auto& pendingOutput = it->second;
+    auto it = pendingOutputs_.begin();
+    while (it != pendingOutputs_.end() and it->first < inputStart) {
+        PendingOutput& pendingOutput = it->second;
         pendingOutput.finalize(interpolationMode_);
 
         outputBuffer_.push_back(
@@ -403,82 +399,55 @@ void ChunkedOnnxEncoder::flushPendingOutputsUpTo(size_t inputStart) {
                         .input_start = it->first,
                         .input_end   = pendingOutput.inputEnd,
                 });
-        pendingOutputs_.erase(it);
+        it = pendingOutputs_.erase(it);
     }
 }
 
-void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f64 weight) {
-    auto                   it = pendingOutputs_.find(data.input_start);
-    std::shared_ptr<f32[]> weightedEncoding(new f32[data.encoding.size()], std::default_delete<f32[]>());
-    switch (interpolationMode_) {
-        case InterpolationMode::Linear:
-        case InterpolationMode::LinearRenorm:
-            std::transform(
-                    data.encoding.data(),
-                    data.encoding.data() + data.encoding.size(),
-                    weightedEncoding.get(),
-                    [weight](f32 encodingValue) {
-                        return weight * encodingValue;
-                    });
-            break;
-        case InterpolationMode::NegLogLinear:
-        case InterpolationMode::NegLogLinearRenorm:
-            std::transform(
-                    data.encoding.data(),
-                    data.encoding.data() + data.encoding.size(),
-                    weightedEncoding.get(),
-                    [weight](f32 encodingValue) {
-                        return weight + encodingValue;
-                    });
-            break;
-        default:
-            std::copy(
-                    data.encoding.data(),
-                    data.encoding.data() + data.encoding.size(),
-                    weightedEncoding.get());
-            break;
-    }
+void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weight) {
+    bool negLogInterpolation = interpolationMode_ == InterpolationMode::NegLogLinear or interpolationMode_ == InterpolationMode::NegLogLinearRenorm;
 
-    if (it == pendingOutputs_.end()) {
-        pendingOutputs_.emplace(
-                data.input_start,
-                PendingOutput{
-                        .inputEnd        = data.input_end,
-                        .accumulator     = weightedEncoding,
-                        .accumulatorSize = data.encoding.size(),
-                        .totalWeight     = weight});
+    // Check if matching output is already pending
+    auto [it, inserted] = pendingOutputs_.emplace(
+            data.input_start,
+            PendingOutput{
+                    .inputEnd        = data.input_end,
+                    .accumulator     = std::shared_ptr<f32[]>(new f32[data.encoding.size()], std::default_delete<f32[]>()),
+                    .accumulatorSize = data.encoding.size(),
+                    .totalWeight     = weight});
+
+    PendingOutput& pendingOutput = it->second;
+    if (inserted) {
+        // No matching output exists, so initialize the accumulator with the weighted encoding
+        pendingOutput.inputEnd = data.input_end;
+        auto weightingFunction = negLogInterpolation
+                                         ? std::function<f32(f32)>([weight](f32 value) { return weight + value; })
+                                         : std::function<f32(f32)>([weight](f32 value) { return weight * value; });
+        std::transform(
+                data.encoding.data(),
+                data.encoding.data() + data.encoding.size(),
+                pendingOutput.accumulator.get(),
+                weightingFunction);
+        pendingOutput.totalWeight = weight;
         return;
     }
 
-    auto& pendingOutput = it->second;
+    // A matching output exists, so we combine it with the weighted encoding
+    auto interpolationFunction = negLogInterpolation
+                                         ? std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return Math::scoreSum(accumValue, encodingValue + weight); })
+                                         : std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return accumValue + encodingValue * weight; });
     require(pendingOutput.accumulatorSize == data.encoding.size());
-    switch (interpolationMode_) {
-        case InterpolationMode::Linear:
-        case InterpolationMode::LinearRenorm:
-            std::transform(
-                    pendingOutput.accumulator.get(),
-                    pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,
-                    weightedEncoding.get(),
-                    pendingOutput.accumulator.get(),
-                    [pendingOutput](f32 currentValue, f32 encodingValue) {
-                        return currentValue + encodingValue;
-                    });
-            pendingOutput.totalWeight += weight;
-            break;
-        case InterpolationMode::NegLogLinear:
-        case InterpolationMode::NegLogLinearRenorm:
-            std::transform(
-                    pendingOutput.accumulator.get(),
-                    pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,
-                    weightedEncoding.get(),
-                    pendingOutput.accumulator.get(),
-                    [pendingOutput](f32 currentValue, f32 encodingValue) {
-                        return Math::scoreSum(currentValue, encodingValue);
-                    });
-            pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
-            break;
-        default:
-            break;
+    std::transform(
+            pendingOutput.accumulator.get(),
+            pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,
+            data.encoding.data(),
+            pendingOutput.accumulator.get(),
+            interpolationFunction);
+
+    if (negLogInterpolation) {
+        pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
+    }
+    else {
+        pendingOutput.totalWeight += weight;
     }
 }
 

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -169,6 +169,37 @@ const Core::ParameterInt ChunkedOnnxEncoder::paramRightPadding(
         0,
         0);
 
+const Core::ParameterBool ChunkedOnnxEncoder::paramZeroPadding(
+        "zero-padding",
+        "If set, add zero-padding features at beginning and end of segment so that these chunks have the same total size as the others.",
+        false);
+
+const Core::Choice ChunkedOnnxEncoder::windowTypeChoice(
+        "none", WindowType::None,
+        "triangular", WindowType::Triangular,
+        "hamming", WindowType::Hamming,
+        Core::Choice::endMark());
+
+const Core::ParameterChoice ChunkedOnnxEncoder::paramWindowType(
+        "window-type",
+        &windowTypeChoice,
+        "Window function used to weight overlapping chunk outputs.",
+        WindowType::Triangular);
+
+const Core::Choice ChunkedOnnxEncoder::interpolationModeChoice(
+        "no-interpolation", InterpolationMode::NoInterpolation,
+        "linear", InterpolationMode::Linear,
+        "linear-renorm", InterpolationMode::LinearRenorm,
+        "neglog-linear", InterpolationMode::NegLogLinear,
+        "neglog-linear-renorm", InterpolationMode::NegLogLinearRenorm,
+        Core::Choice::endMark());
+
+const Core::ParameterChoice ChunkedOnnxEncoder::paramInterpolationMode(
+        "interpolation-mode",
+        &interpolationModeChoice,
+        "How overlapping chunk outputs are interpolated.",
+        InterpolationMode::NoInterpolation);
+
 ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::EncoderModelCache& cachedModel)
         : Core::Component(config),
           Precursor(config, cachedModel),
@@ -176,13 +207,54 @@ ChunkedOnnxEncoder::ChunkedOnnxEncoder(Core::Configuration const& config, Nn::En
           stepSize_(paramStepSize(config)),
           leftPadding_(paramLeftPadding(config)),
           rightPadding_(paramRightPadding(config)),
+          zeroPadding_(paramZeroPadding(config)),
+          leftZeroPaddingAdded_(false),
+          rightZeroPaddingAdded_(false),
+          interpolationMode_(static_cast<InterpolationMode>(paramInterpolationMode(config))),
           chunkCenterStart_(0ul),
-          numDiscardedFeatures_(0ul) {}
+          numDiscardedFeatures_(0ul),
+          pendingOutputs_() {
+    if (inputsPerOutput_ > chunkSize_) {
+        error("Chunk size must be large enough to produce at least one output");
+    }
+    require(inputsPerOutput_ <= chunkSize_);
+    initWindow(static_cast<WindowType>(paramWindowType(config)));
+}
 
 void ChunkedOnnxEncoder::reset() {
     Precursor::reset();
-    chunkCenterStart_     = 0ul;
-    numDiscardedFeatures_ = 0ul;
+    chunkCenterStart_      = 0ul;
+    numDiscardedFeatures_  = 0ul;
+    leftZeroPaddingAdded_  = false;
+    rightZeroPaddingAdded_ = false;
+    pendingOutputs_.clear();
+}
+
+void ChunkedOnnxEncoder::signalNoMoreFeatures() {
+    Precursor::signalNoMoreFeatures();
+    if (not rightZeroPaddingAdded_) {
+        rightZeroPaddingAdded_ = true;
+        if (inputBuffer_.empty()) {
+            return;
+        }
+        auto inputSize  = inputBuffer_.begin()->size();
+        auto zeroVector = Core::tsRef(new Mm::Feature::Vector(inputSize));
+        for (size_t i = 0ul; i < rightPadding_; ++i) {
+            Precursor::addInput({zeroVector});
+        }
+    }
+}
+
+void ChunkedOnnxEncoder::addInput(Nn::DataView const& input) {
+    if (not leftZeroPaddingAdded_) {
+        leftZeroPaddingAdded_ = true;
+        auto inputSize        = input.size();
+        auto zeroVector       = Core::tsRef(new Mm::Feature::Vector(inputSize));
+        for (size_t i = 0ul; i < leftPadding_; ++i) {
+            Precursor::addInput({zeroVector});
+        }
+    }
+    Precursor::addInput(input);
 }
 
 bool ChunkedOnnxEncoder::canEncode() const {
@@ -213,16 +285,18 @@ void ChunkedOnnxEncoder::encode() {
     size_t inputStep       = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
 
     // Buffer all outputs for which the start input lies inside the interval [chunkCenterStart_, chunkCenterEnd)
-    // The rest corresponds to the padding frames and gets skipped
-    size_t startInput = chunkStart;
+    // The rest corresponds to the padding frames and gets skipped.
+    size_t startInput     = chunkStart;
+    auto   weightIterator = window_.begin();
     for (size_t t = 0ul; t < nOutputs; ++t) {
         size_t endInput = std::min(startInput + inputsPerOutput, availableEnd);
         if (startInput >= chunkCenterStart_) {
-            outputBuffer_.push_back(
-                    Nn::EncodedSpan{
-                            .encoding    = {outputView, outputSize, t * outputSize},
-                            .input_start = startInput,
-                            .input_end   = endInput});
+            accumulatePendingOutput(Nn::EncodedSpan{
+                                            .encoding    = {outputView, outputSize, t * outputSize},
+                                            .input_start = startInput,
+                                            .input_end   = endInput},
+                                    *weightIterator);
+            ++weightIterator;
         }
         startInput += inputStep;
 
@@ -231,13 +305,15 @@ void ChunkedOnnxEncoder::encode() {
         }
     }
 
-    if (not expectMoreFeatures_ and chunkCenterEnd == availableEnd) {
-        // At segment end, stop once all inputs have been covered by a chunk center
-        chunkCenterStart_ = availableEnd;
+    bool isLastChunk  = not expectMoreFeatures_ and chunkCenterEnd == availableEnd;
+    chunkCenterStart_ = isLastChunk ? availableEnd : chunkCenterStart_ + stepSize_;
+
+    if (interpolationMode_ == InterpolationMode::NoInterpolation or isLastChunk) {
+        // Flush everything
+        flushPendingOutputsUpTo(Core::Type<size_t>::max);
     }
     else {
-        // Move to next chunk after encoding
-        chunkCenterStart_ += stepSize_;
+        flushPendingOutputsUpTo(chunkCenterStart_);
     }
 }
 
@@ -247,6 +323,163 @@ void ChunkedOnnxEncoder::postEncodeCleanup() {
 
     inputBuffer_.erase(inputBuffer_.begin(), inputBuffer_.begin() + numToDiscard);
     numDiscardedFeatures_ += numToDiscard;
+}
+
+void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::InterpolationMode mode) {
+    // Maybe renormalize based on totalWeight
+    switch (mode) {
+        case InterpolationMode::LinearRenorm:
+            std::transform(
+                    accumulator.get(),
+                    accumulator.get() + accumulatorSize,
+                    accumulator.get(),
+                    [this](f32 value) { return value / totalWeight; });
+            break;
+        case InterpolationMode::NegLogLinearRenorm:
+            std::transform(
+                    accumulator.get(),
+                    accumulator.get() + accumulatorSize,
+                    accumulator.get(),
+                    [this](f32 value) { return value - totalWeight; });
+            break;
+        default:
+            break;
+    }
+}
+
+void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
+    if (inputStepSize_ == 0) {
+        // We can't calculate the true window size based on the chunk size if the parameter hasn't been set
+        if (interpolationMode_ == InterpolationMode::NoInterpolation or windowType == WindowType::None) {
+            // If the weights don't depend on the window size, we don't care about the true window size and just
+            // resize it with an upper bound
+            window_.resize(chunkSize_);
+        }
+        else {
+            error("Input step size must be set so that the encoder can calculate how many outputs are expected per chunk.");
+        }
+    }
+    else {
+        // Ceildiv
+        window_.resize((chunkSize_ + inputStepSize_ - 1) / inputStepSize_);
+    }
+
+    switch (windowType) {
+        case WindowType::None:
+            std::fill(window_.begin(), window_.end(), 1.0);
+            break;
+        case WindowType::Triangular:
+            for (size_t t = 0ul; t < window_.size() / 2; ++t) {
+                window_[t] = static_cast<double>(t + 1) / window_.size();
+            }
+            for (size_t t = window_.size() / 2; t < window_.size(); ++t) {
+                window_[t] = 1.0 - static_cast<double>(t + 1) / window_.size();
+            }
+            break;
+        case WindowType::Hamming:
+            const double alpha = 0.54;
+            for (size_t n = 0ul; n < window_.size(); ++n) {
+                window_[n] = alpha - (1.0 - alpha) * std::cos((2.0 * M_PI * static_cast<double>(n)) / window_.size());
+            }
+            break;
+    }
+
+    if (interpolationMode_ == InterpolationMode::NegLogLinear or interpolationMode_ == InterpolationMode::NegLogLinearRenorm) {
+        std::transform(window_.begin(), window_.end(), window_.begin(), [](f32 weight) { return -std::log(weight); });
+    }
+}
+
+void ChunkedOnnxEncoder::flushPendingOutputsUpTo(size_t inputStart) {
+    for (auto it = pendingOutputs_.begin(); it != pendingOutputs_.end(); ++it) {
+        if (it->first >= inputStart) {
+            break;
+        }
+        auto& pendingOutput = it->second;
+        pendingOutput.finalize(interpolationMode_);
+
+        outputBuffer_.push_back(
+                Nn::EncodedSpan{
+                        .encoding    = {pendingOutput.accumulator, pendingOutput.accumulatorSize},
+                        .input_start = it->first,
+                        .input_end   = pendingOutput.inputEnd,
+                });
+        pendingOutputs_.erase(it);
+    }
+}
+
+void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f64 weight) {
+    auto                   it = pendingOutputs_.find(data.input_start);
+    std::shared_ptr<f32[]> weightedEncoding(new f32[data.encoding.size()], std::default_delete<f32[]>());
+    switch (interpolationMode_) {
+        case InterpolationMode::Linear:
+        case InterpolationMode::LinearRenorm:
+            std::transform(
+                    data.encoding.data(),
+                    data.encoding.data() + data.encoding.size(),
+                    weightedEncoding.get(),
+                    [weight](f32 encodingValue) {
+                        return weight * encodingValue;
+                    });
+            break;
+        case InterpolationMode::NegLogLinear:
+        case InterpolationMode::NegLogLinearRenorm:
+            std::transform(
+                    data.encoding.data(),
+                    data.encoding.data() + data.encoding.size(),
+                    weightedEncoding.get(),
+                    [weight](f32 encodingValue) {
+                        return weight + encodingValue;
+                    });
+            break;
+        default:
+            std::copy(
+                    data.encoding.data(),
+                    data.encoding.data() + data.encoding.size(),
+                    weightedEncoding.get());
+            break;
+    }
+
+    if (it == pendingOutputs_.end()) {
+        pendingOutputs_.emplace(
+                data.input_start,
+                PendingOutput{
+                        .inputEnd        = data.input_end,
+                        .accumulator     = weightedEncoding,
+                        .accumulatorSize = data.encoding.size(),
+                        .totalWeight     = weight});
+        return;
+    }
+
+    auto& pendingOutput = it->second;
+    require(pendingOutput.accumulatorSize == data.encoding.size());
+    switch (interpolationMode_) {
+        case InterpolationMode::Linear:
+        case InterpolationMode::LinearRenorm:
+            std::transform(
+                    pendingOutput.accumulator.get(),
+                    pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,
+                    weightedEncoding.get(),
+                    pendingOutput.accumulator.get(),
+                    [pendingOutput](f32 currentValue, f32 encodingValue) {
+                        return currentValue + encodingValue;
+                    });
+            pendingOutput.totalWeight += weight;
+            break;
+        case InterpolationMode::NegLogLinear:
+        case InterpolationMode::NegLogLinearRenorm:
+            std::transform(
+                    pendingOutput.accumulator.get(),
+                    pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,
+                    weightedEncoding.get(),
+                    pendingOutput.accumulator.get(),
+                    [pendingOutput](f32 currentValue, f32 encodingValue) {
+                        return Math::scoreSum(currentValue, encodingValue);
+                    });
+            pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
+            break;
+        default:
+            break;
+    }
 }
 
 }  // namespace Onnx

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -195,11 +195,8 @@ const Core::ParameterChoice ChunkedOnnxEncoder::paramWindowType(
 const Core::Choice ChunkedOnnxEncoder::interpolationModeChoice(
         "no-interpolation", InterpolationMode::NoInterpolation,
         "linear", InterpolationMode::Linear,
-        "linear-renorm", InterpolationMode::LinearRenorm,
         "log-linear", InterpolationMode::LogLinear,
-        "log-linear-renorm", InterpolationMode::LogLinearRenorm,
         "neglog-linear", InterpolationMode::NegLogLinear,
-        "neglog-linear-renorm", InterpolationMode::NegLogLinearRenorm,
         Core::Choice::endMark());
 
 const Core::ParameterChoice ChunkedOnnxEncoder::paramInterpolationMode(
@@ -321,15 +318,15 @@ void ChunkedOnnxEncoder::postEncodeCleanup() {
 
 void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::InterpolationMode mode) {
     switch (mode) {
-        case InterpolationMode::LinearRenorm:
+        case InterpolationMode::Linear:
             std::transform(
                     accumulator.get(),
                     accumulator.get() + accumulatorSize,
                     accumulator.get(),
                     [this](f32 value) { return value / totalWeight; });
             break;
-        case InterpolationMode::LogLinearRenorm:
-        case InterpolationMode::NegLogLinearRenorm:
+        case InterpolationMode::LogLinear:
+        case InterpolationMode::NegLogLinear:
             std::transform(
                     accumulator.get(),
                     accumulator.get() + accumulatorSize,
@@ -388,7 +385,6 @@ void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
 
     switch (interpolationMode_) {
         case InterpolationMode::LogLinear:
-        case InterpolationMode::LogLinearRenorm:
             std::transform(
                     window_.begin(),
                     window_.end(),
@@ -396,7 +392,6 @@ void ChunkedOnnxEncoder::initWindow(WindowType windowType) {
                     [](f32 value) { return std::log(value); });
             break;
         case InterpolationMode::NegLogLinear:
-        case InterpolationMode::NegLogLinearRenorm:
             std::transform(
                     window_.begin(),
                     window_.end(),
@@ -443,13 +438,10 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
         std::function<f32(f32)> weightingFunction;
         switch (interpolationMode_) {
             case InterpolationMode::Linear:
-            case InterpolationMode::LinearRenorm:
                 weightingFunction = std::function<f32(f32)>([weight](f32 value) { return weight * value; });
                 break;
             case InterpolationMode::LogLinear:
-            case InterpolationMode::LogLinearRenorm:
             case InterpolationMode::NegLogLinear:
-            case InterpolationMode::NegLogLinearRenorm:
                 weightingFunction = std::function<f32(f32)>([weight](f32 value) { return weight + value; });
                 break;
             default:
@@ -469,17 +461,14 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
     std::function<f32(f32, f32)> interpolationFunction;
     switch (interpolationMode_) {
         case InterpolationMode::Linear:
-        case InterpolationMode::LinearRenorm:
             interpolationFunction = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return accumValue + encodingValue * weight; });
             pendingOutput.totalWeight += weight;
             break;
         case InterpolationMode::LogLinear:
-        case InterpolationMode::LogLinearRenorm:
             interpolationFunction     = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return -Math::scoreSum(-accumValue, -(encodingValue + weight)); });
             pendingOutput.totalWeight = -Math::scoreSum(-pendingOutput.totalWeight, -weight);
             break;
         case InterpolationMode::NegLogLinear:
-        case InterpolationMode::NegLogLinearRenorm:
             interpolationFunction     = std::function<f32(f32, f32)>([weight](f32 accumValue, f32 encodingValue) { return Math::scoreSum(accumValue, encodingValue + weight); });
             pendingOutput.totalWeight = Math::scoreSum(pendingOutput.totalWeight, weight);
             break;

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -236,8 +236,14 @@ void ChunkedOnnxEncoder::encode() {
         }
     }
 
-    // Move to next chunk after encoding
-    chunkCenterStart_ += stepSize_;
+    if (not expectMoreFeatures_ and chunkCenterEnd == availableEnd) {
+        // At segment end, stop once all inputs have been covered by a chunk center
+        chunkCenterStart_ = availableEnd;
+    }
+    else {
+        // Move to next chunk after encoding
+        chunkCenterStart_ += stepSize_;
+    }
 }
 
 void ChunkedOnnxEncoder::postEncodeCleanup() {

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -489,6 +489,7 @@ void ChunkedOnnxEncoder::accumulatePendingOutput(Nn::EncodedSpan data, f32 weigh
     }
 
     require(pendingOutput.accumulatorSize == data.encoding.size());
+    pendingOutput.inputEnd = std::max(pendingOutput.inputEnd, data.input_end);
     std::transform(
             pendingOutput.accumulator.get(),
             pendingOutput.accumulator.get() + pendingOutput.accumulatorSize,

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -84,11 +84,15 @@ OnnxEncoder::SessionRunResult OnnxEncoder::runSession(size_t inputStartIndex, si
     std::vector<int64_t> featureShape = {1l, static_cast<int64_t>(leftZeroPadding + nInputs + rightZeroPadding), static_cast<int64_t>(F)};
     Value                value        = Value::createEmpty<f32>(featureShape);
 
-    std::fill(value.data<f32>(0, 0), value.data<f32>(0, leftZeroPadding), 0.0f);
+    if (leftZeroPadding > 0) {
+        std::fill(value.data<f32>(0, 0), value.data<f32>(0, 0) + leftZeroPadding * F, 0.0f);
+    }
     for (size_t t = leftZeroPadding; t < leftZeroPadding + nInputs; ++t) {
         std::copy(inputBuffer_[inputStartIndex + t - leftZeroPadding].data(), inputBuffer_[inputStartIndex + t - leftZeroPadding].data() + F, value.data<f32>(0, t));
     }
-    std::fill(value.data<f32>(0, leftZeroPadding + nInputs), value.data<f32>(0, leftZeroPadding + nInputs + rightZeroPadding), 0.0f);
+    if (rightZeroPadding > 0) {
+        std::fill(value.data<f32>(0, leftZeroPadding + nInputs), value.data<f32>(0, leftZeroPadding + nInputs) + rightZeroPadding * F, 0.0f);
+    }
     sessionInputs.emplace_back(featuresName_, std::move(value));
 
     if (featuresSizeName_ != "") {

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -268,8 +268,9 @@ void ChunkedOnnxEncoder::encode() {
 
     auto [outputView, nOutputs, outputSize] = runSession(inputStartIndex, nInputs, prependZeroCount, appendZeroCount);
 
-    size_t inputsPerOutput = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (nInputs / nOutputs + (nInputs % nOutputs != 0ul));
-    size_t inputStep       = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
+    size_t totalSessionInputs = prependZeroCount + nInputs + appendZeroCount;
+    size_t inputsPerOutput    = (inputsPerOutput_ != 0ul) ? inputsPerOutput_ : (totalSessionInputs / nOutputs + (totalSessionInputs % nOutputs != 0ul));
+    size_t inputStep          = (inputStepSize_ != 0ul) ? inputStepSize_ : inputsPerOutput;
 
     // Buffer all outputs for which the start input lies inside the interval [chunkCenterStart_, chunkCenterEnd)
     // The rest corresponds to the padding frames and gets skipped.

--- a/src/Onnx/OnnxEncoder.cc
+++ b/src/Onnx/OnnxEncoder.cc
@@ -329,18 +329,12 @@ void ChunkedOnnxEncoder::PendingOutput::finalize(ChunkedOnnxEncoder::Interpolati
                     [this](f32 value) { return value / totalWeight; });
             break;
         case InterpolationMode::LogLinearRenorm:
-            std::transform(
-                    accumulator.get(),
-                    accumulator.get() + accumulatorSize,
-                    accumulator.get(),
-                    [this](f32 value) { return value - totalWeight; });
-            break;
         case InterpolationMode::NegLogLinearRenorm:
             std::transform(
                     accumulator.get(),
                     accumulator.get() + accumulatorSize,
                     accumulator.get(),
-                    [this](f32 value) { return value + totalWeight; });
+                    [this](f32 value) { return value - totalWeight; });
             break;
         default:
             break;

--- a/src/Onnx/OnnxEncoder.hh
+++ b/src/Onnx/OnnxEncoder.hh
@@ -116,6 +116,8 @@ private:
         NoInterpolation,
         Linear,
         LinearRenorm,
+        LogLinear,
+        LogLinearRenorm,
         NegLogLinear,
         NegLogLinearRenorm,
     };

--- a/src/Onnx/OnnxEncoder.hh
+++ b/src/Onnx/OnnxEncoder.hh
@@ -115,11 +115,8 @@ private:
     enum InterpolationMode {
         NoInterpolation,
         Linear,
-        LinearRenorm,
         LogLinear,
-        LogLinearRenorm,
         NegLogLinear,
-        NegLogLinearRenorm,
     };
 
     struct PendingOutput {

--- a/src/Onnx/OnnxEncoder.hh
+++ b/src/Onnx/OnnxEncoder.hh
@@ -16,6 +16,8 @@
 #ifndef ONNX_ENCODER_HH
 #define ONNX_ENCODER_HH
 
+#include <map>
+
 #include <Nn/LabelScorer/Encoder.hh>
 #include <Nn/LabelScorer/EncoderFactory.hh>
 
@@ -49,7 +51,8 @@ protected:
     virtual void encode() override;
 
     // Runs onnxModel_ on features from inputBuffer_[inputStartIndex : inputStartIndex + nInputs]
-    SessionRunResult runSession(size_t inputStartIndex, size_t nInputs);
+    // Potentially add zero-padding features to inputs before running session
+    SessionRunResult runSession(size_t inputStartIndex, size_t nInputs, size_t leftZeroPadding = 0ul, size_t rightZeroPadding = 0ul);
 
     const size_t inputsPerOutput_;
     const size_t inputStepSize_;
@@ -90,10 +93,6 @@ public:
 
     ChunkedOnnxEncoder(Core::Configuration const& config, Nn::EncoderModelCache& cachedModel);
 
-    // Modify these to optionally add zero-padding at beginning and end
-    void signalNoMoreFeatures() override;
-    void addInput(Nn::DataView const& input) override;
-
     virtual void reset() override;
 
 protected:
@@ -125,8 +124,9 @@ private:
         size_t                 inputEnd;
         std::shared_ptr<f32[]> accumulator;  // Used to build up the interpolation result
         size_t                 accumulatorSize;
-        f64                    totalWeight;  // For potential renormalization
+        f32                    totalWeight;  // For potential renormalization
 
+        // Optional renormalization based on total weight depending on mode
         void finalize(InterpolationMode mode);
     };
 
@@ -137,15 +137,13 @@ private:
     void flushPendingOutputsUpTo(size_t inputStart);
 
     // Add data from outputView to associated pending output or create a new one if none exists
-    void accumulatePendingOutput(Nn::EncodedSpan data, f64 weight);
+    void accumulatePendingOutput(Nn::EncodedSpan data, f32 weight);
 
     size_t            chunkSize_;
     size_t            stepSize_;
     size_t            leftPadding_;
     size_t            rightPadding_;
     bool              zeroPadding_;
-    bool              leftZeroPaddingAdded_;
-    bool              rightZeroPaddingAdded_;
     std::vector<f32>  window_;
     InterpolationMode interpolationMode_;
 

--- a/src/Onnx/OnnxEncoder.hh
+++ b/src/Onnx/OnnxEncoder.hh
@@ -17,8 +17,8 @@
 #define ONNX_ENCODER_HH
 
 #include <Nn/LabelScorer/Encoder.hh>
-
 #include <Nn/LabelScorer/EncoderFactory.hh>
+
 #include "Model.hh"
 #include "StateManager.hh"
 
@@ -78,12 +78,21 @@ class ChunkedOnnxEncoder : public OnnxEncoder {
 public:
     using Precursor = OnnxEncoder;
 
-    static const Core::ParameterInt paramChunkSize;
-    static const Core::ParameterInt paramStepSize;
-    static const Core::ParameterInt paramLeftPadding;
-    static const Core::ParameterInt paramRightPadding;
+    static const Core::ParameterInt    paramChunkSize;
+    static const Core::ParameterInt    paramStepSize;
+    static const Core::ParameterInt    paramLeftPadding;
+    static const Core::ParameterInt    paramRightPadding;
+    static const Core::ParameterBool   paramZeroPadding;
+    static const Core::Choice          windowTypeChoice;
+    static const Core::ParameterChoice paramWindowType;
+    static const Core::Choice          interpolationModeChoice;
+    static const Core::ParameterChoice paramInterpolationMode;
 
     ChunkedOnnxEncoder(Core::Configuration const& config, Nn::EncoderModelCache& cachedModel);
+
+    // Modify these to optionally add zero-padding at beginning and end
+    void signalNoMoreFeatures() override;
+    void addInput(Nn::DataView const& input) override;
 
     virtual void reset() override;
 
@@ -98,13 +107,51 @@ protected:
     virtual void postEncodeCleanup() override;
 
 private:
-    const size_t chunkSize_;
-    const size_t stepSize_;
-    const size_t leftPadding_;
-    const size_t rightPadding_;
+    enum WindowType {
+        None,
+        Triangular,
+        Hamming,
+    };
 
-    size_t chunkCenterStart_;  // Current absolute chunk start position disregarding how many features have been discarded so far
-    size_t numDiscardedFeatures_;
+    enum InterpolationMode {
+        NoInterpolation,
+        Linear,
+        LinearRenorm,
+        NegLogLinear,
+        NegLogLinearRenorm,
+    };
+
+    struct PendingOutput {
+        size_t                 inputEnd;
+        std::shared_ptr<f32[]> accumulator;  // Used to build up the interpolation result
+        size_t                 accumulatorSize;
+        f64                    totalWeight;  // For potential renormalization
+
+        void finalize(InterpolationMode mode);
+    };
+
+    // Pre-compute window weights for expected chunk output size
+    void initWindow(WindowType windowType);
+
+    // Flush all outputs for which the input start time is before `inputStart` as no outputs from later chunks will add to them
+    void flushPendingOutputsUpTo(size_t inputStart);
+
+    // Add data from outputView to associated pending output or create a new one if none exists
+    void accumulatePendingOutput(Nn::EncodedSpan data, f64 weight);
+
+    size_t            chunkSize_;
+    size_t            stepSize_;
+    size_t            leftPadding_;
+    size_t            rightPadding_;
+    bool              zeroPadding_;
+    bool              leftZeroPaddingAdded_;
+    bool              rightZeroPaddingAdded_;
+    std::vector<f32>  window_;
+    InterpolationMode interpolationMode_;
+
+    size_t                          chunkCenterStart_;  // Current absolute chunk start position disregarding how many features have been discarded so far
+    size_t                          numDiscardedFeatures_;
+    std::map<size_t, PendingOutput> pendingOutputs_;  // Associate outputs with their input start time to interpolate outputs from different chunks. Ordered for flushing
 };
 
 }  // namespace Onnx

--- a/src/Onnx/OnnxEncoder.hh
+++ b/src/Onnx/OnnxEncoder.hh
@@ -25,7 +25,7 @@
 namespace Onnx {
 
 // Encoder that runs the input features through an ONNX model
-class OnnxEncoder : public virtual Nn::Encoder {
+class OnnxEncoder : public Nn::Encoder {
 public:
     using Precursor = Nn::Encoder;
 
@@ -39,10 +39,18 @@ public:
     virtual void reset() override;
 
 protected:
+    struct SessionRunResult {
+        Nn::DataView outputView;
+        size_t       nOutputs;
+        size_t       outputSize;
+    };
+
     // Encode features inside the input buffer and put the results into the output buffer
     virtual void encode() override;
 
-private:
+    // Runs onnxModel_ on features from inputBuffer_[inputStartIndex : inputStartIndex + nInputs]
+    SessionRunResult runSession(size_t inputStartIndex, size_t nInputs);
+
     const size_t inputsPerOutput_;
     const size_t inputStepSize_;
 
@@ -53,6 +61,50 @@ private:
 
     std::unique_ptr<StateManager>  stateManager_;
     std::vector<OnnxStateVariable> stateVariables_;
+};
+
+/*
+ * Encoder that chunks the input features before running them through an ONNX model
+ * For example with chunk-size = 50, step-size = 25, left-padding = 10, right-padding = 5
+ * and 90 feature inputs in total
+ *  - The first chunk consists of features 0 to 55 and the outputs corresponding to
+ *    features 0 to 50 are returned
+ *  - The second chunk consists of features 15 to 80 and the outputs corresponding to
+ *    features 25 to 75 are returned
+ *  - The third chunk consists of features 40 to 90 and the outputs corresponding to
+ *    features 50 to 90 are returned
+ */
+class ChunkedOnnxEncoder : public OnnxEncoder {
+public:
+    using Precursor = OnnxEncoder;
+
+    static const Core::ParameterInt paramChunkSize;
+    static const Core::ParameterInt paramStepSize;
+    static const Core::ParameterInt paramLeftPadding;
+    static const Core::ParameterInt paramRightPadding;
+
+    ChunkedOnnxEncoder(Core::Configuration const& config, Nn::EncoderModelCache& cachedModel);
+
+    virtual void reset() override;
+
+protected:
+    // Check if enough features are buffered to fill the chunk or segment end has been signaled
+    virtual bool canEncode() const override;
+
+    // Encode a single chunk of features
+    virtual void encode() override;
+
+    // Discard all features from input buffer that are no longer needed for future chunks
+    virtual void postEncodeCleanup() override;
+
+private:
+    const size_t chunkSize_;
+    const size_t stepSize_;
+    const size_t leftPadding_;
+    const size_t rightPadding_;
+
+    size_t chunkCenterStart_;  // Current absolute chunk start position disregarding how many features have been discarded so far
+    size_t numDiscardedFeatures_;
 };
 
 }  // namespace Onnx


### PR DESCRIPTION
This PR adds a new Encoder class `ChunkedOnnxEncoder` which inherits from `OnnxEncoder`. The `OnnxEncoder` class has been slightly refactored so that the session run logic can be re-used in the child class. The `ChunkedOnnxEncoder` has a few additional parameters that define the structure of the chunks: "chunk-size", "step-size", "left-padding" and "right-padding".

For example with chunk-size = 50, step-size = 25, left-padding = 10, right-padding = 5 and 90 feature inputs in total
 - The first chunk consists of features 0 to 55 and the outputs corresponding to features 0 to 50 are returned
 - The second chunk consists of features 15 to 80 and the outputs corresponding to features 25 to 75 are returned
 - The third chunk consists of features 40 to 90 and the outputs corresponding to features 50 to 90 are returned