### PR TITLE
TreeTimesyncBeamSearch and LexiconfreeTimesyncBeamSearch: Fix timestamp increment at sentence end

### DIFF
--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -59,10 +59,12 @@ LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
             predecessor = base.trace;
             break;
     }
-    trace = Core::ref(new LatticeTrace(
+    // Only increment timeframe when not SENTENCE_END
+    auto timeframe = Nn::TransitionType::SENTENCE_END ? extension.timeframe : extension.timeframe + 1;
+    trace          = Core::ref(new LatticeTrace(
             predecessor,
             extension.pron,
-            extension.timeframe + 1,
+            timeframe,
             {score, 0},
             {}));
 }
@@ -773,8 +775,6 @@ void LexiconfreeTimesyncBeamSearch::finalizeHypotheses() {
         auto&       ext     = extensions_[extensionIdx];
         auto const& baseHyp = beam_[ext.baseHypIndex];
         // The scoring context is not updated as no further scoring is done afterwards
-        // Make sentence-end length 0 as it should not consume a timestep
-        ext.timeframe -= 1;
         tempHypotheses_.push_back({baseHyp, ext, baseHyp.scoringContexts});
     }
 

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -773,6 +773,8 @@ void LexiconfreeTimesyncBeamSearch::finalizeHypotheses() {
         auto&       ext     = extensions_[extensionIdx];
         auto const& baseHyp = beam_[ext.baseHypIndex];
         // The scoring context is not updated as no further scoring is done afterwards
+        // Make sentence-end length 0 as it should not consume a timestep
+        ext.timeframe -= 1;
         tempHypotheses_.push_back({baseHyp, ext, baseHyp.scoringContexts});
     }
 

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -59,9 +59,10 @@ LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
             predecessor = base.trace;
             break;
     }
+
     // Only increment timeframe when not SENTENCE_END
-    auto timeframe = Nn::TransitionType::SENTENCE_END ? extension.timeframe : extension.timeframe + 1;
-    trace          = Core::ref(new LatticeTrace(
+    auto timeframe = extension.transitionType == Nn::TransitionType::SENTENCE_END ? extension.timeframe : extension.timeframe + 1;
+    trace = Core::ref(new LatticeTrace(
             predecessor,
             extension.pron,
             timeframe,

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -62,7 +62,7 @@ LexiconfreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
 
     // Only increment timeframe when not SENTENCE_END
     auto timeframe = extension.transitionType == Nn::TransitionType::SENTENCE_END ? extension.timeframe : extension.timeframe + 1;
-    trace = Core::ref(new LatticeTrace(
+    trace          = Core::ref(new LatticeTrace(
             predecessor,
             extension.pron,
             timeframe,

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -66,17 +66,19 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
           currentToken(base.currentToken),
           currentState(extension.rootState),
           lmHistory(newLmHistory),
-          timeframe(base.timeframe),
           score(extension.score) {
     auto newLmScore   = score - base.score;
     auto totalLmScore = base.trace->score.lm + newLmScore;
     auto totalAmScore = score - totalLmScore;
 
+    // Only increment timeframe when not SENTENCE_END
+    timeframe = Nn::TransitionType::SENTENCE_END ? base.timeframe : base.timeframe + 1;
+
     // Create a successor trace item from base
     trace = Core::ref(new LatticeTrace(
             base.trace,
             extension.pron,
-            timeframe + 1,
+            timeframe,
             {totalAmScore, totalLmScore},
             {}));
 }
@@ -1004,8 +1006,6 @@ void TreeTimesyncBeamSearch::finalizeHypotheses() {
         for (size_t extensionIdx = 0ul; extensionIdx < wordEndExtensions_.size(); ++extensionIdx) {
             auto& ext     = wordEndExtensions_[extensionIdx];
             auto& baseHyp = newBeam_[ext.baseHypIndex];
-            // Make sentence-end length 0 as it should not consume a timestep
-            baseHyp.timeframe -= 1;
             tempHypotheses_.push_back({baseHyp, ext, baseHyp.lmHistory});
         }
     }

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -1002,8 +1002,10 @@ void TreeTimesyncBeamSearch::finalizeHypotheses() {
 
         tempHypotheses_.clear();
         for (size_t extensionIdx = 0ul; extensionIdx < wordEndExtensions_.size(); ++extensionIdx) {
-            auto&       ext     = wordEndExtensions_[extensionIdx];
-            auto const& baseHyp = newBeam_[ext.baseHypIndex];
+            auto& ext     = wordEndExtensions_[extensionIdx];
+            auto& baseHyp = newBeam_[ext.baseHypIndex];
+            // Make sentence-end length 0 as it should not consume a timestep
+            baseHyp.timeframe -= 1;
             tempHypotheses_.push_back({baseHyp, ext, baseHyp.lmHistory});
         }
     }

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -72,7 +72,7 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
     auto totalAmScore = score - totalLmScore;
 
     // Only increment timeframe when not SENTENCE_END
-    timeframe = Nn::TransitionType::SENTENCE_END ? base.timeframe : base.timeframe + 1;
+    timeframe = extension.transitionType == Nn::TransitionType::SENTENCE_END ? base.timeframe : base.timeframe + 1;
 
     // Create a successor trace item from base
     trace = Core::ref(new LatticeTrace(
@@ -602,7 +602,9 @@ bool TreeTimesyncBeamSearch::decodeStep() {
             wordEndExtensions_.push_back({.pron         = lemmaPron,
                                           .rootState    = exit.transitState,
                                           .score        = hyp.score + lmScore + penalty,
-                                          .baseHypIndex = hypIndex});
+                                          .transitionType = wordEndtransitionType,
+                                          .baseHypIndex = hypIndex,
+                                          });
         }
     }
 
@@ -999,7 +1001,9 @@ void TreeTimesyncBeamSearch::finalizeHypotheses() {
             wordEndExtensions_.push_back({.pron         = sentenceEndLemma_->pronunciations().first,
                                           .rootState    = hyp.currentState,
                                           .score        = hyp.score + sentenceEndScore,
-                                          .baseHypIndex = hypIndex});
+                                          .transitionType = Nn::TransitionType::SENTENCE_END,
+                                          .baseHypIndex = hypIndex,
+                                          });
         }
 
         tempHypotheses_.clear();

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -1004,8 +1004,8 @@ void TreeTimesyncBeamSearch::finalizeHypotheses() {
 
         tempHypotheses_.clear();
         for (size_t extensionIdx = 0ul; extensionIdx < wordEndExtensions_.size(); ++extensionIdx) {
-            auto& ext     = wordEndExtensions_[extensionIdx];
-            auto& baseHyp = newBeam_[ext.baseHypIndex];
+            auto&       ext     = wordEndExtensions_[extensionIdx];
+            auto const& baseHyp = newBeam_[ext.baseHypIndex];
             tempHypotheses_.push_back({baseHyp, ext, baseHyp.lmHistory});
         }
     }

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -66,19 +66,20 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
           currentToken(base.currentToken),
           currentState(extension.rootState),
           lmHistory(newLmHistory),
+          timeframe(base.timeframe),
           score(extension.score) {
     auto newLmScore   = score - base.score;
     auto totalLmScore = base.trace->score.lm + newLmScore;
     auto totalAmScore = score - totalLmScore;
 
     // Only increment timeframe when not SENTENCE_END
-    timeframe = extension.transitionType == Nn::TransitionType::SENTENCE_END ? base.timeframe : base.timeframe + 1;
+    auto trace_timeframe = extension.transitionType == Nn::TransitionType::SENTENCE_END ? base.timeframe : base.timeframe + 1;
 
     // Create a successor trace item from base
     trace = Core::ref(new LatticeTrace(
             base.trace,
             extension.pron,
-            timeframe,
+            trace_timeframe,
             {totalAmScore, totalLmScore},
             {}));
 }

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -599,12 +599,13 @@ bool TreeTimesyncBeamSearch::decodeStep() {
                 penalty += (*scoreAccessor)->getScore(wordEndtransitionType);
             }
 
-            wordEndExtensions_.push_back({.pron         = lemmaPron,
-                                          .rootState    = exit.transitState,
-                                          .score        = hyp.score + lmScore + penalty,
-                                          .transitionType = wordEndtransitionType,
-                                          .baseHypIndex = hypIndex,
-                                          });
+            wordEndExtensions_.push_back({
+                    .pron           = lemmaPron,
+                    .rootState      = exit.transitState,
+                    .score          = hyp.score + lmScore + penalty,
+                    .transitionType = wordEndtransitionType,
+                    .baseHypIndex   = hypIndex,
+            });
         }
     }
 
@@ -998,12 +999,13 @@ void TreeTimesyncBeamSearch::finalizeHypotheses() {
             // Add the LM's sentence-end score
             // The LM history is not updated as this is the last LM scoring step
             Lm::Score sentenceEndScore = languageModel_->sentenceEndScore(hyp.lmHistory);
-            wordEndExtensions_.push_back({.pron         = sentenceEndLemma_->pronunciations().first,
-                                          .rootState    = hyp.currentState,
-                                          .score        = hyp.score + sentenceEndScore,
-                                          .transitionType = Nn::TransitionType::SENTENCE_END,
-                                          .baseHypIndex = hypIndex,
-                                          });
+            wordEndExtensions_.push_back({
+                    .pron           = sentenceEndLemma_->pronunciations().first,
+                    .rootState      = hyp.currentState,
+                    .score          = hyp.score + sentenceEndScore,
+                    .transitionType = Nn::TransitionType::SENTENCE_END,
+                    .baseHypIndex   = hypIndex,
+            });
         }
 
         tempHypotheses_.clear();

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -96,6 +96,7 @@ protected:
         Bliss::LemmaPronunciation const* pron;          // Proposed lemma pronunciation
         StateId                          rootState;     // Proposed root-state to transition to
         Score                            score;         // Would-be total score of the full hypothesis after LM score contribution
+        Nn::TransitionType               transitionType;  // Type of transition towward `rootState`
         size_t                           baseHypIndex;  // Index of base hypothesis in beam
 
         bool operator<(WordEndExtensionCandidate const& other) {

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -93,11 +93,11 @@ protected:
     };
 
     struct WordEndExtensionCandidate {
-        Bliss::LemmaPronunciation const* pron;          // Proposed lemma pronunciation
-        StateId                          rootState;     // Proposed root-state to transition to
-        Score                            score;         // Would-be total score of the full hypothesis after LM score contribution
+        Bliss::LemmaPronunciation const* pron;            // Proposed lemma pronunciation
+        StateId                          rootState;       // Proposed root-state to transition to
+        Score                            score;           // Would-be total score of the full hypothesis after LM score contribution
         Nn::TransitionType               transitionType;  // Type of transition towward `rootState`
-        size_t                           baseHypIndex;  // Index of base hypothesis in beam
+        size_t                           baseHypIndex;    // Index of base hypothesis in beam
 
         bool operator<(WordEndExtensionCandidate const& other) {
             return score < other.score;


### PR DESCRIPTION
Sentence End (SE) should have length 0, i.e., timeframe should not be consumed. 
However, since the label hypothesis constructor automatically increments timeframe, at `finalizeHypotheses`, SE hypotheses were created with timeframe which is out of range (because at this point all timeframes are consumed).
This PR simply decrement the timeframe in `finalizeHypotheses`. 