### PR TITLE
Fix Lexiconfree/Tree-TimesyncBeamSearch: wrong timestamps during extension creation

### DIFF
--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -414,8 +414,10 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
                     }
                     auto transitionType = inferTransitionType(hyp.currentToken, tokenIdx);
                     auto extScore       = hyp.score;
+                    auto extTime        = hyp.trace->time;
                     if (labelScorers_[scorerIdx]->scoresTransition(transitionType)) {
                         extScore += (*scoreAccessor)->getScore(transitionType, tokenIdx);
+                        extTime = std::max(extTime, (*scoreAccessor)->getTime());
                     }
 
                     // Pre-prune based on score before creating extension instance and appending to list
@@ -428,7 +430,7 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
                             {.nextToken      = tokenIdx,
                              .pron           = lemma->pronunciations().first,
                              .score          = extScore,
-                             .timeframe      = std::max(hyp.trace->time, (*scoreAccessor)->getTime()),
+                             .timeframe      = extTime,
                              .transitionType = transitionType,
                              .baseHypIndex   = hypIndex});
                 }

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -485,8 +485,10 @@ bool TreeTimesyncBeamSearch::decodeStep() {
                     }
                     auto transitionType = inferTransitionType(hyp.currentToken, tokenIdx);
                     auto extScore       = hyp.score;
+                    auto extTime        = hyp.timeframe;
                     if (labelScorers_[scorerIdx]->scoresTransition(transitionType)) {
                         extScore = hyp.score + (*scoreAccessor)->getScore(transitionType, tokenIdx);
+                        extTime  = std::max(extTime, (*scoreAccessor)->getTime());
                     }
 
                     // Pre-prune based on score before creating extension instance and appending to list
@@ -498,7 +500,7 @@ bool TreeTimesyncBeamSearch::decodeStep() {
                     withinWordExtensions_.push_back(
                             {.nextToken      = tokenIdx,
                              .nextState      = successorState,
-                             .timeframe      = hyp.timeframe,
+                             .timeframe      = extTime,
                              .score          = extScore,
                              .transitionType = transitionType,
                              .baseHypIndex   = hypIndex});


### PR DESCRIPTION
This fixes a bug where the timestamps for extension creation were set incorrectly and don't consider whether the LabelScorer scores the transition in LexiconfreeTimesyncBeamSearch and TreeTimesyncBeamSearch. This bug was introduced through #199.