### PR TITLE
Fix score accessing in LexiconfreeLabelsyncBeamSearch and check buffer requirements in StateManagedOnnxLabelScorer::cacheStatesAndScores

### DIFF
--- a/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.cc
+++ b/src/Nn/LabelScorer/StateManagedOnnxLabelScorer.cc
@@ -277,6 +277,11 @@ void StateManagedOnnxLabelScorer::cacheStatesAndScores(std::vector<StateManagedO
         return;
     }
 
+    // Can't score before any encoder features are buffered; defer (mirrors the guard in getScoreAccessors()).
+    if ((not encoderStatesName_.empty() or not encoderStatesSizeName_.empty()) and bufferSize() == 0ul) {
+        return;
+    }
+
     std::vector<size_t>              prefixLengths;
     std::vector<HistoryState const*> prefixStates;
     prefixLengths.reserve(scoringContextBatch.size());

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -330,6 +330,9 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
 
     Score currentBestScore = Core::Type<Score>::max;
 
+    // `scoreAccessors` only covers the active hypotheses (in beam order), so index it by a running
+    // active-hypothesis counter rather than the beam position.
+    size_t activeIndex = 0ul;
     for (size_t hypIndex = 0ul; hypIndex < beam_.size(); ++hypIndex) {
         auto& hyp = beam_[hypIndex];
 
@@ -337,11 +340,13 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
             continue;
         }
 
-        if (not scoreAccessors[hypIndex]) {
+        size_t const scoreIndex = activeIndex++;
+
+        if (not scoreAccessors[scoreIndex]) {
             continue;
         }
 
-        auto const& scoreAccessor = *scoreAccessors[hypIndex];
+        auto const& scoreAccessor = *scoreAccessors[scoreIndex];
 
         // Iterate over possible successors (all lemmas)
         for (auto lemmaIt = lemmas.first; lemmaIt != lemmas.second; ++lemmaIt) {


### PR DESCRIPTION
Bug 1. In `src/Nn/LabelScorer/StateManagedOnnxLabelScorer.cc` scoring can be triggered before feeding any features.
Bug 2. `scoreAccessors` indexing was wrong in beam search; it indexed over all beams, not active beams.