### PR TITLE
Bugfix: LabelScorer cache cleanup on correct beam in LexiconfreeTimesyncBeamSearch

### DIFF
--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -532,7 +532,7 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
     if (currentSearchStep_ % cacheCleanupInterval_ == 0) {
         for (size_t scorerIdx = 0ul; scorerIdx < labelScorers_.size(); ++scorerIdx) {
             Core::CollapsedVector<Nn::ScoringContextRef> activeContexts;
-            for (auto const& hyp : newBeam_) {
+            for (auto const& hyp : beam_) {
                 activeContexts.push_back(hyp.scoringContexts[scorerIdx]);
             }
             labelScorers_[scorerIdx]->cleanupCaches(activeContexts);


### PR DESCRIPTION
Another small bug: The LabelScorer's cache cleanup in the LexiconfreeTimesyncBeamSearch was done using `newBeam_` instead of `beam_`, even though they are swapped right before, so it basically used the old beam.