### PR TITLE
Update PythonLabelScorer: add interface to set allowed transition types

### DIFF
--- a/src/Python/LabelScorer.cc
+++ b/src/Python/LabelScorer.cc
@@ -88,6 +88,19 @@ void PythonLabelScorer::addPythonInputs(py::array const& inputs) {
 void PythonLabelScorer::setInstance(py::object const& instance) {
     py::gil_scoped_acquire gil;
     pyInstance_ = instance;
+
+    py::object allowedTransitionTypes = getPythonAllowedTransitionTypes();
+    for (py::handle transitionType : allowedTransitionTypes) {
+        enabledTransitions_.enable(transitionType.cast<Nn::TransitionType>());
+    }
+}
+
+py::object PythonLabelScorer::getPythonAllowedTransitionTypes() {
+    PYBIND11_OVERRIDE_PURE_NAME(
+            py::object,
+            Nn::LabelScorer,
+            "allowed_transition_types",
+            getPythonAllowedTransitionTypes);
 }
 
 Nn::ScoringContextRef PythonLabelScorer::extendedScoringContext(Nn::ScoringContextRef scoringContext, Nn::LabelIndex nextToken, Nn::TransitionType transitionType) {

--- a/src/Python/LabelScorer.hh
+++ b/src/Python/LabelScorer.hh
@@ -61,6 +61,9 @@ public:
     // Keep track of python object as a member to make sure it doesn't get garbage collected
     void setInstance(py::object const& instance);
 
+    // Must be overridden in python by name "allowed_transition_types"
+    virtual py::object getPythonAllowedTransitionTypes();
+
     // the following methods are protected in the base class
 
     // Must be overridden in python by name "extended_scoring_context_internal"

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -60,7 +60,8 @@ void bindLabelScorer(py::module_& module) {
             .value("INITIAL_BLANK", Nn::TransitionType::INITIAL_BLANK)
             .value("WORD_EXIT", Nn::TransitionType::WORD_EXIT)
             .value("NONWORD_EXIT", Nn::TransitionType::NONWORD_EXIT)
-            .value("SILENCE_EXIT", Nn::TransitionType::SILENCE_EXIT);
+            .value("SILENCE_EXIT", Nn::TransitionType::SILENCE_EXIT)
+            .value("SENTENCE_END", Nn::TransitionType::SENTENCE_END);
 
     // Specify `Python::LabelScorer` as trampoline class and `Core::Ref<Nn::LabelScorer>` as holder type
     py::class_<Nn::LabelScorer, Python::PythonLabelScorer, Core::Ref<Nn::LabelScorer>> pyLabelScorer(
@@ -78,6 +79,7 @@ void bindLabelScorer(py::module_& module) {
             " - `reset`\n"
             " - `signal_no_more_features`\n"
             " - `get_initial_scoring_context`\n"
+            " - `allowed_transition_types`\n"
             " - `extended_scoring_context`\n"
             " - `add_inputs`\n"
             " - `compute_scores_with_times`");
@@ -101,6 +103,11 @@ void bindLabelScorer(py::module_& module) {
             "get_initial_scoring_context",
             [](Python::PythonLabelScorer& self) { return self.getInitialPythonScoringContext(); },
             "Create some arbitrary (hashable) python object which symbolizes the scoring context in the first search step");
+
+    pyLabelScorer.def(
+            "allowed_transition_types",
+            [](Python::PythonLabelScorer& self) { return self.getPythonAllowedTransitionTypes(); },
+            "Return an iterable of `TransitionType` values that can be scored by this label scorer.");
 
     pyLabelScorer.def(
             "extended_scoring_context",


### PR DESCRIPTION
The PythonLabelScorer currently always uses the default `TransitionPresetType` which is `TransitionPresetType::NONE`. This means that it will not score any transition. This PR changes the interface so that the user has to implement a new function `allowed_transition_types` which is used for the allowed transitions.

Also, the `SENTENCE_END` transition type was missing from the pybinds.