### PR TITLE
Update Python.cmake: Initialize FindPython before pybind11 is used

### DIFF
--- a/cmake_resources/Python.cmake
+++ b/cmake_resources/Python.cmake
@@ -1,5 +1,4 @@
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
-find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+find_package(Python3 REQUIRED COMPONENTS Development NumPy Interpreter Development.Module)
 
 add_library(RasrPythonDependencies INTERFACE)
 target_compile_definitions(

--- a/cmake_resources/Python.cmake
+++ b/cmake_resources/Python.cmake
@@ -1,10 +1,9 @@
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
-find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+find_package(Python REQUIRED COMPONENTS Development NumPy Interpreter Development.Module)
 
 add_library(RasrPythonDependencies INTERFACE)
 target_compile_definitions(
     RasrPythonDependencies INTERFACE ${Python3_DEFINITIONS}
 )
 target_link_libraries(
-    RasrPythonDependencies INTERFACE Python3::Python Python3::NumPy
+        RasrPythonDependencies INTERFACE Python::Python Python::NumPy
 )

--- a/cmake_resources/Python.cmake
+++ b/cmake_resources/Python.cmake
@@ -1,4 +1,5 @@
-find_package(Python3 REQUIRED COMPONENTS Development NumPy Interpreter Development.Module)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(Python3 REQUIRED COMPONENTS Development NumPy)
 
 add_library(RasrPythonDependencies INTERFACE)
 target_compile_definitions(

--- a/cmake_resources/Python.cmake
+++ b/cmake_resources/Python.cmake
@@ -5,5 +5,5 @@ target_compile_definitions(
     RasrPythonDependencies INTERFACE ${Python3_DEFINITIONS}
 )
 target_link_libraries(
-        RasrPythonDependencies INTERFACE Python::Python Python::NumPy
+    RasrPythonDependencies INTERFACE Python::Python Python::NumPy
 )

--- a/cmake_resources/Python.cmake
+++ b/cmake_resources/Python.cmake
@@ -1,3 +1,4 @@
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(Python3 REQUIRED COMPONENTS Development NumPy)
 
 add_library(RasrPythonDependencies INTERFACE)


### PR DESCRIPTION
Recent pybind11 CMake code uses CMake's modern `FindPython` support for `pybind11_add_module`. In a new Apptainer image I was using, configuration failed in `pybind11NewTools.cmake` with `Unknown CMake command "python_add_library"` because the generic Python package had not been initialized with module development support.

I only ran into this problem when having the new Torch module enabled, since the Torch setup also queries the active Python environment.