### PR TITLE
Make Core::Configuration resource resolution thread-safe

### DIFF
--- a/src/Core/Configuration.cc
+++ b/src/Core/Configuration.cc
@@ -64,7 +64,8 @@ s32 Configuration::Resource::match(const std::vector<std::string>& components) c
 }
 
 void Configuration::Resource::writeUsage(XmlWriter& os) const {
-    for (std::vector<Usage>::const_iterator u = usage.begin(); u != usage.end(); ++u) {
+    auto sync_usage = usage.synchronize();
+    for (std::vector<Usage>::const_iterator u = sync_usage->begin(); u != sync_usage->end(); ++u) {
         os << "! used as: " << u->fullParameterName
            << " = " << u->effectiveValue;
         if (u->parameter) {
@@ -659,27 +660,31 @@ const Configuration::Resource* Configuration::find(
     return res;
 }
 
-std::string Configuration::getResolvedValue(const Resource* res) const {
+std::string Configuration::getResolvedValue(const Resource* res, std::unordered_set<Resource const*>& resolvingValues) const {
     std::string result;
 
-    if (res->isBeingResolved()) {
+    if (resolvingValues.find(res) != resolvingValues.end()) {
         std::cerr << "configuration error: "
                   << "circular references encountered in resource \""
                   << res->getName() << "\"" << std::endl;
         result = "(" + res->getName() + ")";
     }
     else {
-        res->beginResolution();  // protect against infinite recursion
-        result = resolve(res->getValue());
-        res->endResolution();
+        resolvingValues.insert(res);
+        result = resolve(res->getValue(), resolvingValues);
     }
 
     return result;
 }
 
 std::string Configuration::resolve(const std::string& value) const {
+    std::unordered_set<Resource const*> resolvingValues;
+    return resolve(value, resolvingValues);
+}
+
+std::string Configuration::resolve(const std::string& value, std::unordered_set<Resource const*>& resolvingValues) const {
     std::string result;
-    result = resolveReferences(value);
+    result = resolveReferences(value, resolvingValues);
     result = resolveArithmeticExpressions(result);
 #ifdef MODULE_CORE_CACHE_MANAGER
     result = resolveCacheManagerCommands(result);
@@ -687,7 +692,7 @@ std::string Configuration::resolve(const std::string& value) const {
     return result;
 }
 
-std::string Configuration::resolveReferences(const std::string& value) const {
+std::string Configuration::resolveReferences(const std::string& value, std::unordered_set<Resource const*>& resolvingValues) const {
     std::string            result;
     std::string::size_type begin, pos = 0;
 
@@ -718,7 +723,7 @@ std::string Configuration::resolveReferences(const std::string& value) const {
             }
 
             if (resource) {
-                result += getResolvedValue(resource);
+                result += getResolvedValue(resource, resolvingValues);
             }
             else {
                 // if not still not resolved -> warn
@@ -809,7 +814,8 @@ bool Configuration::get(const std::string& parameter, std::string& value) const 
     // get value for parameter
     const Resource* resource = find(query);
     if (resource) {
-        value = getResolvedValue(resource);
+        std::unordered_set<Resource const*> resolvingValues;
+        value = getResolvedValue(resource, resolvingValues);
         resource->registerUsage(query, 0, value);
         return true;
     }
@@ -840,7 +846,8 @@ void Configuration::writeResolvedResources(XmlWriter& os) const {
     for (std::set<Resource>::const_iterator itResource = db_->getResources().begin();
          itResource != db_->getResources().end();
          ++itResource) {
-        std::string value = getResolvedValue(&*itResource);
+        std::unordered_set<Resource const*> resolvingValues;
+        std::string                         value = getResolvedValue(&*itResource, resolvingValues);
         os << itResource->getName() << " = " << value
            << "\n";
     }

--- a/src/Core/Configuration.hh
+++ b/src/Core/Configuration.hh
@@ -23,6 +23,9 @@
 #include <vector>
 #include <string.h>
 #include <sys/stat.h>
+
+#include <boost/thread/synchronized_value.hpp>
+
 #include "Assertions.hh"
 #include "ReferenceCounting.hh"
 #include "Types.hh"
@@ -273,6 +276,9 @@ private:
      * @return the most specific resource matching @c parameter
      */
     const Resource* find(const std::string& parameter) const;
+
+    std::string resolve(const std::string& value, std::unordered_set<Resource const*>& resolvingValues) const;
+
     /**
      * Substitute parameter references in a string.
      *
@@ -293,7 +299,7 @@ private:
      * @param value is a string which may contain configuration references.
      * @return @c value with all references substituted.
      **/
-    std::string resolveReferences(const std::string& value) const;
+    std::string resolveReferences(const std::string& value, std::unordered_set<Resource const*>& resolvingValues) const;
 
 #ifdef MODULE_CORE_CACHE_MANAGER
     /**
@@ -312,7 +318,7 @@ private:
     std::string resolveCacheManagerCommands(const std::string& value) const;
 #endif
 
-    std::string getResolvedValue(const Resource* resource) const;
+    std::string getResolvedValue(const Resource* resource, std::unordered_set<Resource const*>& resolvingValues) const;
 };
 
 /**
@@ -339,7 +345,6 @@ private:
     const SourceDescriptor* source_;
     std::string             name_;
     std::string             value_;
-    mutable bool            isBeingResolved_; /**< flag to trap circular reference */
 
     struct Usage {
         std::string              fullParameterName;
@@ -347,14 +352,13 @@ private:
         std::string              effectiveValue;
     };
 
-    mutable std::vector<Usage> usage;
+    mutable boost::synchronized_value<std::vector<Usage>> usage;
 
 public:
     Resource(const std::string& _name, const std::string& _value, const SourceDescriptor* _source)
             : source_(_source),
               name_(_name),
-              value_(_value),
-              isBeingResolved_(false) {}
+              value_(_value) {}
 
     inline const std::string& getName() const {
         return name_;
@@ -362,16 +366,6 @@ public:
     inline const std::string& getValue() const {
         return value_;
     };
-
-    bool isBeingResolved() const {
-        return isBeingResolved_;
-    }
-    void beginResolution() const {
-        isBeingResolved_ = true;
-    }
-    void endResolution() const {
-        isBeingResolved_ = false;
-    }
 
     inline bool operator<(const Resource& r) const {
         return name_ < r.name_;
@@ -397,7 +391,7 @@ public:
         u.fullParameterName = n;
         u.parameter         = p;
         u.effectiveValue    = v;
-        usage.push_back(u);
+        usage.synchronize()->push_back(u);
     }
 
     void writeUsage(XmlWriter&) const;

--- a/src/Tools/LibRASR/PybindModule.cc
+++ b/src/Tools/LibRASR/PybindModule.cc
@@ -18,11 +18,11 @@ PYBIND11_MODULE(librasr, m) {
 
     py::class_<Core::Configuration> baseConfigClass(m, "_BaseConfig");
     baseConfigClass.def("enable_logging", &Core::Configuration::enableLogging)
-            .def("set_from_file", static_cast<bool (Core::Configuration::*)(const std::string&)>(&Core::Configuration::setFromFile))
+            .def("set_from_file", static_cast<bool (Core::Configuration::*)(std::string const&)>(&Core::Configuration::setFromFile))
             .def("get_selection", &Core::Configuration::getSelection)
             .def("get_name", &Core::Configuration::getName)
             .def("set_selection", &Core::Configuration::setSelection)
-            .def("resolve", &Core::Configuration::resolve)
+            .def("resolve", static_cast<std::string (Core::Configuration::*)(std::string const& value) const>(&Core::Configuration::resolve))
             .def("__getitem__", [](Core::Configuration const& self, std::string const& parameter) {
                 std::string value;
                 if (self.get(parameter, value)) {


### PR DESCRIPTION
This PR ports changes from AppTek RASR made by @curufinwe that fix race conditions in the resource resolution of `Core::Configuration`.