### PR TITLE
Bugfix: Make cache-cleanup-interval a ParameterInt

### DIFF
--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -140,10 +140,11 @@ const Core::ParameterBool LexiconfreeLabelsyncBeamSearch::paramLogStepwiseStatis
         "Log statistics about the beam at every search step.",
         false);
 
-const Core::ParameterBool LexiconfreeLabelsyncBeamSearch::paramCacheCleanupInterval(
+const Core::ParameterInt LexiconfreeLabelsyncBeamSearch::paramCacheCleanupInterval(
         "cache-cleanup-interval",
         "Interval of search steps after which buffered inputs that are not needed anymore get cleaned up.",
-        10);
+        10,
+        1);
 
 LexiconfreeLabelsyncBeamSearch::LexiconfreeLabelsyncBeamSearch(Core::Configuration const& config)
         : Core::Component(config),

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.hh
@@ -46,7 +46,7 @@ public:
     static const Core::ParameterInt   paramNumHistogramBins;
 
     static const Core::ParameterInt   paramSentenceEndLabelIndex;
-    static const Core::ParameterBool  paramCacheCleanupInterval;
+    static const Core::ParameterInt   paramCacheCleanupInterval;
     static const Core::ParameterFloat paramLengthNormScale;
     static const Core::ParameterFloat paramMaxLabelsPerTimestep;
     static const Core::ParameterBool  paramLogStepwiseStatistics;

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -130,10 +130,11 @@ const Core::ParameterBool LexiconfreeTimesyncBeamSearch::paramLogStepwiseStatist
         "Log statistics about the beam at every search step.",
         false);
 
-const Core::ParameterBool LexiconfreeTimesyncBeamSearch::paramCacheCleanupInterval(
+const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramCacheCleanupInterval(
         "cache-cleanup-interval",
         "Interval of search steps after which buffered inputs that are not needed anymore get cleaned up.",
-        10);
+        10,
+        1);
 
 const Core::ParameterInt LexiconfreeTimesyncBeamSearch::paramMaximumStableDelay(
         "maximum-stable-delay",

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.hh
@@ -48,7 +48,7 @@ public:
     static const Core::ParameterInt         paramBlankLabelIndex;
     static const Core::ParameterInt         paramSentenceEndLabelIndex;
     static const Core::ParameterBool        paramCollapseRepeatedLabels;
-    static const Core::ParameterBool        paramCacheCleanupInterval;
+    static const Core::ParameterInt         paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
     static const Core::ParameterBool        paramLogStepwiseStatistics;

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -149,10 +149,11 @@ const Core::ParameterBool TreeTimesyncBeamSearch::paramLogStepwiseStatistics(
         "Log statistics about the beam at every search step.",
         false);
 
-const Core::ParameterBool TreeTimesyncBeamSearch::paramCacheCleanupInterval(
+const Core::ParameterInt TreeTimesyncBeamSearch::paramCacheCleanupInterval(
         "cache-cleanup-interval",
         "Interval of search steps after which buffered inputs that are not needed anymore get cleaned up.",
-        10);
+        10,
+        1);
 
 const Core::ParameterInt TreeTimesyncBeamSearch::paramMaximumStableDelay(
         "maximum-stable-delay",

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -53,7 +53,7 @@ public:
     static const Core::ParameterBool        paramCollapseRepeatedLabels;
     static const Core::ParameterBool        paramSentenceEndFallBack;
     static const Core::ParameterBool        paramLogStepwiseStatistics;
-    static const Core::ParameterBool        paramCacheCleanupInterval;
+    static const Core::ParameterInt         paramCacheCleanupInterval;
     static const Core::ParameterInt         paramMaximumStableDelay;
     static const Core::ParameterInt         paramMaximumStableDelayPruningInterval;
 


### PR DESCRIPTION
I just accidentally found a small bug.
In the new search algorithms, `cache-cleanup-interval` (so `paramCacheCleanupInterval`) was a `ParameterBool` instead of a `ParameterInt`.
I assume that this resulted in `cacheCleanupInterval_` always being 1 because whatever (positive) value was assigned to this config parameter, it was casted to bool true and this was again casted to int 1.