### PR TITLE
Update new search algorithms: Perform all reset logic in enterSegment instead of reset

### DIFF
--- a/src/Flf/RecognizerV2.cc
+++ b/src/Flf/RecognizerV2.cc
@@ -48,7 +48,6 @@ void RecognizerNodeV2::recognizeSegment(const Bliss::SpeechSegment* segment) {
     }
 
     // Initialize recognizer and feature extractor
-    searchAlgorithm_->reset();
     searchAlgorithm_->enterSegment();
 
     featureExtractor_->enterSegment(segment);
@@ -230,7 +229,6 @@ void RecognizerNodeV2::sync() {
 }
 
 void RecognizerNodeV2::finalize() {
-    searchAlgorithm_->reset();
 }
 
 ConstSegmentRef RecognizerNodeV2::sendSegment(RecognizerNodeV2::Port to) {

--- a/src/Python/Search.cc
+++ b/src/Python/Search.cc
@@ -34,10 +34,6 @@ SearchAlgorithm::SearchAlgorithm(const Core::Configuration& c)
     searchAlgorithm_->setModelCombination(modelCombination_);
 }
 
-void SearchAlgorithm::reset() {
-    searchAlgorithm_->reset();
-}
-
 void SearchAlgorithm::enterSegment() {
     searchAlgorithm_->enterSegment();
 }
@@ -185,7 +181,6 @@ std::vector<Traceback> SearchAlgorithm::getCurrentNBestList(size_t nBestSize) {
 }
 
 Traceback SearchAlgorithm::recognizeSegment(py::array_t<f32> const& features) {
-    reset();
     enterSegment();
     putFeatures(features);
     finishSegment();
@@ -193,7 +188,6 @@ Traceback SearchAlgorithm::recognizeSegment(py::array_t<f32> const& features) {
 }
 
 std::vector<Traceback> SearchAlgorithm::recognizeSegmentNBest(py::array_t<f32> const& features, size_t nBestSize) {
-    reset();
     enterSegment();
     putFeatures(features);
     finishSegment();

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -42,10 +42,6 @@ class SearchAlgorithm : public Core::Component {
 public:
     SearchAlgorithm(const Core::Configuration& c);
 
-    // Call before starting a new recognition. Clean up existing data structures
-    // from the previous run.
-    void reset();
-
     // Call at the beginning of a new segment.
     void enterSegment();
 

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -227,13 +227,8 @@ void LexiconfreeLabelsyncBeamSearch::reset() {
 }
 
 void LexiconfreeLabelsyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    initializationTime_.start();
-    labelScorer_->reset();
+    reset();
     resetStatistics();
-    initializationTime_.stop();
-    finishedSegment_   = false;
-    totalTimesteps_    = 0ul;
-    currentSearchStep_ = 0ul;
 }
 
 void LexiconfreeLabelsyncBeamSearch::finishSegment() {

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -205,11 +205,19 @@ bool LexiconfreeLabelsyncBeamSearch::setModelCombination(Speech::ModelCombinatio
         }
     }
 
-    reset();
     return true;
 }
 
-void LexiconfreeLabelsyncBeamSearch::reset() {
+void LexiconfreeLabelsyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
+    initializationTime_.reset();
+    featureProcessingTime_.reset();
+    scoringTime_.reset();
+    contextExtensionTime_.reset();
+    numTerminatedHypsAfterScorePruning_.clear();
+    numTerminatedHypsAfterBeamPruning_.clear();
+    numActiveHypsAfterScorePruning_.clear();
+    numActiveHypsAfterBeamPruning_.clear();
+
     initializationTime_.start();
 
     labelScorer_->reset();
@@ -224,11 +232,6 @@ void LexiconfreeLabelsyncBeamSearch::reset() {
     currentSearchStep_ = 0ul;
 
     initializationTime_.stop();
-}
-
-void LexiconfreeLabelsyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    reset();
-    resetStatistics();
 }
 
 void LexiconfreeLabelsyncBeamSearch::finishSegment() {
@@ -593,17 +596,6 @@ LexiconfreeLabelsyncBeamSearch::LabelHypothesis const& LexiconfreeLabelsyncBeamS
     result = getWorstActiveHypothesis();
     verify(result != nullptr);
     return *result;
-}
-
-void LexiconfreeLabelsyncBeamSearch::resetStatistics() {
-    initializationTime_.reset();
-    featureProcessingTime_.reset();
-    scoringTime_.reset();
-    contextExtensionTime_.reset();
-    numTerminatedHypsAfterScorePruning_.clear();
-    numTerminatedHypsAfterBeamPruning_.clear();
-    numActiveHypsAfterScorePruning_.clear();
-    numActiveHypsAfterBeamPruning_.clear();
 }
 
 void LexiconfreeLabelsyncBeamSearch::logStatistics() const {

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -57,7 +57,6 @@ public:
 
     Speech::ModelCombination::Mode  requiredModelCombination() const override;
     bool                            setModelCombination(Speech::ModelCombination const& modelCombination) override;
-    void                            reset() override;
     void                            enterSegment(Bliss::SpeechSegment const* = nullptr) override;
     void                            finishSegment() override;
     void                            putFeature(Nn::DataView const& feature) override;
@@ -170,7 +169,6 @@ private:
     LabelHypothesis const& getBestHypothesis() const;
     LabelHypothesis const& getWorstHypothesis() const;
 
-    void resetStatistics();
     void logStatistics() const;
 
     /*

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -258,11 +258,20 @@ bool LexiconfreeTimesyncBeamSearch::setModelCombination(Speech::ModelCombination
         }
     }
 
-    reset();
     return true;
 }
 
-void LexiconfreeTimesyncBeamSearch::reset() {
+void LexiconfreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
+    initializationTime_.reset();
+    featureProcessingTime_.reset();
+    scoringTime_.reset();
+    for (auto& stat : numHypsAfterIntermediatePruning_) {
+        stat.clear();
+    }
+    numHypsAfterRecombination_.clear();
+    numHypsAfterPruning_.clear();
+    numActiveHyps_.clear();
+
     initializationTime_.start();
 
     for (auto& labelScorer : labelScorers_) {
@@ -281,11 +290,6 @@ void LexiconfreeTimesyncBeamSearch::reset() {
     finishedSegment_   = false;
 
     initializationTime_.stop();
-}
-
-void LexiconfreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    reset();
-    resetStatistics();
 }
 
 void LexiconfreeTimesyncBeamSearch::finishSegment() {
@@ -577,18 +581,6 @@ LexiconfreeTimesyncBeamSearch::LabelHypothesis const& LexiconfreeTimesyncBeamSea
     verify(not beam_.empty());
 
     return *std::max_element(beam_.begin(), beam_.end());
-}
-
-void LexiconfreeTimesyncBeamSearch::resetStatistics() {
-    initializationTime_.reset();
-    featureProcessingTime_.reset();
-    scoringTime_.reset();
-    for (auto& stat : numHypsAfterIntermediatePruning_) {
-        stat.clear();
-    }
-    numHypsAfterRecombination_.clear();
-    numHypsAfterPruning_.clear();
-    numActiveHyps_.clear();
 }
 
 void LexiconfreeTimesyncBeamSearch::logStatistics() const {

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -284,14 +284,8 @@ void LexiconfreeTimesyncBeamSearch::reset() {
 }
 
 void LexiconfreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    initializationTime_.start();
-    for (auto& labelScorer : labelScorers_) {
-        labelScorer->reset();
-    }
+    reset();
     resetStatistics();
-    initializationTime_.stop();
-    currentSearchStep_ = 0ul;
-    finishedSegment_   = false;
 }
 
 void LexiconfreeTimesyncBeamSearch::finishSegment() {

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -59,7 +59,6 @@ public:
 
     Speech::ModelCombination::Mode requiredModelCombination() const override;
     bool                           setModelCombination(Speech::ModelCombination const& modelCombination) override;
-    void                           reset() override;
     void                           enterSegment(Bliss::SpeechSegment const* = nullptr) override;
     void                           finishSegment() override;
     void                           putFeature(Nn::DataView const& feature) override;
@@ -155,7 +154,6 @@ private:
     LabelHypothesis const& getBestHypothesis() const;
     LabelHypothesis const& getWorstHypothesis() const;
 
-    void resetStatistics();
     void logStatistics() const;
 
     /*

--- a/src/Search/SearchV2.hh
+++ b/src/Search/SearchV2.hh
@@ -45,9 +45,7 @@ namespace Search {
  *  (6. Optionally retrieve intermediate results via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.)
  *  7. Call `finishSegment` to signal that all features have been passed and finalize the search with all the segment features.
  *  8. Retrieve the final result via `getCurrentBestTraceback` or `getCurrentBestWordLattice`.
- *  9. Call `reset` to clean up any buffered features, hypotheses, flags etc. from the previous segment and prepare the algorithm for the next one.
- *  (10. Optionally also reset search statistics via `resetStatistics`).
- *  11. Continue again at step 3.
+ *  9. Continue again at step 3.
  */
 class SearchAlgorithmV2 : public virtual Core::Component {
 public:
@@ -66,10 +64,8 @@ public:
     // Pass a `Speech::ModelCombination` that matches the requirements set by `requiredModelCombination` (and `requiredAcousticModel`) to the search.
     virtual bool setModelCombination(Speech::ModelCombination const& modelCombination) = 0;
 
-    // Cleans up buffers, hypotheses, flags etc. from the previous segment recognition.
-    virtual void reset() = 0;
-
     // Signal the beginning of a new audio segment.
+    // Cleans up buffers, hypotheses, flags etc. from the previous segment recognition.
     virtual void enterSegment(Bliss::SpeechSegment const* = nullptr) = 0;
 
     // Signal that all features of the current segment have been passed.

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -316,12 +316,24 @@ bool TreeTimesyncBeamSearch::setModelCombination(Speech::ModelCombination const&
     // Create look-ups for state successors and exits of each state
     createSuccessorLookups();
 
-    reset();
-
     return true;
 }
 
-void TreeTimesyncBeamSearch::reset() {
+void TreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
+    initializationTime_.reset();
+    featureProcessingTime_.reset();
+    scoringTime_.reset();
+    for (auto& stat : numHypsAfterIntermediatePruning_) {
+        stat.clear();
+    }
+    numHypsAfterRecombination_.clear();
+    numHypsAfterPruning_.clear();
+    numWordEndHypsAfterScorePruning_.clear();
+    numWordEndHypsAfterRecombination_.clear();
+    numWordEndHypsAfterBeamPruning_.clear();
+    numActiveHyps_.clear();
+    numActiveTrees_.clear();
+
     initializationTime_.start();
 
     for (auto& labelScorer : labelScorers_) {
@@ -342,11 +354,6 @@ void TreeTimesyncBeamSearch::reset() {
     finishedSegment_   = false;
 
     initializationTime_.stop();
-}
-
-void TreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    reset();
-    resetStatistics();
     if (segment != nullptr) {
         languageModel_->setSegment(segment);
         for (auto& hyp : beam_) {
@@ -746,22 +753,6 @@ TreeTimesyncBeamSearch::LabelHypothesis const& TreeTimesyncBeamSearch::getWorstH
     verify(not beam_.empty());
 
     return *std::max_element(beam_.begin(), beam_.end());
-}
-
-void TreeTimesyncBeamSearch::resetStatistics() {
-    initializationTime_.reset();
-    featureProcessingTime_.reset();
-    scoringTime_.reset();
-    for (auto& stat : numHypsAfterIntermediatePruning_) {
-        stat.clear();
-    }
-    numHypsAfterRecombination_.clear();
-    numHypsAfterPruning_.clear();
-    numWordEndHypsAfterScorePruning_.clear();
-    numWordEndHypsAfterRecombination_.clear();
-    numWordEndHypsAfterBeamPruning_.clear();
-    numActiveHyps_.clear();
-    numActiveTrees_.clear();
 }
 
 void TreeTimesyncBeamSearch::logStatistics() const {

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -345,19 +345,14 @@ void TreeTimesyncBeamSearch::reset() {
 }
 
 void TreeTimesyncBeamSearch::enterSegment(Bliss::SpeechSegment const* segment) {
-    initializationTime_.start();
-    for (auto& labelScorer : labelScorers_) {
-        labelScorer->reset();
-    }
+    reset();
+    resetStatistics();
     if (segment != nullptr) {
         languageModel_->setSegment(segment);
         for (auto& hyp : beam_) {
             hyp.lmHistory = languageModel_->startHistory();
         }
     }
-    resetStatistics();
-    initializationTime_.stop();
-    finishedSegment_ = false;
 }
 
 void TreeTimesyncBeamSearch::finishSegment() {

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -64,7 +64,6 @@ public:
     Speech::ModelCombination::Mode requiredModelCombination() const override;
     Am::AcousticModel::Mode        requiredAcousticModel() const override;
     bool                           setModelCombination(Speech::ModelCombination const& modelCombination) override;
-    void                           reset() override;
     void                           enterSegment(Bliss::SpeechSegment const* = nullptr) override;
     void                           finishSegment() override;
     void                           putFeature(Nn::DataView const& feature) override;
@@ -197,7 +196,6 @@ private:
     LabelHypothesis const& getBestHypothesis() const;
     LabelHypothesis const& getWorstHypothesis() const;
 
-    void resetStatistics();
     void logStatistics() const;
 
     /*

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -68,7 +68,6 @@ void bindSearchAlgorithm(py::module_& module) {
             "It works by calling `enter_segment()`, passing segment features\n"
             "via `put_feature` or `put_features` and finally calling `finish_segment()`.\n"
             "Intermediate and final results can be retrieved via `get_current_best_traceback()`.\n"
-            "Before recognizing the next segment, `reset` should be called.\n"
             "There is also a convenience function `recognize_segment` that performs all\n"
             "these steps in one go given an array of segment features.");
 
@@ -76,11 +75,6 @@ void bindSearchAlgorithm(py::module_& module) {
             py::init<const Core::Configuration&>(),
             py::arg("config"),
             "Initialize search algorithm using a RASR config.");
-
-    pySearchAlgorithm.def(
-            "reset",
-            &SearchAlgorithm::reset,
-            "Call before starting a new recognition. Cleans up existing data structures from the previous run.");
 
     pySearchAlgorithm.def(
             "enter_segment",
@@ -124,12 +118,12 @@ void bindSearchAlgorithm(py::module_& module) {
             "recognize_segment",
             &SearchAlgorithm::recognizeSegment,
             py::arg("features"),
-            "Convenience function to reset the search algorithm, start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return the recognition result.");
+            "Convenience function to start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return the recognition result.");
 
     pySearchAlgorithm.def(
             "recognize_segment_n_best",
             &SearchAlgorithm::recognizeSegmentNBest,
             py::arg("features"),
             py::arg("n"),
-            "Convenience function to reset the search algorithm, start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return a n-best list of results.");
+            "Convenience function to start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return a n-best list of results.");
 }


### PR DESCRIPTION
Previously, the `enterSegment` function in the new search algorithms only reset the LabelScorers but kept the current hypotheses in the beam. For certain LabelScorers this can become a problem because the existing scoring contexts in the hypotheses can become invalid when resetting the LabelScorer.

This PR calls the `reset` function in `enterSegment` which first resets the LabelScorers and then also re-initializes the beam.