### PR TITLE
Update build flags: make some warnings again into errors

### DIFF
--- a/cmake_resources/CompileOptions.cmake
+++ b/cmake_resources/CompileOptions.cmake
@@ -11,6 +11,11 @@ add_compile_options(
     -Wno-long-long
     -Wno-deprecated
     -fno-strict-aliasing
+    "$<$<COMPILE_LANGUAGE:CXX>:-Werror=format-security>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-Werror=reorder>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-Werror=return-type>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-Werror=delete-non-virtual-dtor>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-Werror=unused-but-set-variable>"
 )
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i[3-6]86)$")


### PR DESCRIPTION
When porting from Make to CMake, some compiler flags to throw errors on certain warnings were missed. This adds them back in.