### PR TITLE
Add config option to skip recombination step in new search algorithms

### DIFF
--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -27,6 +27,15 @@
 
 namespace Search {
 
+namespace {
+
+enum RecombinationMode {
+    recombinationOff,
+    recombinationOn,
+};
+
+}  // namespace
+
 /*
  * =======================
  * === LabelHypothesis ===
@@ -135,6 +144,17 @@ const Core::ParameterFloat LexiconfreeLabelsyncBeamSearch::paramMaxLabelsPerTime
         "Maximum number of emitted labels per input timestep counted via `addInput`/`addInputs`.",
         1.0);
 
+const Core::Choice LexiconfreeLabelsyncBeamSearch::choiceRecombination(
+        "off", recombinationOff,
+        "on", recombinationOn,
+        Core::Choice::endMark());
+
+const Core::ParameterChoice LexiconfreeLabelsyncBeamSearch::paramRecombination(
+        "recombination",
+        &choiceRecombination,
+        "Whether hypotheses with identical recombination state should be recombined.",
+        recombinationOn);
+
 const Core::ParameterBool LexiconfreeLabelsyncBeamSearch::paramLogStepwiseStatistics(
         "log-stepwise-statistics",
         "Log statistics about the beam at every search step.",
@@ -154,6 +174,7 @@ LexiconfreeLabelsyncBeamSearch::LexiconfreeLabelsyncBeamSearch(Core::Configurati
           lengthNormScale_(paramLengthNormScale(config)),
           maxLabelsPerTimestep_(paramMaxLabelsPerTimestep(config)),
           sentenceEndLabelIndex_(paramSentenceEndLabelIndex(config)),
+          recombinationEnabled_(paramRecombination(config) == recombinationOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           debugChannel_(config, "debug"),
@@ -669,6 +690,10 @@ void LexiconfreeLabelsyncBeamSearch::scorePruning(std::vector<Element>& hypothes
 }
 
 void LexiconfreeLabelsyncBeamSearch::recombination() {
+    if (not recombinationEnabled_) {
+        return;
+    }
+
     // Represents a unique combination of currentToken and scoringContext
     struct RecombinationContext {
         Nn::LabelIndex        currentToken;

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -30,8 +30,8 @@ namespace Search {
 namespace {
 
 enum RecombinationMode {
-    recombinationOff,
-    recombinationOn,
+    recombinationModeOff,
+    recombinationModeOn,
 };
 
 }  // namespace
@@ -148,16 +148,16 @@ const Core::ParameterFloat LexiconfreeLabelsyncBeamSearch::paramMaxLabelsPerTime
         "Maximum number of emitted labels per input timestep counted via `addInput`/`addInputs`.",
         1.0);
 
-const Core::Choice LexiconfreeLabelsyncBeamSearch::choiceRecombination(
-        "off", recombinationOff,
-        "on", recombinationOn,
+const Core::Choice LexiconfreeLabelsyncBeamSearch::choiceRecombinationMode(
+        "off", recombinationModeOff,
+        "on", recombinationModeOn,
         Core::Choice::endMark());
 
-const Core::ParameterChoice LexiconfreeLabelsyncBeamSearch::paramRecombination(
-        "recombination",
-        &choiceRecombination,
+const Core::ParameterChoice LexiconfreeLabelsyncBeamSearch::paramRecombinationMode(
+        "recombination-mode",
+        &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationOn);
+        recombinationModeOn);
 
 const Core::ParameterBool LexiconfreeLabelsyncBeamSearch::paramLogStepwiseStatistics(
         "log-stepwise-statistics",
@@ -176,7 +176,7 @@ LexiconfreeLabelsyncBeamSearch::LexiconfreeLabelsyncBeamSearch(Core::Configurati
           lengthNormScale_(paramLengthNormScale(config)),
           maxLabelsPerTimestep_(paramMaxLabelsPerTimestep(config)),
           sentenceEndLabelIndex_(paramSentenceEndLabelIndex(config)),
-          recombinationEnabled_(paramRecombination(config) == recombinationOn),
+          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           debugChannel_(config, "debug"),

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -30,8 +30,8 @@ namespace Search {
 namespace {
 
 enum RecombinationMode {
-    recombinationModeOff,
-    recombinationModeOn,
+    RecombinationModeOff,
+    RecombinationModeOn,
 };
 
 }  // namespace
@@ -149,15 +149,15 @@ const Core::ParameterFloat LexiconfreeLabelsyncBeamSearch::paramMaxLabelsPerTime
         1.0);
 
 const Core::Choice LexiconfreeLabelsyncBeamSearch::choiceRecombinationMode(
-        "off", recombinationModeOff,
-        "on", recombinationModeOn,
+        "off", RecombinationModeOff,
+        "on", RecombinationModeOn,
         Core::Choice::endMark());
 
 const Core::ParameterChoice LexiconfreeLabelsyncBeamSearch::paramRecombinationMode(
         "recombination-mode",
         &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationModeOn);
+        RecombinationModeOn);
 
 const Core::ParameterBool LexiconfreeLabelsyncBeamSearch::paramLogStepwiseStatistics(
         "log-stepwise-statistics",
@@ -176,7 +176,7 @@ LexiconfreeLabelsyncBeamSearch::LexiconfreeLabelsyncBeamSearch(Core::Configurati
           lengthNormScale_(paramLengthNormScale(config)),
           maxLabelsPerTimestep_(paramMaxLabelsPerTimestep(config)),
           sentenceEndLabelIndex_(paramSentenceEndLabelIndex(config)),
-          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
+          recombinationEnabled_(paramRecombinationMode(config) == RecombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           debugChannel_(config, "debug"),

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -48,8 +48,10 @@ public:
     static const Core::ParameterInt   paramSentenceEndLabelIndex;
     static const Core::ParameterBool  paramCacheCleanupInterval;
     static const Core::ParameterFloat paramLengthNormScale;
-    static const Core::ParameterFloat paramMaxLabelsPerTimestep;
-    static const Core::ParameterBool  paramLogStepwiseStatistics;
+    static const Core::ParameterFloat  paramMaxLabelsPerTimestep;
+    static const Core::Choice          choiceRecombination;
+    static const Core::ParameterChoice paramRecombination;
+    static const Core::ParameterBool   paramLogStepwiseStatistics;
 
     LexiconfreeLabelsyncBeamSearch(Core::Configuration const&);
 
@@ -129,6 +131,7 @@ private:
     float          lengthNormScale_;
     float          maxLabelsPerTimestep_;
     Nn::LabelIndex sentenceEndLabelIndex_;
+    bool           recombinationEnabled_;
     bool           logStepwiseStatistics_;
     size_t         cacheCleanupInterval_;
 

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -49,8 +49,8 @@ public:
     static const Core::ParameterBool        paramCacheCleanupInterval;
     static const Core::ParameterFloat       paramLengthNormScale;
     static const Core::ParameterFloat       paramMaxLabelsPerTimestep;
-    static const Core::Choice               choiceRecombination;
-    static const Core::ParameterChoice      paramRecombination;
+    static const Core::Choice               choiceRecombinationMode;
+    static const Core::ParameterChoice      paramRecombinationMode;
     static const Core::ParameterBool        paramLogStepwiseStatistics;
 
     LexiconfreeLabelsyncBeamSearch(Core::Configuration const&);

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -30,6 +30,15 @@
 
 namespace Search {
 
+namespace {
+
+enum RecombinationMode {
+    recombinationOff,
+    recombinationOn,
+};
+
+}  // namespace
+
 /*
  * =======================
  * === LabelHypothesis ===
@@ -148,6 +157,17 @@ const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaximumStableDelayP
         10,
         1);
 
+const Core::Choice LexiconfreeTimesyncBeamSearch::choiceRecombination(
+        "off", recombinationOff,
+        "on", recombinationOn,
+        Core::Choice::endMark());
+
+const Core::ParameterChoice LexiconfreeTimesyncBeamSearch::paramRecombination(
+        "recombination",
+        &choiceRecombination,
+        "Whether hypotheses with identical recombination state should be recombined.",
+        recombinationOn);
+
 LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
           SearchAlgorithmV2(config),
@@ -159,6 +179,7 @@ LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           maximumStableDelay_(paramMaximumStableDelay(config)),
           maximumStableDelayPruningInterval_(paramMaximumStableDelayPruningInterval(config)),
+          recombinationEnabled_(paramRecombination(config) == recombinationOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           debugChannel_(config, "debug"),
           labelScorers_(),
@@ -692,6 +713,10 @@ template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBea
 template void LexiconfreeTimesyncBeamSearch::scorePruning<LexiconfreeTimesyncBeamSearch::LabelHypothesis>(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>&, Score, size_t);
 
 void LexiconfreeTimesyncBeamSearch::recombination(std::vector<LexiconfreeTimesyncBeamSearch::LabelHypothesis>& hypotheses) {
+    if (not recombinationEnabled_) {
+        return;
+    }
+
     // Represents a unique combination of currentToken and scoringContext
     struct RecombinationContext {
         Nn::LabelIndex                     currentToken;

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -33,8 +33,8 @@ namespace Search {
 namespace {
 
 enum RecombinationMode {
-    recombinationModeOff,
-    recombinationModeOn,
+    RecombinationModeOff,
+    RecombinationModeOn,
 };
 
 }  // namespace
@@ -158,15 +158,15 @@ const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaximumStableDelayP
         1);
 
 const Core::Choice LexiconfreeTimesyncBeamSearch::choiceRecombinationMode(
-        "off", recombinationModeOff,
-        "on", recombinationModeOn,
+        "off", RecombinationModeOff,
+        "on", RecombinationModeOn,
         Core::Choice::endMark());
 
 const Core::ParameterChoice LexiconfreeTimesyncBeamSearch::paramRecombinationMode(
         "recombination-mode",
         &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationModeOn);
+        RecombinationModeOn);
 
 LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
@@ -179,7 +179,7 @@ LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           maximumStableDelay_(paramMaximumStableDelay(config)),
           maximumStableDelayPruningInterval_(paramMaximumStableDelayPruningInterval(config)),
-          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
+          recombinationEnabled_(paramRecombinationMode(config) == RecombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           debugChannel_(config, "debug"),
           labelScorers_(),

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -33,8 +33,8 @@ namespace Search {
 namespace {
 
 enum RecombinationMode {
-    recombinationOff,
-    recombinationOn,
+    recombinationModeOff,
+    recombinationModeOn,
 };
 
 }  // namespace
@@ -157,16 +157,16 @@ const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaximumStableDelayP
         10,
         1);
 
-const Core::Choice LexiconfreeTimesyncBeamSearch::choiceRecombination(
-        "off", recombinationOff,
-        "on", recombinationOn,
+const Core::Choice LexiconfreeTimesyncBeamSearch::choiceRecombinationMode(
+        "off", recombinationModeOff,
+        "on", recombinationModeOn,
         Core::Choice::endMark());
 
-const Core::ParameterChoice LexiconfreeTimesyncBeamSearch::paramRecombination(
-        "recombination",
-        &choiceRecombination,
+const Core::ParameterChoice LexiconfreeTimesyncBeamSearch::paramRecombinationMode(
+        "recombination-mode",
+        &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationOn);
+        recombinationModeOn);
 
 LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
@@ -179,7 +179,7 @@ LexiconfreeTimesyncBeamSearch::LexiconfreeTimesyncBeamSearch(Core::Configuration
           cacheCleanupInterval_(paramCacheCleanupInterval(config)),
           maximumStableDelay_(paramMaximumStableDelay(config)),
           maximumStableDelayPruningInterval_(paramMaximumStableDelayPruningInterval(config)),
-          recombinationEnabled_(paramRecombination(config) == recombinationOn),
+          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           debugChannel_(config, "debug"),
           labelScorers_(),

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -51,6 +51,8 @@ public:
     static const Core::ParameterBool        paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
+    static const Core::Choice               choiceRecombination;
+    static const Core::ParameterChoice      paramRecombination;
     static const Core::ParameterBool        paramLogStepwiseStatistics;
 
     LexiconfreeTimesyncBeamSearch(Core::Configuration const&);
@@ -124,6 +126,7 @@ private:
     size_t              cacheCleanupInterval_;
     size_t              maximumStableDelay_;
     size_t              maximumStableDelayPruningInterval_;
+    bool                recombinationEnabled_;
     bool                logStepwiseStatistics_;
 
     Core::Channel debugChannel_;

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -51,8 +51,8 @@ public:
     static const Core::ParameterBool        paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
-    static const Core::Choice               choiceRecombination;
-    static const Core::ParameterChoice      paramRecombination;
+    static const Core::Choice               choiceRecombinationMode;
+    static const Core::ParameterChoice      paramRecombinationMode;
     static const Core::ParameterBool        paramLogStepwiseStatistics;
 
     LexiconfreeTimesyncBeamSearch(Core::Configuration const&);

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -31,8 +31,8 @@
 namespace {
 
 enum RecombinationMode {
-    recombinationModeOff,
-    recombinationModeOn,
+    RecombinationModeOff,
+    RecombinationModeOn,
 };
 
 }  // namespace
@@ -177,15 +177,15 @@ const Core::ParameterInt TreeTimesyncBeamSearch::paramMaximumStableDelayPruningI
         1);
 
 const Core::Choice TreeTimesyncBeamSearch::choiceRecombinationMode(
-        "off", recombinationModeOff,
-        "on", recombinationModeOn,
+        "off", RecombinationModeOff,
+        "on", RecombinationModeOn,
         Core::Choice::endMark());
 
 const Core::ParameterChoice TreeTimesyncBeamSearch::paramRecombinationMode(
         "recombination-mode",
         &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationModeOn);
+        RecombinationModeOn);
 
 TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
@@ -202,7 +202,7 @@ TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config
           useBlank_(),
           collapseRepeatedLabels_(paramCollapseRepeatedLabels(config)),
           sentenceEndFallback_(paramSentenceEndFallBack(config)),
-          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
+          recombinationEnabled_(paramRecombinationMode(config) == RecombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           labelScorers_(),
           nonWordLemmas_(),

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -28,6 +28,15 @@
 #include <Search/Traceback.hh>
 #include <Search/TracebackHelper.hh>
 
+namespace {
+
+enum RecombinationMode {
+    recombinationOff,
+    recombinationOn,
+};
+
+}  // namespace
+
 namespace Search {
 
 /*
@@ -167,6 +176,17 @@ const Core::ParameterInt TreeTimesyncBeamSearch::paramMaximumStableDelayPruningI
         10,
         1);
 
+const Core::Choice TreeTimesyncBeamSearch::choiceRecombination(
+        "off", recombinationOff,
+        "on", recombinationOn,
+        Core::Choice::endMark());
+
+const Core::ParameterChoice TreeTimesyncBeamSearch::paramRecombination(
+        "recombination",
+        &choiceRecombination,
+        "Whether hypotheses with identical recombination state should be recombined.",
+        recombinationOn);
+
 TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
           SearchAlgorithmV2(config),
@@ -182,6 +202,7 @@ TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config
           useBlank_(),
           collapseRepeatedLabels_(paramCollapseRepeatedLabels(config)),
           sentenceEndFallback_(paramSentenceEndFallBack(config)),
+          recombinationEnabled_(paramRecombination(config) == recombinationOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           labelScorers_(),
           nonWordLemmas_(),
@@ -868,6 +889,10 @@ template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::Withi
 template void TreeTimesyncBeamSearch::scorePruning<TreeTimesyncBeamSearch::WordEndExtensionCandidate>(std::vector<TreeTimesyncBeamSearch::WordEndExtensionCandidate>&, Score, size_t);
 
 void TreeTimesyncBeamSearch::recombination(std::vector<TreeTimesyncBeamSearch::LabelHypothesis>& hypotheses, bool createTraceSiblings) {
+    if (not recombinationEnabled_) {
+        return;
+    }
+
     // Represents a unique combination of StateId, ScoringContext and LmHistory
     struct RecombinationContext {
         StateId                            state;

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -31,8 +31,8 @@
 namespace {
 
 enum RecombinationMode {
-    recombinationOff,
-    recombinationOn,
+    recombinationModeOff,
+    recombinationModeOn,
 };
 
 }  // namespace
@@ -176,16 +176,16 @@ const Core::ParameterInt TreeTimesyncBeamSearch::paramMaximumStableDelayPruningI
         10,
         1);
 
-const Core::Choice TreeTimesyncBeamSearch::choiceRecombination(
-        "off", recombinationOff,
-        "on", recombinationOn,
+const Core::Choice TreeTimesyncBeamSearch::choiceRecombinationMode(
+        "off", recombinationModeOff,
+        "on", recombinationModeOn,
         Core::Choice::endMark());
 
-const Core::ParameterChoice TreeTimesyncBeamSearch::paramRecombination(
-        "recombination",
-        &choiceRecombination,
+const Core::ParameterChoice TreeTimesyncBeamSearch::paramRecombinationMode(
+        "recombination-mode",
+        &choiceRecombinationMode,
         "Whether hypotheses with identical recombination state should be recombined.",
-        recombinationOn);
+        recombinationModeOn);
 
 TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),
@@ -202,7 +202,7 @@ TreeTimesyncBeamSearch::TreeTimesyncBeamSearch(Core::Configuration const& config
           useBlank_(),
           collapseRepeatedLabels_(paramCollapseRepeatedLabels(config)),
           sentenceEndFallback_(paramSentenceEndFallBack(config)),
-          recombinationEnabled_(paramRecombination(config) == recombinationOn),
+          recombinationEnabled_(paramRecombinationMode(config) == recombinationModeOn),
           logStepwiseStatistics_(paramLogStepwiseStatistics(config)),
           labelScorers_(),
           nonWordLemmas_(),

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -56,6 +56,8 @@ public:
     static const Core::ParameterBool        paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
+    static const Core::Choice               choiceRecombination;
+    static const Core::ParameterChoice      paramRecombination;
 
     TreeTimesyncBeamSearch(Core::Configuration const&);
 
@@ -151,6 +153,7 @@ private:
     bool useBlank_;
     bool collapseRepeatedLabels_;
     bool sentenceEndFallback_;
+    bool recombinationEnabled_;
     bool logStepwiseStatistics_;
 
     std::vector<Core::Ref<Nn::LabelScorer>>        labelScorers_;

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -56,8 +56,8 @@ public:
     static const Core::ParameterBool        paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
-    static const Core::Choice               choiceRecombination;
-    static const Core::ParameterChoice      paramRecombination;
+    static const Core::Choice               choiceRecombinationMode;
+    static const Core::ParameterChoice      paramRecombinationMode;
 
     TreeTimesyncBeamSearch(Core::Configuration const&);
 


### PR DESCRIPTION
In some cases, when the ScoringContext of LabelScorers depends on the full label (or alignment) history, no two distinct hypotheses can ever be recombined, which makes the recombination step essentially an expensive no-op. This is especially important when no score-based pruning is done and all possible extensions enter the recombination step.

This PR adds the option to disable the recombination step. It is introduced as an enum instead of a boolean parameter since in the future we might want to introduce an additional auto-detection-mode where it's inferred based on the LabelScorers and the possible transition types whether recombination should be performed or not.

In a speech LLM example recognition without score-pruning, this reduced the search time from 40.49s to 23.22 (RTF 1.02 to 0.58). With score-pruning enabled, the difference is negligible since only a few hypotheses enter recombination.