### PR TITLE
Refactoring: Insert explicit casts in many places to get rid of sign-compare warnings

### DIFF
--- a/src/Bliss/Phoneme.cc
+++ b/src/Bliss/Phoneme.cc
@@ -103,7 +103,7 @@ Core::Ref<const PhonemeAlphabet> PhonemeInventory::phonemeAlphabet() const {
 std::set<Phoneme::Id> PhonemeInventory::parseSelection(std::string selector) const {
     std::set<Bliss::Phoneme::Id> selection;
     if (!selector.empty()) {
-        for (Bliss::Token::Id phone = 1; phone < nPhonemes(); ++phone) {
+        for (Bliss::Token::Id phone = 1; phone < static_cast<Bliss::Token::Id>(nPhonemes()); ++phone) {
             std::string phoneName(phoneme(phone)->symbol());
             if ((selector[0] == '*' && selector[selector.length() - 1] == '*' && phoneName.find(selector.substr(1, selector.length() - 2)) != std::string::npos) ||
                 (selector[0] == '*' && phoneName.rfind(selector.substr(1)) == phoneName.length() - (selector.length() - 1)) ||

--- a/src/Core/MappedArchive.cc
+++ b/src/Core/MappedArchive.cc
@@ -138,7 +138,7 @@ MappedArchiveWriter MappedArchive::getWriter(std::string name) {
 
     // Skip the header, which we will write later
     currentWriter_->itemOffset_ = currentWriter_->out_->tellp();
-    if (!currentWriter_->out_->good() || currentWriter_->itemOffset_ == -1) {
+    if (!currentWriter_->out_->good() || currentWriter_->itemOffset_ == static_cast<size_t>(-1)) {
         delete currentWriter_;
         currentWriter_ = 0;
         Core::Application::us()->log() << tempFile_ << ": creating writer failed " << name;
@@ -192,11 +192,11 @@ void MappedArchive::releaseWriter(MappedArchive::Writer* writer) {
     fwrite((char*)&nameLength, sizeof(u32), 1, f);
     fwrite((char*)&dataSize, sizeof(u64), 1, f);
 
-    verify(ftell(f) == writer->itemOffset_ + sizeof(u32) + sizeof(u64));
+    verify(ftell(f) == static_cast<long>(writer->itemOffset_ + sizeof(u32) + sizeof(u64)));
 
     fwrite(writer->name_.data(), sizeof(char), writer->name_.length(), f);
 
-    verify(ftell(f) == writer->itemOffset_ + sizeof(u32) + sizeof(u64) + nameLength);
+    verify(ftell(f) == static_cast<long>(writer->itemOffset_ + sizeof(u32) + sizeof(u64) + nameLength));
     verify(writer->dataOffset_ == writer->itemOffset_ + sizeof(u32) + sizeof(u64) + nameLength);
 
     verify((size_t)ftell(f) == writer->dataOffset_);

--- a/src/Flf/IncrementalRecognizer.cc
+++ b/src/Flf/IncrementalRecognizer.cc
@@ -409,22 +409,22 @@ struct ForwardBackwardAlignment {
                 }
             }
             if (!badForWords.count(*it + 1)) {
-                if (*it == forWords.size() - 1) {
+                if (static_cast<size_t>(*it) == forWords.size() - 1) {
                     currentRange.endTime = segmentLength_ - 1;
                 }
                 else {
                     currentRange.lastForWord = *it + 1;
-                    verify(currentRange.lastForWord >= 0 && currentRange.lastForWord < forWords.size());
+                    verify(currentRange.lastForWord >= 0 && static_cast<size_t>(currentRange.lastForWord) < forWords.size());
                     currentRange.endTime      = forWords[currentRange.lastForWord].end;
                     currentRange.lastBackWord = forWordAlignment[currentRange.lastForWord];
-                    verify(currentRange.lastBackWord >= 0 && currentRange.lastBackWord < backWords.size());
-                    verify(currentRange.endTime == backWords[currentRange.lastBackWord].end);
+                    verify(currentRange.lastBackWord >= 0 && static_cast<size_t>(currentRange.lastBackWord) < backWords.size());
+                    verify(static_cast<u32>(currentRange.endTime) == backWords[currentRange.lastBackWord].end);
                     currentRange.backwardCoarticulation = backward_->boundary(backWords[currentRange.lastBackWord].originState).transit();
                     verify(forward_->getState(forWords[currentRange.lastForWord].originState)->nArcs() == 1);
                     currentRange.finalCoarticulation = forward_->boundary(forward_->getState(forWords[currentRange.lastForWord].originState)->getArc(0)->target()).transit();
                     for (u32 q = currentRange.lastForWord + 1; q < forWords.size(); ++q)
                         currentRange.suffix.push_back(forWords[q].pron->lemma());
-                    if (currentRange.lastForWord + 1 < forWords.size()) {
+                    if (static_cast<size_t>(currentRange.lastForWord + 1) < forWords.size()) {
                         const Bliss::LemmaPronunciation* pron = forWords[currentRange.lastForWord + 1].pron;
                         if (pron && pron->pronunciation()->length())
                             currentRange.sufPhon = pron->pronunciation()->operator[](0);
@@ -437,7 +437,7 @@ struct ForwardBackwardAlignment {
                     currentRange.firstForWord = -1;
                 }
 
-                if (currentRange.lastForWord == forWords.size() - 1) {
+                if (static_cast<size_t>(currentRange.lastForWord) == forWords.size() - 1) {
                     // Lift unneeded constraints
                     currentRange.endTime     = segmentLength_ - 1;
                     currentRange.lastForWord = -1;
@@ -454,15 +454,15 @@ struct ForwardBackwardAlignment {
                 }
                 else {
                     currentRange.firstBackWord = *it - 1;
-                    verify(currentRange.firstBackWord >= 0 && currentRange.firstBackWord < backWords.size());
+                    verify(currentRange.firstBackWord >= 0 && static_cast<size_t>(currentRange.firstBackWord) < backWords.size());
                     currentRange.startTime = backWords[currentRange.firstBackWord].start;
                     verify(backWordAlignment.count(currentRange.firstBackWord));
                     currentRange.firstForWord = backWordAlignment[currentRange.firstBackWord];
-                    verify(currentRange.firstForWord >= 0 && currentRange.firstForWord < forWords.size());
+                    verify(currentRange.firstForWord >= 0 && static_cast<size_t>(currentRange.firstForWord) < forWords.size());
                     currentRange.coarticulation = forward_->boundary(forWords[currentRange.firstForWord].originState).transit();
                     verify(backward_->getState(backWords[currentRange.firstBackWord].originState)->nArcs() == 1);
                     currentRange.finalBackwardCoarticulation = backward_->boundary(backward_->getState(backWords[currentRange.firstBackWord].originState)->getArc(0)->target()).transit();
-                    verify(forWords[currentRange.firstForWord].start == currentRange.startTime);
+                    verify(forWords[currentRange.firstForWord].start == static_cast<u32>(currentRange.startTime));
 
                     for (s32 q = 0; q < currentRange.firstBackWord; ++q)
                         currentRange.prefix.push_back(backWords[q].pron->lemma());
@@ -474,22 +474,22 @@ struct ForwardBackwardAlignment {
                 }
             }
             if (!badBackWords.count(*it + 1)) {
-                if (*it == backWords.size() - 1) {
+                if (static_cast<size_t>(*it) == backWords.size() - 1) {
                     currentRange.endTime = segmentLength_ - 1;
                 }
                 else {
                     currentRange.lastBackWord = *it + 1;
                     currentRange.endTime      = backWords[currentRange.lastBackWord].end;
-                    verify(currentRange.lastBackWord >= 0 && currentRange.lastBackWord < backWords.size());
+                    verify(currentRange.lastBackWord >= 0 && static_cast<size_t>(currentRange.lastBackWord) < backWords.size());
                     currentRange.lastForWord = backWordAlignment[*it + 1];
-                    verify(currentRange.lastForWord >= 0 && currentRange.lastForWord < forWords.size());
-                    verify(currentRange.endTime == forWords[currentRange.lastForWord].end);
+                    verify(currentRange.lastForWord >= 0 && static_cast<size_t>(currentRange.lastForWord) < forWords.size());
+                    verify(static_cast<u32>(currentRange.endTime) == forWords[currentRange.lastForWord].end);
                     currentRange.backwardCoarticulation = backward_->boundary(backWords[currentRange.lastBackWord].originState).transit();
                     verify(forward_->getState(forWords[currentRange.lastForWord].originState)->nArcs() == 1);
                     currentRange.finalCoarticulation = forward_->boundary(forward_->getState(forWords[currentRange.lastForWord].originState)->getArc(0)->target()).transit();
                     for (u32 q = currentRange.lastBackWord + 1; q < backWords.size(); ++q)
                         currentRange.suffix.push_back(backWords[q].pron->lemma());
-                    if (currentRange.lastBackWord + 1 < backWords.size()) {
+                    if (static_cast<size_t>(currentRange.lastBackWord) + 1 < backWords.size()) {
                         const Bliss::LemmaPronunciation* pron = backWords[currentRange.lastBackWord + 1].pron;
                         if (pron && pron->pronunciation()->length())
                             currentRange.sufPhon = pron->pronunciation()->operator[](0);
@@ -502,7 +502,7 @@ struct ForwardBackwardAlignment {
                     currentRange.firstForWord = -1;
                 }
 
-                if (currentRange.lastForWord == forWords.size() - 1) {
+                if (static_cast<size_t>(currentRange.lastForWord) == forWords.size() - 1) {
                     // Lift unneeded constraints
                     currentRange.endTime     = segmentLength_ - 1;
                     currentRange.lastForWord = -1;
@@ -1109,14 +1109,14 @@ protected:
                     std::cout << "good count: " << good << " out of " << secondOrderCorrectionHistory_.size() << std::endl;
 
                 if (secondOrderCorrectionHistory_.size() == 10) {
-                    if (good > adaptCorrectionRatio_ && alignment.errorRate() == 0) {
+                    if (good > static_cast<u32>(adaptCorrectionRatio_) && alignment.errorRate() == 0) {
                         // Tighten more
                         relaxPruningFactor_ = 1.0 + (relaxPruningFactor_ - 1.0) / adaptPruningFactor_;
                         relaxPruningOffset_ /= adaptPruningFactor_;
                         if (verboseRefinement_)
                             std::cout << "Tightened relax-pruning-factor to " << relaxPruningFactor_ << " and relax-pruning-offset to " << relaxPruningOffset_ << std::endl;
                     }
-                    else if (good < adaptCorrectionRatio_ && alignment.errorRate() > 0) {
+                    else if (good < static_cast<u32>(adaptCorrectionRatio_) && alignment.errorRate() > 0) {
                         // Relax more
                         relaxPruningFactor_ = 1.0 + (relaxPruningFactor_ - 1.0) * adaptPruningFactor_;
                         relaxPruningOffset_ *= adaptPruningFactor_;
@@ -1218,7 +1218,7 @@ protected:
             for (std::set<ForwardBackwardAlignment::Range>::iterator rangeIt = ranges.begin(); rangeIt != ranges.end(); ++rangeIt) {
                 if (verboseRefinement_)
                     std::cout << "updating subrange " << rangeIt->startTime << " -> " << rangeIt->endTime << std::endl;
-                verify(rangeIt->startTime >= 0 && rangeIt->endTime < features.size());
+                verify(rangeIt->startTime >= 0 && static_cast<size_t>(rangeIt->endTime) < features.size());
 
                 if (refinements.count(*rangeIt)) {
                     if (verboseRefinement_)
@@ -1294,7 +1294,7 @@ protected:
                         }
                     }
                     if (refined.extension & ExtendRight) {
-                        if (rangeIt->lastForWord == -1 || (rangeIt->lastForWord == alignment.forWords.size() - 1 && forceLastWord)) {
+                        if (rangeIt->lastForWord == -1 || (static_cast<size_t>(rangeIt->lastForWord) == alignment.forWords.size() - 1 && forceLastWord)) {
                             ret.extension = Extension(ret.extension | ExtendRight);
                         }
                         else {
@@ -1360,10 +1360,10 @@ protected:
                 if (insertIt != refinements.end()) {
                     // Insert new lattice
                     Speech::TimeframeIndex timeOffset = newBoundaries->get(currentState->id()).time();
-                    if (timeOffset != insertIt->first.startTime) {
+                    if (timeOffset != static_cast<Speech::TimeframeIndex>(insertIt->first.startTime)) {
                         std::cout << "Time-offset mismatch " << timeOffset << " " << insertIt->first.startTime << std::endl;
                     }
-                    verify(timeOffset == insertIt->first.startTime);
+                    verify(timeOffset == static_cast<Speech::TimeframeIndex>(insertIt->first.startTime));
                     Flf::ConstLatticeRef        insertLattice = insertIt->second;
                     Flf::Lattice::ConstStateRef insertState   = insertLattice->getState(insertLattice->initialStateId());
                     verify(insertState->nArcs() == 1);
@@ -1948,7 +1948,7 @@ public:
                             LatticeCounts counts  = count(ret.first);
                             f32           minArcs = (minArcsPerSecond_ * features.size()) / 100.0;
                             if (counts.nArcs_ < minArcs) {
-                                if (i > maxLatticeRegenerations_) {
+                                if (i > static_cast<u32>(maxLatticeRegenerations_)) {
                                     log() << "not enough arcs: "
                                           << counts.nArcs_
                                           << " need at least "

--- a/src/Flf/NonWordFilter.cc
+++ b/src/Flf/NonWordFilter.cc
@@ -223,7 +223,7 @@ struct LatticeClosure {
                     bool shortenClosure = false;
                     if (arc->input() != Fsa::Epsilon) {
                         shortenClosure = shortenClosureStates_.count(arc->target());
-                        if (!shortenClosure && l_->boundary(arc->target()).time() - startTime > maxClosureLength_ && preBp != ArcTraceback::InvalidIndex) {
+                        if (!shortenClosure && l_->boundary(arc->target()).time() - startTime > static_cast<Speech::TimeframeIndex>(maxClosureLength_) && preBp != ArcTraceback::InvalidIndex) {
                             shortenClosure = true;
                             shortenClosureStates_.insert(arc->target());
                         }
@@ -501,13 +501,13 @@ StaticLatticeRef uniqueSentenceAlignmentFilter(ConstLatticeRef l, u32 maxWidth, 
                     verify(currentExtension != -1);
 
                     while (currentExtension != -1) {
-                        verify(currentExtension < wordExtensions.size());
+                        verify(static_cast<size_t>(currentExtension) < wordExtensions.size());
                         const std::pair<std::pair<Fsa::LabelId, s32>, std::pair<s32, s32>>& extension(wordExtensions[currentExtension]);
                         verify(extension.first.first == label);
 
                         std::pair<Fsa::StateId, Flf::WordTraceback::Index> oldHypothesis(*(hypBegin + extension.second.first));
                         s32                                                closureIndex = extension.second.second;
-                        verify(closureIndex < latticeClosure.closures_.size());
+                        verify(static_cast<size_t>(closureIndex) < latticeClosure.closures_.size());
                         const LatticeClosure::Closure& closure(latticeClosure.closures_[closureIndex]);
                         Score                          newScore = closure.score;
                         if (oldHypothesis.second != -1)
@@ -641,7 +641,7 @@ StaticLatticeRef uniqueSentenceAlignmentFilter(ConstLatticeRef l, u32 maxWidth, 
                             ConstStateRef state = l->getState(stateId);
                             if (!s->hasState(stateId))
                                 s->setState(new State(state->id(), state->tags(), state->weight()));
-                            verify(*arcIt < state->nArcs());
+                            verify(static_cast<u32>(*arcIt) < state->nArcs());
                             const Flf::Arc& a = *state->getArc(*arcIt);
 
                             State* sp = s->fastState(stateId);

--- a/src/Flf/Prune.cc
+++ b/src/Flf/Prune.cc
@@ -90,7 +90,7 @@ ConstLatticeRef pruneByFwdBwdScores(ConstLatticeRef l, ConstFwdBwdRef fb, Score 
 
     if (minArcsPerSec) {
         LatticeCounts counts = count(l);
-        if (counts.nArcs_ <= minArcs)
+        if (counts.nArcs_ <= static_cast<size_t>(minArcs))
             return l;
     }
 
@@ -99,7 +99,7 @@ ConstLatticeRef pruneByFwdBwdScores(ConstLatticeRef l, ConstFwdBwdRef fb, Score 
 
     if (maxArcs != Core::Type<s32>::max) {
         LatticeCounts counts = count(p);
-        while ((counts.nArcs_ > maxArcs) && t > 0.1) {
+        while ((counts.nArcs_ > static_cast<size_t>(maxArcs)) && t > 0.1) {
             t *= 0.9;  /// @todo binary search instead of static steps
             Core::Application::us()->log() << "pruning because too many arcs: " << counts.nArcs_ << ", specified maximum: " << maxArcs << " new threshold: " << t;
             p      = ConstLatticeRef(new FwdBwdPruningLattice(l, fb, t + fb->min()));
@@ -108,7 +108,7 @@ ConstLatticeRef pruneByFwdBwdScores(ConstLatticeRef l, ConstFwdBwdRef fb, Score 
     }
     if (minArcs) {
         LatticeCounts counts = count(p);
-        while (counts.nArcs_ < minArcs && t < 100.0) {
+        while (counts.nArcs_ < static_cast<size_t>(minArcs) && t < 100.0) {
             t *= 1.2;  /// @todo binary search instead of static steps
             Core::Application::us()->log() << "pruning because too few arcs per second: " << counts.nArcs_ << ", specified minimum: " << minArcs << " new threshold: " << t;
             p      = ConstLatticeRef(new FwdBwdPruningLattice(l, fb, t + fb->min()));
@@ -159,13 +159,13 @@ private:
             maxTime_ = time + 1;
         ScoreAndArc* best    = bestArcs(time, phoneId);
         ScoreAndArc* bestEnd = best + coverage_;
-        verify(bestEnd - bestArcs_.data() <= bestArcs_.size());
+        verify(static_cast<size_t>(bestEnd - bestArcs_.data()) <= bestArcs_.size());
 
         for (ScoreAndArc* current = bestEnd - 1; current >= best; --current) {
             if (scoredArc.first > current->first) {
                 if (current < bestEnd - 1) {
                     // Insert behind
-                    verify((current - bestArcs_.data()) + 2 + (coverage_ - 2 - (current - best)) <= bestArcs_.size());
+                    verify(static_cast<size_t>((current - bestArcs_.data()) + 2 + (coverage_ - 2 - (current - best))) <= bestArcs_.size());
                     memmove(current + 2, current + 1, (coverage_ - 2 - (current - best)) * sizeof(ScoreAndArc));
                     *(current + 1) = scoredArc;
                 }

--- a/src/Mm/BatchFeatureScorer.cc
+++ b/src/Mm/BatchFeatureScorer.cc
@@ -228,7 +228,7 @@ void BatchFloatFeatureScorer::fillScoreCacheTpl(EmissionIndex e, u32 featureInde
             const f32* feature = features_ + (rp * paddedDimension_);
             s1                 = c;
             s2                 = _mm_setzero_ps();
-            for (int d = 0; d < paddedDimension_; d += BlockSize) {
+            for (int d = 0; d < static_cast<int>(paddedDimension_); d += BlockSize) {
                 x1 = _mm_sub_ps(_mm_load_ps(mean + d), _mm_load_ps(feature + d));
                 s1 = _mm_add_ps(s1, _mm_mul_ps(x1, x1));
                 x2 = _mm_sub_ps(_mm_load_ps(mean + d + 4), _mm_load_ps(feature + d + 4));
@@ -416,7 +416,7 @@ void BatchIntFeatureScorer::init(const MixtureSet& mixtureSet) {
 }
 
 void BatchIntFeatureScorer::setFeature(size_t pos, const FeatureVector& f) const {
-    verify(pos < bufferSize_);
+    verify(pos < static_cast<size_t>(bufferSize_));
     QuantizedType* feature = features_ + (pos * paddedDimension_);
     memset(feature, 0, sizeof(QuantizedType) * paddedDimension_);
     std::transform(f.begin(), f.end(), variance_,
@@ -480,7 +480,7 @@ void BatchIntFeatureScorer::fillScoreCacheTpl(EmissionIndex e, u32 featureIndex,
         for (size_t dns = startDns; dns < endDns; ++dns) {
             if (selector.value()) {
                 __m128i sum = _mm_setzero_si128();
-                for (int d = 0; d < paddedDimension_; d += BlockSize) {
+                for (int d = 0; d < static_cast<int>(paddedDimension_); d += BlockSize) {
                     __m128i m, x;
                     m = _mm_load_si128(reinterpret_cast<const __m128i*>(mean + d));
                     // m = mean[d .. d+15]

--- a/src/Nn/BufferedAlignedFeatureProcessor.cc
+++ b/src/Nn/BufferedAlignedFeatureProcessor.cc
@@ -183,7 +183,7 @@ void BufferedAlignedFeatureProcessor<T>::initTrainer(const std::vector<NnMatrix>
     PrecursorBuffer::trainer_->setClassWeights(&classWeights_);
     if (PrecursorBuffer::trainer_->hasClassLabelPosteriors()) {
         require(classLabelWrapper_);
-        if (PrecursorBuffer::trainer_->getClassLabelPosteriorDimension() != classLabelWrapper_->nClassesToAccumulate()) {
+        if (static_cast<u32>(PrecursorBuffer::trainer_->getClassLabelPosteriorDimension()) != classLabelWrapper_->nClassesToAccumulate()) {
             this->warning("mismatch in number of trainer class labels (e.g. NN output layer dim) and number of classes to accumulate: ")
                     << PrecursorBuffer::trainer_->getClassLabelPosteriorDimension()
                     << " vs. "

--- a/src/Nn/FeedForwardTrainer.cc
+++ b/src/Nn/FeedForwardTrainer.cc
@@ -185,7 +185,7 @@ void FeedForwardTrainer<T>::finalize() {
             Core::Component::log(
                     "The last %i batches were ignored because of accumulate-multiple-batches=%i",
                     latestRecentBatchesCount, estimator().accumulateMultipleBatches());
-            if (minibatchCount_ < estimator().accumulateMultipleBatches())
+            if (minibatchCount_ < static_cast<u32>(estimator().accumulateMultipleBatches()))
                 Core::Component::warning("We did not use any batches. (because accumulate-multiple-batches)");
         }
     }

--- a/src/Nn/NeuralNetwork.cc
+++ b/src/Nn/NeuralNetwork.cc
@@ -460,7 +460,7 @@ void NeuralNetwork<T>::initializeNetwork(u32 batchSize, std::vector<u32> streamS
             }
         }
     }
-    for (int k = 0; k < streamSizes.size(); ++k) {
+    for (int k = 0; k < static_cast<int>(streamSizes.size()); ++k) {
         this->log("%s", Core::form("streamSizes[%d]=%d\n", k, streamSizes[k]).c_str());
     }
     // set the size of the input activations, determined from streamSizes

--- a/src/Onnx/Value.cc
+++ b/src/Onnx/Value.cc
@@ -70,7 +70,7 @@ void dynamic_rank_concat(Ort::Value& out, std::vector<Ort::Value const*> const& 
         data.push_back(values[value_idx]->GetTensorData<T>());
     }
 
-    for (size_t block_idx = 0ul; block_idx < static_cast<size_t>(num_blocks); block_idx++) {
+    for (int64_t block_idx = 0ul; block_idx < num_blocks; block_idx++) {
         int64_t partial_sum = 0l;
         for (size_t value_idx = 0ul; value_idx < data.size(); ++value_idx) {
             std::copy(data[value_idx] + block_sizes[value_idx] * block_idx, data[value_idx] + block_sizes[value_idx] * (block_idx + 1), data_out + (out_block_size)*block_idx + partial_sum);

--- a/src/Onnx/Value.cc
+++ b/src/Onnx/Value.cc
@@ -70,7 +70,7 @@ void dynamic_rank_concat(Ort::Value& out, std::vector<Ort::Value const*> const& 
         data.push_back(values[value_idx]->GetTensorData<T>());
     }
 
-    for (size_t block_idx = 0ul; block_idx < num_blocks; block_idx++) {
+    for (size_t block_idx = 0ul; block_idx < static_cast<size_t>(num_blocks); block_idx++) {
         int64_t partial_sum = 0l;
         for (size_t value_idx = 0ul; value_idx < data.size(); ++value_idx) {
             std::copy(data[value_idx] + block_sizes[value_idx] * block_idx, data[value_idx] + block_sizes[value_idx] * (block_idx + 1), data_out + (out_block_size)*block_idx + partial_sum);
@@ -92,7 +92,7 @@ void blockwise_copy(Ort::Value& left, Ort::Value const& right, int64_t offset, i
 
     int64_t block_head;
     int64_t block_tail;
-    for (size_t block_idx = 0ul; block_idx < num_blocks; ++block_idx) {
+    for (size_t block_idx = 0ul; block_idx < static_cast<size_t>(num_blocks); ++block_idx) {
         block_head = offset + block_idx * block_stride;
         block_tail = block_head + block_size;
 

--- a/src/Python/Numpy.cc
+++ b/src/Python/Numpy.cc
@@ -101,8 +101,8 @@ void numpy2rawMat(PyArrayObject* nparr, ContainerT& nnmat) {
     require_eq(PyArray_TYPE(nparr), NumpyType<NumpyT>::type());
     require_eq(PyArray_NDIM(nparr), 2);
     if (std::is_same<decltype(nnmat.at(0, 0)), NumpyT&>::value &&
-        PyArray_STRIDES(nparr)[0] == sizeof(NumpyT) &&
-        PyArray_STRIDES(nparr)[1] == sizeof(NumpyT) * nnmat.nRows()) {
+        PyArray_STRIDES(nparr)[0] == static_cast<npy_intp>(sizeof(NumpyT)) &&
+        PyArray_STRIDES(nparr)[1] == static_cast<npy_intp>(sizeof(NumpyT) * nnmat.nRows())) {
         // fast version. we can just use memcpy
         memcpy(&nnmat.at(0, 0), PyArray_BYTES(nparr), nnmat.nRows() * nnmat.nColumns() * sizeof(NumpyT));
     }
@@ -136,8 +136,8 @@ void rawMat2numpy(PyArrayObject* nparr, const ContainerT& nnmat) {
     require_eq(PyArray_TYPE(nparr), NumpyType<NumpyT>::type());
     require_eq(PyArray_NDIM(nparr), 2);
     if (std::is_same<decltype(nnmat.at(0, 0)), const NumpyT&>::value &&
-        PyArray_STRIDES(nparr)[0] == sizeof(NumpyT) &&
-        PyArray_STRIDES(nparr)[1] == sizeof(NumpyT) * nnmat.nRows()) {
+        PyArray_STRIDES(nparr)[0] == static_cast<npy_intp>(sizeof(NumpyT)) &&
+        PyArray_STRIDES(nparr)[1] == static_cast<npy_intp>(sizeof(NumpyT) * nnmat.nRows())) {
         // fast version. we can just use memcpy
         memcpy(PyArray_BYTES(nparr), &nnmat.at(0, 0), nnmat.nRows() * nnmat.nColumns() * sizeof(NumpyT));
     }
@@ -233,8 +233,8 @@ bool numpy2nnMatrix(CriticalErrorFunc criticalErrorFunc, PyObject* nparr, Math::
 
     Python::ObjRef _nparr;
     if (PyArray_TYPE((PyArrayObject*)nparr) != NumpyType<T>::type() ||
-        PyArray_STRIDES((PyArrayObject*)nparr)[0] != sizeof(T) ||
-        PyArray_STRIDES((PyArrayObject*)nparr)[1] != sizeof(T) * nnmat.nRows()) {
+        PyArray_STRIDES((PyArrayObject*)nparr)[0] != static_cast<npy_intp>(sizeof(T)) ||
+        PyArray_STRIDES((PyArrayObject*)nparr)[1] != static_cast<npy_intp>(sizeof(T) * nnmat.nRows())) {
         // numpy2rawMat has a slow fallback which works in all cases.
         // However, we can speed it up by converting it to our prefered format which we can handle much faster.
         // So we ultimatively hope that Numpy can do that faster than our slow fallback would be.

--- a/src/Search/LanguageModelLookahead.cc
+++ b/src/Search/LanguageModelLookahead.cc
@@ -1870,7 +1870,6 @@ bool LanguageModelLookahead::computeScoresSparse(LanguageModelLookahead::Context
                                        parentEnd = parents_.begin() + nodes_[node.first + 1].firstParent;
             for (; parent != parentEnd; ++parent) {
                 verify(nodes_[*parent].depth < static_cast<u32>(depth));
-                ;
                 waitingLookaheadNodesByDepth_[nodes_[*parent].depth].push_back(std::make_pair(*parent, node.second));
             }
         }

--- a/src/Search/LanguageModelLookahead.cc
+++ b/src/Search/LanguageModelLookahead.cc
@@ -732,7 +732,7 @@ void LanguageModelLookahead::ConstructionTree::build(HMMStateNetwork const&     
         s32 collectTopologicalStates(StateId node, int depth,
                                      std::vector<std::vector<StateId>>& topologicalStates,
                                      std::vector<s32>&                  collected) {
-            if (topologicalStates.size() <= depth) {
+            if (topologicalStates.size() <= static_cast<size_t>(depth)) {
                 topologicalStates.resize(depth + 1);
             }
 
@@ -1105,9 +1105,9 @@ struct WeightedDistributedStandardHash {
                 continue;
             }
             s32 cell = hash % testHash.size();
-            verify(cell >= 0 && cell < testHash.size());
+            verify(cell >= 0 && static_cast<size_t>(cell) < testHash.size());
             s32 previousCell = previous % testHash.size();
-            verify(previousCell >= 0 && previousCell < testHash.size());
+            verify(previousCell >= 0 && static_cast<size_t>(previousCell) < testHash.size());
             float currentLocality = abs(cell - previousCell) / (float)testHash.size();
             verify(currentLocality <= 1.0 && currentLocality >= 0.0);
             if ((currentLocality == 0 || currentLocality > locality + (1.0 / testHash.size())) && iter < maxIter) {
@@ -1167,7 +1167,7 @@ void LanguageModelLookahead::buildCompressesLookaheadStructure(u32              
             nodeId_.edit(*ri) = ci;
     }
 
-    for (StateTree::StateId si = nodeStart; si < numNodes; ++si)
+    for (StateTree::StateId si = nodeStart; si < static_cast<StateTree::StateId>(numNodes); ++si)
         verify(nodeId_[si] != invalidId);
 
     // add sentinel
@@ -1291,7 +1291,7 @@ void LanguageModelLookahead::buildCompressesLookaheadStructure(u32              
     log() << "lexicon syntactic tokens: " << lm_->lexicon()->nSyntacticTokens();
 
     // using lexicon_->nSyntacticTokens() intead of lm_->tokenInventory().size() here for mismatch case
-    for (int token = 0; token < lm_->lexicon()->nSyntacticTokens(); ++token) {
+    for (int token = 0; token < static_cast<int>(lm_->lexicon()->nSyntacticTokens()); ++token) {
         firstNodeForToken_.push_back(nodeForToken_.size());
         std::pair<TokenNodeMap::iterator, TokenNodeMap::iterator> range = nodeForTokenMap.equal_range(token);
         for (; range.first != range.second; ++range.first)
@@ -1402,9 +1402,9 @@ void LanguageModelLookahead::assignHashes(std::string hashName, Hash& hash, u32 
     for (u32 s = 1; s < nEntries_; ++s) {
         // Locality statistics
         s32 cell = hashForNode_[s] % testHash.size();
-        verify(cell >= 0 && cell < testHash.size());
+        verify(cell >= 0 && static_cast<size_t>(cell) < testHash.size());
         s32 previousCell = hashForNode_[s - 1] % testHash.size();
-        verify(previousCell >= 0 && previousCell < testHash.size());
+        verify(previousCell >= 0 && static_cast<size_t>(previousCell) < testHash.size());
         float currentLocality = abs(cell - previousCell) / (float)testHash.size();
         averageLocality += currentLocality;
     }
@@ -1413,9 +1413,9 @@ void LanguageModelLookahead::assignHashes(std::string hashName, Hash& hash, u32 
 
     for (u32 s = 1; s < nEntries_; ++s) {
         s32 cell = hashForNode_[s] % testHash.size();
-        verify(cell >= 0 && cell < testHash.size());
+        verify(cell >= 0 && static_cast<size_t>(cell) < testHash.size());
         s32 previousCell = hashForNode_[s - 1] % testHash.size();
-        verify(previousCell >= 0 && previousCell < testHash.size());
+        verify(previousCell >= 0 && static_cast<size_t>(previousCell) < testHash.size());
         float currentLocality = abs(cell - previousCell) / (float)testHash.size();
         quadraticLocalityDeviation += (currentLocality - averageLocality) * (currentLocality - averageLocality);
     }
@@ -1435,7 +1435,7 @@ void LanguageModelLookahead::propagateDepth(int node, int depth) {
         nodes_.edit(node).depth = depth;
     }
     else {
-        if (depth > nodes_[node].depth) {
+        if (static_cast<u32>(depth) > nodes_[node].depth) {
             nodes_.edit(node).depth = depth;
         }
 
@@ -1461,7 +1461,7 @@ void LanguageModelLookahead::buildDepths() {
         for (u32 p = nodes_[a].firstParent; p < nodes_[a + 1].firstParent; ++p) {
             LookaheadId parentNode  = parents_[p];
             int         parentDepth = ((int)nodes_[a].depth) - 1;
-            if (parentDepth > nodes_[parentNode].depth) {
+            if (static_cast<u32>(parentDepth) > nodes_[parentNode].depth) {
                 propagateDepth(parentNode, parentDepth);
             }
         }
@@ -1869,7 +1869,8 @@ bool LanguageModelLookahead::computeScoresSparse(LanguageModelLookahead::Context
             Successors::const_iterator parent    = parents_.begin() + nodes_[node.first].firstParent,
                                        parentEnd = parents_.begin() + nodes_[node.first + 1].firstParent;
             for (; parent != parentEnd; ++parent) {
-                verify(nodes_[*parent].depth < depth);
+                verify(nodes_[*parent].depth < static_cast<u32>(depth));
+                ;
                 waitingLookaheadNodesByDepth_[nodes_[*parent].depth].push_back(std::make_pair(*parent, node.second));
             }
         }
@@ -2140,8 +2141,8 @@ LanguageModelLookahead::LookaheadId LanguageModelLookahead::lastNodeOnDepth(int 
     verify(depth < 100000);
 
     LanguageModelLookahead::LookaheadId ret = 0;
-    for (int a = 0; a < nEntries_; ++a) {
-        if (nodes_[a].depth == depth) {
+    for (int a = 0; a < static_cast<int>(nEntries_); ++a) {
+        if (nodes_[a].depth == static_cast<u32>(depth)) {
             ret = a;
         }
     }

--- a/src/Search/LanguageModelLookahead.cc
+++ b/src/Search/LanguageModelLookahead.cc
@@ -732,7 +732,7 @@ void LanguageModelLookahead::ConstructionTree::build(HMMStateNetwork const&     
         s32 collectTopologicalStates(StateId node, int depth,
                                      std::vector<std::vector<StateId>>& topologicalStates,
                                      std::vector<s32>&                  collected) {
-            if (topologicalStates.size() <= static_cast<size_t>(depth)) {
+            if (static_cast<int>(topologicalStates.size()) <= depth) {
                 topologicalStates.resize(depth + 1);
             }
 
@@ -1435,7 +1435,7 @@ void LanguageModelLookahead::propagateDepth(int node, int depth) {
         nodes_.edit(node).depth = depth;
     }
     else {
-        if (static_cast<u32>(depth) > nodes_[node].depth) {
+        if (depth > static_cast<int>(nodes_[node].depth)) {
             nodes_.edit(node).depth = depth;
         }
 
@@ -1461,7 +1461,7 @@ void LanguageModelLookahead::buildDepths() {
         for (u32 p = nodes_[a].firstParent; p < nodes_[a + 1].firstParent; ++p) {
             LookaheadId parentNode  = parents_[p];
             int         parentDepth = ((int)nodes_[a].depth) - 1;
-            if (static_cast<u32>(parentDepth) > nodes_[parentNode].depth) {
+            if (parentDepth > static_cast<int>(nodes_[parentNode].depth)) {
                 propagateDepth(parentNode, parentDepth);
             }
         }
@@ -1869,7 +1869,7 @@ bool LanguageModelLookahead::computeScoresSparse(LanguageModelLookahead::Context
             Successors::const_iterator parent    = parents_.begin() + nodes_[node.first].firstParent,
                                        parentEnd = parents_.begin() + nodes_[node.first + 1].firstParent;
             for (; parent != parentEnd; ++parent) {
-                verify(nodes_[*parent].depth < static_cast<u32>(depth));
+                verify(static_cast<int>(nodes_[*parent].depth) < depth);
                 waitingLookaheadNodesByDepth_[nodes_[*parent].depth].push_back(std::make_pair(*parent, node.second));
             }
         }
@@ -2141,7 +2141,7 @@ LanguageModelLookahead::LookaheadId LanguageModelLookahead::lastNodeOnDepth(int 
 
     LanguageModelLookahead::LookaheadId ret = 0;
     for (int a = 0; a < static_cast<int>(nEntries_); ++a) {
-        if (nodes_[a].depth == static_cast<u32>(depth)) {
+        if (static_cast<int>(nodes_[a].depth) == depth) {
             ret = a;
         }
     }

--- a/src/Search/LinearPrediction.hh
+++ b/src/Search/LinearPrediction.hh
@@ -53,7 +53,7 @@ public:
         while (lower > 0 && recorded[lower].count == 0)
             --lower;
 
-        while (higher < recorded.size() - 1 && recorded[higher].count == 0)
+        while (!recorded.empty() && higher < static_cast<int>(recorded.size() - 1) && recorded[higher].count == 0)
             ++higher;
 
         if (recorded[higher].count != 0 && recorded[lower].count != 0 && higher != lower) {

--- a/src/Search/PersistentStateTree.cc
+++ b/src/Search/PersistentStateTree.cc
@@ -98,7 +98,7 @@ struct ConvertTree {
         for (std::unordered_map<StateTree::StateId, StateId>::const_iterator it = nodesForStates.begin(); it != nodesForStates.end(); ++it) {
             StateId            node  = (*it).second;
             StateTree::StateId state = (*it).first;
-            verify(node == state + 1);
+            verify(node == static_cast<Search::StateId>(state + 1));
 
             std::set<u32>           exitIndices;
             const StateTree::State& realState(tree->state(state));
@@ -145,7 +145,7 @@ private:
             return;
         }
 
-        verify(stateId + 1 == node);
+        verify(static_cast<Search::StateId>(stateId + 1) == node);
 
         nodesForStates[stateId] = node;
 

--- a/src/Search/StateTree.cc
+++ b/src/Search/StateTree.cc
@@ -230,7 +230,7 @@ inline const Am::Allophone* StateTree::getAllophone(const PronunciationSuffix& s
         phonology.appendHistory(allophone, s.predecessorPhoneme_);
     }
     if (s.successorPhoneme_ != Bliss::Phoneme::term) {
-        verify(s.phoneme == s.pronunciation_->length() - 1);
+        verify(static_cast<u32>(s.phoneme) == s.pronunciation_->length() - 1);
         phonology.appendFuture(allophone, s.successorPhoneme_);
     }
 
@@ -250,7 +250,7 @@ inline s16 StateTree::boundary(const PronunciationSuffix& s) const {
     s16 result = 0;
     if (s.phoneme == 0)
         result |= Am::Allophone::isInitialPhone;
-    if (s.phoneme == s.pronunciation_->length() - 1)
+    if (static_cast<u32>(s.phoneme) == s.pronunciation_->length() - 1)
         result |= Am::Allophone::isFinalPhone;
     return result;
 }
@@ -307,7 +307,7 @@ void StateTree::advancePronunciationSuffix(const PronunciationSuffix&           
             // next phoneme reached
             ++s.phoneme;
             s.isHashValid_ = false;
-            if (s.phoneme >= s.pronunciation_->length()) {
+            if (static_cast<u32>(s.phoneme) >= s.pronunciation_->length()) {
                 // end of pronunciation reached.
                 s.isEmpty_ = true;
                 *ends++    = s;
@@ -319,7 +319,7 @@ void StateTree::advancePronunciationSuffix(const PronunciationSuffix&           
         }
 
         if (acousticModel_->isAcrossWordModelEnabled() &&
-            mustAdvancePhoneme && s.phoneme == s.pronunciation_->length() - 1) {
+            mustAdvancePhoneme && static_cast<u32>(s.phoneme) == s.pronunciation_->length() - 1) {
             // last phoneme in the pronunciation
             // create fan-out suffixes, i.e. create pronuncation alternatives
             // using all initial phonemes as successor phoneme
@@ -338,7 +338,7 @@ void StateTree::advancePronunciationSuffix(const PronunciationSuffix&           
 u32 StateTree::nStatesRemaining(const PronunciationSuffix& _s) const {
     u32                 result = 0;
     PronunciationSuffix s(_s);
-    while (s.phoneme < s.pronunciation_->length()) {
+    while (static_cast<u32>(s.phoneme) < s.pronunciation_->length()) {
         if (advanceSubState(s))
             if (advancePhoneState(s))
                 ++s.phoneme;
@@ -633,7 +633,7 @@ std::pair<Bliss::Phoneme::Id, Bliss::Phoneme::Id> StateTree::describeRootState(S
         final = initial = Bliss::Phoneme::term;
     }
     else {
-        if (s < coarticulationStructure_->boundaryPhonemes.size()) {
+        if (static_cast<size_t>(s) < coarticulationStructure_->boundaryPhonemes.size()) {
             final   = coarticulationStructure_->boundaryPhonemes[s].final;
             initial = coarticulationStructure_->boundaryPhonemes[s].initial;
         }
@@ -1074,7 +1074,7 @@ void StateTree::buildCoarticulatedRootStates(Bliss::LexiconRef lexicon) {
             criticalError("Failed to determine silence phoneme.");
         }
         boundaryPhonemes.final = Bliss::Phoneme::term;
-        verify(cs.boundaryPhonemes.size() == ciRoot_);
+        verify(cs.boundaryPhonemes.size() == static_cast<size_t>(ciRoot_));
         cs.boundaryPhonemes.push_back(boundaryPhonemes);
         BatchRequest* request = new BatchRequest(this, ciRoot_);
         SuffixSet&    suffixes(request->suffixes);
@@ -1102,7 +1102,7 @@ void StateTree::buildCoarticulatedRootStates(Bliss::LexiconRef lexicon) {
             boundaryPhonemes.initial = cs.initialPhonemes[r];
             StateId root             = states_.size();
             cs.roots[l][r]           = root;
-            verify(cs.boundaryPhonemes.size() == root);
+            verify(cs.boundaryPhonemes.size() == static_cast<size_t>(root));
             cs.boundaryPhonemes.push_back(boundaryPhonemes);
             BatchRequest* request = new BatchRequest(this, root);
             SuffixSet&    suffixes(request->suffixes);

--- a/src/Search/TreeBuilder.cc
+++ b/src/Search/TreeBuilder.cc
@@ -120,7 +120,7 @@ MinimizedTreeBuilder::MinimizedTreeBuilder(Core::Configuration config, const Bli
     if (allowCrossWordSkips_) {
         Score skipPenalty    = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::skip);
         Score forwardPenalty = acousticModel_.stateTransition(0)->operator[](Am::StateTransitionModel::forward);
-        for (u32 t = 0; t < acousticModel_.nStateTransitions(); ++t) {
+        for (u32 t = 0; t < static_cast<u32>(acousticModel_.nStateTransitions()); ++t) {
             Score modelPenalty        = acousticModel_.stateTransition(t)->operator[](Am::StateTransitionModel::skip);
             Score modelForwardPenalty = acousticModel_.stateTransition(t)->operator[](Am::StateTransitionModel::forward);
             if (modelPenalty != skipPenalty)
@@ -286,7 +286,7 @@ void MinimizedTreeBuilder::buildBody() {
 
         std::pair<Bliss::Pronunciation::LemmaIterator, Bliss::Pronunciation::LemmaIterator> lemmaProns = pron.lemmas();
 
-        if (pronLength - 1 < minPhones_ || !isContextDependent(phones[pronLength - 1])) {
+        if (pronLength - 1 < static_cast<u32>(minPhones_) || !isContextDependent(phones[pronLength - 1])) {
             // Statically expand the fan-out.
             for (std::set<Bliss::Phoneme::Id>::iterator initialIt = initialPhonemes_.begin(); initialIt != initialPhonemes_.end(); ++initialIt) {
                 std::pair<StateId, StateId> tail = extendPhone(currentState.second, pronLength - 1, phones, Bliss::Phoneme::term, *initialIt);
@@ -634,12 +634,12 @@ void MinimizedTreeBuilder::hmmFromAllophone(HMMSequence&       ret,
 
     const Am::ClassicHmmTopology* hmmTopology = acousticModel_.hmmTopology(central);
 
-    for (u32 phoneState = 0; phoneState < hmmTopology->nPhoneStates(); ++phoneState) {
+    for (u32 phoneState = 0; phoneState < static_cast<u32>(hmmTopology->nPhoneStates()); ++phoneState) {
         Am::AllophoneState   alloState = acousticModel_.allophoneStateAlphabet()->allophoneState(allophone, phoneState);
         StateTree::StateDesc desc;
         desc.acousticModel = acousticModel_.emissionIndex(alloState);  // Decision tree look-up for CART id.
 
-        for (u32 subState = 0; subState < hmmTopology->nSubStates(); ++subState) {
+        for (u32 subState = 0; subState < static_cast<u32>(hmmTopology->nSubStates()); ++subState) {
             desc.transitionModelIndex = acousticModel_.stateTransitionIndex(alloState, subState);
             verify(desc.transitionModelIndex < Core::Type<StateTree::StateDesc::TransitionModelIndex>::max);
 
@@ -702,7 +702,7 @@ std::pair<AbstractTreeBuilder::StateId, AbstractTreeBuilder::StateId> MinimizedT
         currentState = extendBodyState(currentState, left, phones[phoneIndex], hmm[hmmState++]);
     }
 
-    for (; hmmState < hmm.length; ++hmmState) {
+    for (; hmmState < static_cast<u32>(hmm.length); ++hmmState) {
         previousState = currentState;
         currentState  = extendState(currentState, hmm[hmmState]);
     }
@@ -1380,12 +1380,12 @@ StateId CtcTreeBuilder::extendPronunciation(StateId startState, Bliss::Pronuncia
         const Am::ClassicHmmTopology*        hmmTopology      = acousticModel_.hmmTopology(phoneme);
         const bool                           allophoneIsBlank = acousticModel_.allophoneStateAlphabet()->index(allophone, 0, false) == blankAllophoneStateIndex_;
 
-        for (u32 phoneState = 0; phoneState < hmmTopology->nPhoneStates(); ++phoneState) {
+        for (u32 phoneState = 0; phoneState < static_cast<u32>(hmmTopology->nPhoneStates()); ++phoneState) {
             Am::AllophoneState   alloState = acousticModel_.allophoneStateAlphabet()->allophoneState(allophone, phoneState);
             StateTree::StateDesc desc;
             desc.acousticModel = acousticModel_.emissionIndex(alloState);  // state-tying look-up
 
-            for (u32 subState = 0; subState < hmmTopology->nSubStates(); ++subState) {
+            for (u32 subState = 0; subState < static_cast<u32>(hmmTopology->nSubStates()); ++subState) {
                 desc.transitionModelIndex = acousticModel_.stateTransitionIndex(alloState, subState);
                 verify(desc.transitionModelIndex < Core::Type<StateTree::StateDesc::TransitionModelIndex>::max);
 
@@ -1405,7 +1405,7 @@ StateId CtcTreeBuilder::extendPronunciation(StateId startState, Bliss::Pronuncia
                 }
                 prevNonBlankState = currentState;
 
-                bool isLastStateInLemma = ((phoneState + 1) == hmmTopology->nPhoneStates()) and ((subState + 1) == hmmTopology->nSubStates()) and (boundary & Am::Allophone::isFinalPhone);
+                bool isLastStateInLemma = ((phoneState + 1) == static_cast<u32>(hmmTopology->nPhoneStates())) and ((subState + 1) == static_cast<u32>(hmmTopology->nSubStates())) and (boundary & Am::Allophone::isFinalPhone);
                 if (not allophoneIsBlank and not isLastStateInLemma) {
                     // Add blank state after the newly created state
                     currentState = extendState(currentState, blankDesc_);
@@ -1561,12 +1561,12 @@ StateId AedTreeBuilder::extendPronunciation(StateId startState, Bliss::Pronuncia
         const Am::Allophone*                 allophone   = acousticModel_.allophoneAlphabet()->allophone(Am::Allophone(Bliss::ContextPhonology::PhonemeInContext(phoneme, history, future), boundary));
         const Am::ClassicHmmTopology*        hmmTopology = acousticModel_.hmmTopology(phoneme);
 
-        for (u32 phoneState = 0; phoneState < hmmTopology->nPhoneStates(); ++phoneState) {
+        for (u32 phoneState = 0; phoneState < static_cast<u32>(hmmTopology->nPhoneStates()); ++phoneState) {
             Am::AllophoneState   alloState = acousticModel_.allophoneStateAlphabet()->allophoneState(allophone, phoneState);
             StateTree::StateDesc desc;
             desc.acousticModel = acousticModel_.emissionIndex(alloState);  // state-tying look-up
 
-            for (u32 subState = 0; subState < hmmTopology->nSubStates(); ++subState) {
+            for (u32 subState = 0; subState < static_cast<u32>(hmmTopology->nSubStates()); ++subState) {
                 desc.transitionModelIndex = acousticModel_.stateTransitionIndex(alloState, subState);
                 verify(desc.transitionModelIndex < Core::Type<StateTree::StateDesc::TransitionModelIndex>::max);
 

--- a/src/Search/TreeBuilder.hh
+++ b/src/Search/TreeBuilder.hh
@@ -101,7 +101,7 @@ protected:
         }
 
         void reverse() {
-            for (u32 i = 0; i < length / 2; ++i) {
+            for (u32 i = 0; i < static_cast<u32>(length / 2); ++i) {
                 Search::StateTree::StateDesc temp(hmm[i]);
                 hmm[i]              = hmm[length - 1 - i];
                 hmm[length - 1 - i] = temp;

--- a/src/Tools/Archiver/Archiver.cc
+++ b/src/Tools/Archiver/Archiver.cc
@@ -529,7 +529,7 @@ public:
             return;
         const u32 max_states = 6;  // TODO: should be increased for non-speech
         for (state = 0; state < max_states; ++state) {
-            if (emission >= allophones_.size())
+            if (static_cast<size_t>(emission) >= allophones_.size())
                 emission -= (1 << 26);
             else
                 break;


### PR DESCRIPTION
My dream is to have RASR compiling without warnings. Or let's say, realistically, with only very few warnings.
Here is a first step. I went through all `Wsign-compare` warnings and inserted explicit casting to fix them.

However I can't guarantee that this is 100% safe. The problem is that if a signed value is casted to an unsigned value, but the value is negative, it will lead to an underflow. I think this should actually be fine everywhere, but I would appreciate if someone could double-check.