### PR TITLE
Move specific ScoringContext classes to corresponding LabelScorers

### DIFF
--- a/src/Nn/LabelScorer/CombineLabelScorer.cc
+++ b/src/Nn/LabelScorer/CombineLabelScorer.cc
@@ -22,6 +22,44 @@ namespace {
 using namespace Nn;
 
 /*
+ * Combines multiple scoring contexts at once
+ */
+struct CombineScoringContext : public ScoringContext {
+    std::vector<ScoringContextRef> scoringContexts;
+
+    CombineScoringContext()
+            : scoringContexts() {}
+
+    CombineScoringContext(std::vector<ScoringContextRef>&& scoringContexts)
+            : scoringContexts(scoringContexts) {}
+
+    bool isEqual(ScoringContextRef const& other) const {
+        auto* otherPtr = dynamic_cast<CombineScoringContext const*>(other.get());
+
+        if (otherPtr == nullptr) {
+            return false;
+        }
+
+        return std::equal(
+                scoringContexts.begin(),
+                scoringContexts.end(),
+                otherPtr->scoringContexts.begin(),
+                otherPtr->scoringContexts.end(),
+                [](auto const& sc1, auto const& sc2) {
+                    return sc1->isEqual(sc2);
+                });
+    }
+
+    size_t hash() const {
+        size_t value = 0ul;
+        for (auto const& scoringContext : scoringContexts) {
+            value = Core::combineHashes(value, scoringContext->hash());
+        }
+        return value;
+    }
+};
+
+/*
  * Score accessor that contains a list of sub-accessors and adds up the scores they return
  */
 class CombinedScoreAccessor : public ScoreAccessor {

--- a/src/Nn/LabelScorer/CtcPrefixLabelScorer.cc
+++ b/src/Nn/LabelScorer/CtcPrefixLabelScorer.cc
@@ -18,10 +18,11 @@
 #include <Nn/Module.hh>
 #include <cmath>
 #include <limits>
-
-namespace Nn {
+#include "ScoringContext.hh"
 
 namespace {
+
+using namespace Nn;
 
 // Compute score difference while accounting for inf values
 Score scoreDelta(Score extScore, Score prefixScore) {
@@ -82,6 +83,37 @@ Score extendedPrefixScore(
 }
 
 }  // namespace
+
+namespace Nn {
+
+/*
+ * ==============================
+ * == CtcPrefixScoringContext ===
+ * ==============================
+ */
+
+Score CtcPrefixScoringContext::PrefixScore::totalScore() const {
+    return Math::scoreSum(blankEndingScore, nonBlankEndingScore);
+}
+
+CtcPrefixScoringContext::CtcPrefixScoringContext()
+        : labelSeq(), parent(), timePrefixScores(), prefixScore(), extScores(), requiresFinalize(true) {}
+
+CtcPrefixScoringContext::CtcPrefixScoringContext(std::vector<LabelIndex>&& seq, ScoringContextRef const& parent)
+        : labelSeq(std::move(seq)), parent(parent), timePrefixScores(), prefixScore(), extScores(), requiresFinalize(true) {}
+
+bool CtcPrefixScoringContext::isEqual(ScoringContextRef const& other) const {
+    auto* otherPtr = dynamic_cast<const CtcPrefixScoringContext*>(other.get());
+    if (otherPtr == nullptr) {
+        return false;
+    }
+
+    return labelSeqEqual(labelSeq, otherPtr->labelSeq);
+}
+
+size_t CtcPrefixScoringContext::hash() const {
+    return labelSeqHash(labelSeq);
+}
 
 /*
  * =============================

--- a/src/Nn/LabelScorer/CtcPrefixLabelScorer.hh
+++ b/src/Nn/LabelScorer/CtcPrefixLabelScorer.hh
@@ -20,6 +20,36 @@
 
 namespace Nn {
 
+/*
+ * Scoring context for computation of CTC prefix scores.
+ * Contains the label sequence, a parent pointer for lazy computation of the prefix score,
+ * time-wise prefix scores and a cache for the score of extended prefixes.
+ * Hash and equality operators are based on the label sequence.
+ */
+struct CtcPrefixScoringContext : public ScoringContext {
+    struct PrefixScore {
+        Score blankEndingScore    = std::numeric_limits<Score>::infinity();
+        Score nonBlankEndingScore = std::numeric_limits<Score>::infinity();
+
+        Score totalScore() const;
+    };
+
+    std::vector<LabelIndex>                           labelSeq;
+    ScoringContextRef                                 parent;            // Parent prefix without the last label, used to finalize lazily
+    mutable std::shared_ptr<std::vector<PrefixScore>> timePrefixScores;  // Represents neg-log-probabilities of emitting `labelSeq` ending in blank or nonblank after each real CTC frame t = 0, ..., T - 1
+    mutable std::optional<Score>                      prefixScore;       // Cached score of the prefix -log P(prefix), computed on demand from the parent; needed to compute score-delta for next token
+    mutable std::unordered_map<LabelIndex, Score>     extScores;         // Cache for -log P(prefix + token, ...) to avoid repeated computation
+    mutable bool                                      requiresFinalize;  // Check whether the mutable members have been set
+
+    CtcPrefixScoringContext();
+    CtcPrefixScoringContext(std::vector<LabelIndex>&& seq, ScoringContextRef const& parent);
+
+    bool   isEqual(ScoringContextRef const& other) const override;
+    size_t hash() const override;
+};
+
+typedef Core::Ref<const CtcPrefixScoringContext> CtcPrefixScoringContextRef;
+
 class CtcPrefixScoreAccessor : public ScoreAccessor {
 public:
     CtcPrefixScoreAccessor(CtcPrefixScoringContextRef const& scoringContext, std::shared_ptr<Math::FastMatrix<Score>> const& ctcScores);

--- a/src/Nn/LabelScorer/FixedContextOnnxLabelScorer.cc
+++ b/src/Nn/LabelScorer/FixedContextOnnxLabelScorer.cc
@@ -18,6 +18,34 @@
 
 namespace Nn {
 
+SeqStepScoringContext::SeqStepScoringContext()
+        : labelSeq(), currentStep(0ul) {}
+
+SeqStepScoringContext::SeqStepScoringContext(std::vector<LabelIndex> const& seq, Speech::TimeframeIndex step)
+        : labelSeq(seq), currentStep(step) {}
+
+SeqStepScoringContext::SeqStepScoringContext(std::vector<LabelIndex>&& seq, Speech::TimeframeIndex step)
+        : labelSeq(std::move(seq)), currentStep(step) {}
+
+bool SeqStepScoringContext::isEqual(ScoringContextRef const& other) const {
+    auto* otherPtr = dynamic_cast<SeqStepScoringContext const*>(other.get());
+    if (otherPtr == nullptr) {
+        return false;
+    }
+
+    if (currentStep != otherPtr->currentStep) {
+        return false;
+    }
+
+    return labelSeqEqual(labelSeq, otherPtr->labelSeq);
+}
+
+size_t SeqStepScoringContext::hash() const {
+    return Core::combineHashes(currentStep, labelSeqHash(labelSeq));
+}
+
+typedef Core::Ref<SeqStepScoringContext const> SeqStepScoringContextRef;
+
 const Core::ParameterInt FixedContextOnnxLabelScorer::paramStartLabelIndex(
         "start-label-index",
         "Initial history in the first step is filled with this label index.",

--- a/src/Nn/LabelScorer/FixedContextOnnxLabelScorer.hh
+++ b/src/Nn/LabelScorer/FixedContextOnnxLabelScorer.hh
@@ -23,6 +23,23 @@
 namespace Nn {
 
 /*
+ * Scoring context that describes a sequence of previously observed labels as well as the current decoding step
+ */
+struct SeqStepScoringContext : public ScoringContext {
+    std::vector<LabelIndex> labelSeq;
+    Speech::TimeframeIndex  currentStep;
+
+    SeqStepScoringContext();
+    SeqStepScoringContext(std::vector<LabelIndex> const& seq, Speech::TimeframeIndex step);
+    SeqStepScoringContext(std::vector<LabelIndex>&& seq, Speech::TimeframeIndex step);
+
+    bool   isEqual(ScoringContextRef const& other) const override;
+    size_t hash() const override;
+};
+
+typedef Core::Ref<SeqStepScoringContext const> SeqStepScoringContextRef;
+
+/*
  * Label Scorer that performs scoring by forwarding the input feature at the current timestep together
  * with a fixed-size sequence of history tokens through an ONNX model.
  * A common use case would be a neural transducer model with a fixed-size history.

--- a/src/Nn/LabelScorer/ScoringContext.cc
+++ b/src/Nn/LabelScorer/ScoringContext.cc
@@ -20,6 +20,14 @@ namespace Nn {
 
 typedef Mm::EmissionIndex LabelIndex;
 
+size_t labelSeqHash(std::vector<LabelIndex> const& labelSeq) {
+    return Core::MurmurHash3_x64_64(reinterpret_cast<void const*>(labelSeq.data()), labelSeq.size() * sizeof(LabelIndex), 0x78b174eb);
+}
+
+bool labelSeqEqual(std::vector<LabelIndex> const& lhs, std::vector<LabelIndex> const& rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
 /*
  * =============================
  * ====== ScoringContext =======
@@ -35,35 +43,6 @@ bool ScoringContext::isEqual(ScoringContextRef const& other) const {
 
 /*
  * =============================
- * === CombineScoringContext ===
- * =============================
- */
-size_t CombineScoringContext::hash() const {
-    size_t value = 0ul;
-    for (auto const& scoringContext : scoringContexts) {
-        value = Core::combineHashes(value, scoringContext->hash());
-    }
-    return value;
-}
-
-bool CombineScoringContext::isEqual(ScoringContextRef const& other) const {
-    auto* otherPtr = dynamic_cast<CombineScoringContext const*>(other.get());
-
-    if (otherPtr == nullptr or scoringContexts.size() != otherPtr->scoringContexts.size()) {
-        return false;
-    }
-
-    for (auto it_l = scoringContexts.begin(), it_r = otherPtr->scoringContexts.begin(); it_l != scoringContexts.end(); ++it_l, ++it_r) {
-        if (!(*it_l)->isEqual(*it_r)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/*
- * =============================
  * ==== StepScoringContext =====
  * =============================
  */
@@ -74,135 +53,6 @@ size_t StepScoringContext::hash() const {
 bool StepScoringContext::isEqual(ScoringContextRef const& other) const {
     StepScoringContext const* o = dynamic_cast<StepScoringContext const*>(other.get());
     return o != nullptr and currentStep == o->currentStep;
-}
-
-/*
- * =============================
- * === SeqStepScoringContext ===
- * =============================
- */
-size_t SeqStepScoringContext::hash() const {
-    return Core::combineHashes(currentStep, Core::MurmurHash3_x64_64(reinterpret_cast<void const*>(labelSeq.data()), labelSeq.size() * sizeof(LabelIndex), 0x78b174eb));
-}
-
-bool SeqStepScoringContext::isEqual(ScoringContextRef const& other) const {
-    auto* otherPtr = dynamic_cast<SeqStepScoringContext const*>(other.get());
-    if (otherPtr == nullptr) {
-        return false;
-    }
-
-    if (currentStep != otherPtr->currentStep) {
-        return false;
-    }
-
-    if (labelSeq.size() != otherPtr->labelSeq.size()) {
-        return false;
-    }
-
-    for (auto it_l = labelSeq.begin(), it_r = otherPtr->labelSeq.begin(); it_l != labelSeq.end(); ++it_l, ++it_r) {
-        if (*it_l != *it_r) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/*
- * =================================
- * = OnnxHiddenStateScoringContext =
- * =================================
- */
-size_t OnnxHiddenStateScoringContext::hash() const {
-    return Core::MurmurHash3_x64_64(reinterpret_cast<void const*>(labelSeq.data()), labelSeq.size() * sizeof(LabelIndex), 0x78b174eb);
-}
-
-bool OnnxHiddenStateScoringContext::isEqual(ScoringContextRef const& other) const {
-    auto* otherPtr = dynamic_cast<OnnxHiddenStateScoringContext const*>(other.get());
-    if (otherPtr == nullptr) {
-        return false;
-    }
-
-    if (labelSeq.size() != otherPtr->labelSeq.size()) {
-        return false;
-    }
-
-    for (auto it_l = labelSeq.begin(), it_r = otherPtr->labelSeq.begin(); it_l != labelSeq.end(); ++it_l, ++it_r) {
-        if (*it_l != *it_r) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/*
- * =============================
- * == CtcPrefixScoringContext ==
- * =============================
- */
-
-size_t CtcPrefixScoringContext::hash() const {
-    return Core::MurmurHash3_x64_64(reinterpret_cast<void const*>(labelSeq.data()), labelSeq.size() * sizeof(LabelIndex), 0x78b174eb);
-}
-
-bool CtcPrefixScoringContext::isEqual(ScoringContextRef const& other) const {
-    auto* otherPtr = dynamic_cast<const CtcPrefixScoringContext*>(other.get());
-    if (otherPtr == nullptr) {
-        return false;
-    }
-
-    if (labelSeq.size() != otherPtr->labelSeq.size()) {
-        return false;
-    }
-
-    for (auto it_l = labelSeq.begin(), it_r = otherPtr->labelSeq.begin(); it_l != labelSeq.end(); ++it_l, ++it_r) {
-        if (*it_l != *it_r) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/*
- * ====================================
- * = StateManagedOnnxScoringContext ===
- * ====================================
- */
-StateManagedOnnxScoringContext::StateManagedOnnxScoringContext(HistoryState&& initialState)
-        : labelSeq(),
-          parent(),
-          state(std::make_shared<HistoryState>(std::move(initialState))) {
-}
-
-StateManagedOnnxScoringContext::StateManagedOnnxScoringContext(std::vector<LabelIndex>&&                       labelSeq,
-                                                               Core::Ref<StateManagedOnnxScoringContext const> parent)
-        : labelSeq(std::move(labelSeq)),
-          parent(parent),
-          state() {
-}
-
-size_t StateManagedOnnxScoringContext::hash() const {
-    return Core::MurmurHash3_x64_64(reinterpret_cast<void const*>(labelSeq.data()), labelSeq.size() * sizeof(LabelIndex), 0x78b174eb);
-}
-
-bool StateManagedOnnxScoringContext::isEqual(ScoringContextRef const& other) const {
-    auto* otherPtr = dynamic_cast<StateManagedOnnxScoringContext const*>(other.get());
-
-    if (otherPtr == nullptr) {
-        return false;
-    }
-
-    if (labelSeq.size() != otherPtr->labelSeq.size()) {
-        return false;
-    }
-
-    for (auto it_l = labelSeq.begin(), it_r = otherPtr->labelSeq.begin(); it_l != labelSeq.end(); ++it_l, ++it_r) {
-        if (*it_l != *it_r) {
-            return false;
-        }
-    }
-    return true;
 }
 
 }  // namespace Nn

--- a/src/Nn/LabelScorer/ScoringContext.hh
+++ b/src/Nn/LabelScorer/ScoringContext.hh
@@ -16,17 +16,16 @@
 #ifndef SCORING_CONTEXT_HH
 #define SCORING_CONTEXT_HH
 
-#include <optional>
-
 #include <Core/ReferenceCounting.hh>
 #include <Mm/Types.hh>
 #include <Nn/AbstractStateManager.hh>
-#include <Onnx/OnnxStateVariable.hh>
-#include <Onnx/Value.hh>
 
 #include "Types.hh"
 
 namespace Nn {
+
+size_t labelSeqHash(std::vector<LabelIndex> const& labelSeq);
+bool   labelSeqEqual(std::vector<LabelIndex> const& lhs, std::vector<LabelIndex> const& rhs);
 
 /*
  * Empty scoring context base class
@@ -53,24 +52,6 @@ struct ScoringContextEq {
 };
 
 /*
- * Combines multiple scoring contexts at once
- */
-struct CombineScoringContext : public ScoringContext {
-    std::vector<ScoringContextRef> scoringContexts;
-
-    CombineScoringContext()
-            : scoringContexts() {}
-
-    CombineScoringContext(std::vector<ScoringContextRef>&& scoringContexts)
-            : scoringContexts(scoringContexts) {}
-
-    bool   isEqual(ScoringContextRef const& other) const;
-    size_t hash() const;
-};
-
-typedef Core::Ref<CombineScoringContext const> CombineScoringContextRef;
-
-/*
  * Scoring context that only describes the current decoding step
  */
 struct StepScoringContext : public ScoringContext {
@@ -87,126 +68,6 @@ struct StepScoringContext : public ScoringContext {
 };
 
 typedef Core::Ref<StepScoringContext const> StepScoringContextRef;
-
-/*
- * Scoring context that describes a sequence of previously observed labels as well as the current decoding step
- */
-struct SeqStepScoringContext : public ScoringContext {
-    std::vector<LabelIndex> labelSeq;
-    Speech::TimeframeIndex  currentStep;
-
-    SeqStepScoringContext()
-            : labelSeq(), currentStep(0ul) {}
-    SeqStepScoringContext(std::vector<LabelIndex> const& seq, Speech::TimeframeIndex step)
-            : labelSeq(seq), currentStep(step) {}
-    SeqStepScoringContext(std::vector<LabelIndex>&& seq, Speech::TimeframeIndex step)
-            : labelSeq(std::move(seq)), currentStep(step) {}
-
-    bool   isEqual(ScoringContextRef const& other) const;
-    size_t hash() const;
-};
-
-typedef Core::Ref<SeqStepScoringContext const> SeqStepScoringContextRef;
-
-/*
- * Hidden state represented by a dictionary of named ONNX values
- */
-struct OnnxHiddenState : public Core::ReferenceCounted {
-    std::unordered_map<std::string, Onnx::Value> stateValueMap;
-
-    OnnxHiddenState()
-            : stateValueMap() {}
-
-    OnnxHiddenState(std::vector<std::string>&& names, std::vector<Onnx::Value>&& values) {
-        verify(names.size() == values.size());
-        stateValueMap.reserve(names.size());
-        for (size_t i = 0ul; i < names.size(); ++i) {
-            stateValueMap.emplace(std::move(names[i]), std::move(values[i]));
-        }
-    }
-};
-
-typedef Core::Ref<OnnxHiddenState const> OnnxHiddenStateRef;
-
-/*
- * Scoring context consisting of a hidden state.
- * Assumes that two hidden states are equal if and only if they were created
- * from the same label history.
- */
-struct OnnxHiddenStateScoringContext : public ScoringContext {
-    std::vector<LabelIndex>    labelSeq;  // Used for hashing
-    mutable OnnxHiddenStateRef hiddenState;
-    mutable bool               requiresFinalize;
-
-    OnnxHiddenStateScoringContext()
-            : labelSeq(), hiddenState(), requiresFinalize(false) {}
-
-    OnnxHiddenStateScoringContext(std::vector<LabelIndex> const& labelSeq, OnnxHiddenStateRef state, bool requiresFinalize)
-            : labelSeq(labelSeq), hiddenState(state), requiresFinalize(requiresFinalize) {}
-
-    bool   isEqual(ScoringContextRef const& other) const;
-    size_t hash() const;
-};
-
-typedef Core::Ref<OnnxHiddenStateScoringContext const> OnnxHiddenStateScoringContextRef;
-
-/*
- * Scoring context for computation of CTC prefix scores.
- * Contains the label sequence, a parent pointer for lazy computation of the prefix score,
- * time-wise prefix scores and a cache for the score of extended prefixes.
- * Hash and equality operators are based on the label sequence.
- */
-struct CtcPrefixScoringContext : public ScoringContext {
-    struct PrefixScore {
-        Score blankEndingScore    = std::numeric_limits<Score>::infinity();
-        Score nonBlankEndingScore = std::numeric_limits<Score>::infinity();
-
-        Score totalScore() const {
-            return Math::scoreSum(blankEndingScore, nonBlankEndingScore);
-        }
-    };
-
-    std::vector<LabelIndex>                           labelSeq;
-    ScoringContextRef                                 parent;            // Parent prefix without the last label, used to finalize lazily
-    mutable std::shared_ptr<std::vector<PrefixScore>> timePrefixScores;  // Represents neg-log-probabilities of emitting `labelSeq` ending in blank or nonblank after each real CTC frame t = 0, ..., T - 1
-    mutable std::optional<Score>                      prefixScore;       // Cached score of the prefix -log P(prefix), computed on demand from the parent; needed to compute score-delta for next token
-    mutable std::unordered_map<LabelIndex, Score>     extScores;         // Cache for -log P(prefix + token, ...) to avoid repeated computation
-    mutable bool                                      requiresFinalize;  // Check whether the mutable members have been set
-
-    CtcPrefixScoringContext()
-            : labelSeq(), parent(), timePrefixScores(), prefixScore(), extScores(), requiresFinalize(true) {}
-
-    CtcPrefixScoringContext(std::vector<LabelIndex>&& seq, ScoringContextRef const& parent)
-            : labelSeq(std::move(seq)), parent(parent), timePrefixScores(), prefixScore(), extScores(), requiresFinalize(true) {}
-
-    bool   isEqual(ScoringContextRef const& other) const;
-    size_t hash() const;
-};
-
-typedef Core::Ref<const CtcPrefixScoringContext> CtcPrefixScoringContextRef;
-
-/*
- * Scoring context for ONNX models with state managed by a StateManager.
- * The state stores only the slice produced for the most recent token.
- */
-struct StateManagedOnnxScoringContext : public ScoringContext {
-    using StateManager = AbstractStateManager<Onnx::Value, Onnx::OnnxStateVariable>;
-    using HistoryState = StateManager::HistoryState;
-
-    std::vector<LabelIndex>                                 labelSeq;
-    mutable Core::Ref<StateManagedOnnxScoringContext const> parent;
-
-    mutable std::shared_ptr<HistoryState> state;
-
-    StateManagedOnnxScoringContext(HistoryState&& initialState);
-    StateManagedOnnxScoringContext(std::vector<LabelIndex>&&                       labelSeq,
-                                   Core::Ref<StateManagedOnnxScoringContext const> parent);
-
-    bool   isEqual(ScoringContextRef const& other) const override;
-    size_t hash() const override;
-};
-
-typedef Core::Ref<StateManagedOnnxScoringContext const> StateManagedOnnxScoringContextRef;
 
 }  // namespace Nn
 

--- a/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.cc
+++ b/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.cc
@@ -19,7 +19,38 @@
 
 #include "ScoreAccessor.hh"
 
+/*
+ * Scoring context for ONNX models with state managed by a StateManager.
+ * The state stores only the slice produced for the most recent token.
+ */
 namespace Nn {
+
+StateManagedOnnxScoringContext::StateManagedOnnxScoringContext(HistoryState&& initialState)
+        : labelSeq(),
+          parent(),
+          state(std::make_shared<HistoryState>(std::move(initialState))) {
+}
+
+StateManagedOnnxScoringContext::StateManagedOnnxScoringContext(std::vector<LabelIndex>&&                       labelSeq,
+                                                               Core::Ref<StateManagedOnnxScoringContext const> parent)
+        : labelSeq(std::move(labelSeq)),
+          parent(parent),
+          state() {
+}
+
+bool StateManagedOnnxScoringContext::isEqual(ScoringContextRef const& other) const {
+    auto* otherPtr = dynamic_cast<StateManagedOnnxScoringContext const*>(other.get());
+
+    if (otherPtr == nullptr) {
+        return false;
+    }
+
+    return labelSeqEqual(labelSeq, otherPtr->labelSeq);
+}
+
+size_t StateManagedOnnxScoringContext::hash() const {
+    return labelSeqHash(labelSeq);
+}
 
 static const std::vector<Onnx::IOSpecification> ioSpec = {
         Onnx::IOSpecification{

--- a/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.hh
+++ b/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.hh
@@ -25,6 +25,29 @@
 namespace Nn {
 
 /*
+ * Scoring context for ONNX models with state managed by a StateManager.
+ * The state stores only the slice produced for the most recent token.
+ */
+struct StateManagedOnnxScoringContext : public ScoringContext {
+    using StateManager = AbstractStateManager<Onnx::Value, Onnx::OnnxStateVariable>;
+    using HistoryState = StateManager::HistoryState;
+
+    std::vector<LabelIndex>                                 labelSeq;
+    mutable Core::Ref<StateManagedOnnxScoringContext const> parent;
+
+    mutable std::shared_ptr<HistoryState> state;
+
+    StateManagedOnnxScoringContext(HistoryState&& initialState);
+    StateManagedOnnxScoringContext(std::vector<LabelIndex>&&                       labelSeq,
+                                   Core::Ref<StateManagedOnnxScoringContext const> parent);
+
+    bool   isEqual(ScoringContextRef const& other) const override;
+    size_t hash() const override;
+};
+
+typedef Core::Ref<StateManagedOnnxScoringContext const> StateManagedOnnxScoringContextRef;
+
+/*
  * LabelScorer for ONNX models whose hidden-state management is done by a RASR StateManager.
  * Each scoring context stores only the state slice produced
  * for its most recent token plus a parent pointer, which allows transformer KV caches to

--- a/src/Nn/LabelScorer/StatefulOnnxLabelScorer.cc
+++ b/src/Nn/LabelScorer/StatefulOnnxLabelScorer.cc
@@ -24,12 +24,46 @@
 #include <Flow/Timestamp.hh>
 #include <Math/FastMatrix.hh>
 #include <Mm/Module.hh>
+#include <Onnx/OnnxStateVariable.hh>
+#include <Onnx/Value.hh>
 #include <Speech/Types.hh>
 
 #include "ScoreAccessor.hh"
 #include "ScoringContext.hh"
 
 namespace Nn {
+
+OnnxHiddenState::OnnxHiddenState()
+        : stateValueMap() {}
+
+OnnxHiddenState::OnnxHiddenState(std::vector<std::string>&& names, std::vector<Onnx::Value>&& values) {
+    verify(names.size() == values.size());
+    stateValueMap.reserve(names.size());
+    for (size_t i = 0ul; i < names.size(); ++i) {
+        stateValueMap.emplace(std::move(names[i]), std::move(values[i]));
+    }
+}
+
+OnnxHiddenStateScoringContext::OnnxHiddenStateScoringContext()
+        : labelSeq(), hiddenState(), requiresFinalize(false) {}
+
+OnnxHiddenStateScoringContext::OnnxHiddenStateScoringContext(std::vector<LabelIndex> const& labelSeq, OnnxHiddenStateRef state, bool requiresFinalize)
+        : labelSeq(labelSeq), hiddenState(state), requiresFinalize(requiresFinalize) {}
+
+bool OnnxHiddenStateScoringContext::isEqual(ScoringContextRef const& other) const {
+    auto* otherPtr = dynamic_cast<OnnxHiddenStateScoringContext const*>(other.get());
+    if (otherPtr == nullptr) {
+        return false;
+    }
+
+    return labelSeqEqual(labelSeq, otherPtr->labelSeq);
+}
+
+size_t OnnxHiddenStateScoringContext::hash() const {
+    return labelSeqHash(labelSeq);
+}
+
+typedef Core::Ref<OnnxHiddenStateScoringContext const> OnnxHiddenStateScoringContextRef;
 
 /*
  * =============================

--- a/src/Nn/LabelScorer/StatefulOnnxLabelScorer.hh
+++ b/src/Nn/LabelScorer/StatefulOnnxLabelScorer.hh
@@ -34,6 +34,37 @@
 namespace Nn {
 
 /*
+ * Hidden state represented by a dictionary of named ONNX values
+ */
+struct OnnxHiddenState : public Core::ReferenceCounted {
+    std::unordered_map<std::string, Onnx::Value> stateValueMap;
+
+    OnnxHiddenState();
+    OnnxHiddenState(std::vector<std::string>&& names, std::vector<Onnx::Value>&& values);
+};
+
+typedef Core::Ref<OnnxHiddenState const> OnnxHiddenStateRef;
+
+/*
+ * Scoring context consisting of a hidden state.
+ * Assumes that two hidden states are equal if and only if they were created
+ * from the same label history.
+ */
+struct OnnxHiddenStateScoringContext : public ScoringContext {
+    std::vector<LabelIndex>    labelSeq;  // Used for hashing
+    mutable OnnxHiddenStateRef hiddenState;
+    mutable bool               requiresFinalize;
+
+    OnnxHiddenStateScoringContext();
+    OnnxHiddenStateScoringContext(std::vector<LabelIndex> const& labelSeq, OnnxHiddenStateRef state, bool requiresFinalize);
+
+    bool   isEqual(ScoringContextRef const& other) const override;
+    size_t hash() const override;
+};
+
+typedef Core::Ref<OnnxHiddenStateScoringContext const> OnnxHiddenStateScoringContextRef;
+
+/*
  * Label Scorer that performs scoring by forwarding hidden states through an ONNX model.
  * This Label Scorer requires three ONNX models:
  *  - A State Initializer which produces the hidden states for the first step (optionally based on the input sequence)

--- a/src/Nn/LabelScorer/TransitionLabelScorer.cc
+++ b/src/Nn/LabelScorer/TransitionLabelScorer.cc
@@ -17,12 +17,6 @@
 
 #include <Nn/Module.hh>
 
-namespace {
-
-using namespace Nn;
-
-}  // namespace
-
 namespace Nn {
 
 /*


### PR DESCRIPTION
Many ScoringContext classes are only used by a single LabelScorer. This PR moves these from `ScoringContexts.[hh|cc]` next to the corresponding LabelScorer classes that use them. In addition, since many ScoringContexts have hashes and equality operators based on label sequences, helper functions `labelSeqHash` and `labelSeqEqual` are introduced in order to avoid repeated logic.