### PR TITLE
Add new apptainer image 2026-05-19_pytorch-2.12_onnx-1.24_v1

### DIFF
--- a/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/README.txt
+++ b/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/README.txt
@@ -1,0 +1,10 @@
+Image based on official nvidia image pytorch:26.04-py3.
+
+Contains:
+ - Ubuntu 24.04
+ - CUDA 13.2.1
+ - PyTorch 2.12
+ - ONNX 1.24.4
+ - Python 3.12
+ - i6 Cache Manager
+ - Basics required to compile RASR

--- a/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
+++ b/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
@@ -1,0 +1,31 @@
+Bootstrap: docker
+From: nvcr.io/nvidia/pytorch:26.04-py3
+Stage: build
+
+%post
+    apt update -y
+
+    # fundamental basics to compile RASR, zsh is needed because calling the cache manager might launch the user shell
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+        zsh bison libopenblas-dev libsndfile1-dev cmake
+
+    pip3 install "pybind11[global]"
+
+    # download the cache manager and place in /usr/local
+    cd /usr/local
+    git clone https://github.com/rwth-i6/cache-manager.git
+    cd bin
+    ln -s ../cache-manager/cf cf
+
+    cd /usr/local
+    wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+    tar xzvf onnxruntime-linux-x64-*.tgz
+    mkdir -p /usr/local/{include,lib}
+    mv onnxruntime-linux-x64-*/include/* /usr/local/include/
+    mv onnxruntime-linux-x64-*/lib/cmake/* /usr/local/lib/cmake
+    mv onnxruntime-linux-x64-*/lib/pkgconfig/* /usr/local/lib/pkgconfig
+    rmdir onnxruntime-linux-x64-*/lib/cmake
+    rmdir onnxruntime-linux-x64-*/lib/pkgconfig
+    mv onnxruntime-linux-x64-*/lib/* /usr/local/lib/
+    rm -r onnxruntime-linux-x64-*
+    ldconfig

--- a/cmake_resources/Modules.cmake
+++ b/cmake_resources/Modules.cmake
@@ -111,7 +111,7 @@ add_module_option(MODULE_ACML OFF)
 add_module_option(MODULE_CUDA ON)
 
 # ****** Tensorflow integration ******
-add_module_option(MODULE_TENSORFLOW ON)
+add_module_option(MODULE_TENSORFLOW OFF)
 
 # ****** ONNX integration ******
 add_module_option(MODULE_ONNX ON)


### PR DESCRIPTION
New (minimalist) Apptainer image with PyTorch 2.12, Onnx 1.24 and **without Tensorflow**.
The Tensorflow Module is now turned off by default.
I tried to keep only the packages which are required to compile RASR and which are not already contained in the base image.