### PR TITLE
Update Onnx::Session: Add warning on exception in Session::run

### DIFF
--- a/src/Onnx/Session.cc
+++ b/src/Onnx/Session.cc
@@ -230,6 +230,7 @@ bool Session::run(std::vector<std::pair<std::string, Value>>&& inputs,
         out_vals = session_.Run(run_options, input_names.data(), input_vals.data(), inputs.size(), output_cnames.data(), output_cnames.size());
     }
     catch (Ort::Exception& e) {
+        warning() << "Exception during ONNX session run: " << e.what();
         return false;
     }
 


### PR DESCRIPTION
When an ONNX session run raises an exception, the error message currently gets swallowed by RASR. This PR adds a warning which logs the error message which can be helpful for debugging purposes.