### PR TITLE
Fix RecurrentLanguageModel: add missing output_transform_function if no transformation should be performed

### DIFF
--- a/src/Lm/RecurrentLanguageModel.hh
+++ b/src/Lm/RecurrentLanguageModel.hh
@@ -1,6 +1,7 @@
 #ifndef _LM_RECURRENT_LANGUAGE_MODEL_HH
 #define _LM_RECURRENT_LANGUAGE_MODEL_HH
 
+#include <functional>
 #include <future>
 #include <thread>
 #include <vector>
@@ -314,9 +315,7 @@ RecurrentLanguageModel<value_t, state_variable_t>::RecurrentLanguageModel(Core::
         };
     }
     else {
-        output_transform_function_ = [](Score v) {
-            return v;
-        };
+        output_transform_function_ = std::identity();
     }
 
     if (async_) {

--- a/src/Lm/RecurrentLanguageModel.hh
+++ b/src/Lm/RecurrentLanguageModel.hh
@@ -313,6 +313,11 @@ RecurrentLanguageModel<value_t, state_variable_t>::RecurrentLanguageModel(Core::
             return -v;
         };
     }
+    else {
+        output_transform_function_ = [](Score v) {
+            return v;
+        };
+    }
 
     if (async_) {
         background_forwarder_thread_ = std::thread(std::bind(&RecurrentLanguageModel<value_t, state_variable_t>::background_forward, this));


### PR DESCRIPTION
The `output_transform_function_` in `RecurrentLanguageModel` is currently only set if at least one of `transform-output-log` or `transform-output-negate` is true. If both are false, the function is never initialized and the LM crashes with a `bad_function_call` error during scoring. This PR adds a default no-op value for the transform function.