### PR TITLE
Add Python bindings to manipulate the LM/LabelScorer scale in SearchV2

### DIFF
--- a/src/Nn/LabelScorer/CombineLabelScorer.cc
+++ b/src/Nn/LabelScorer/CombineLabelScorer.cc
@@ -69,6 +69,28 @@ CombineLabelScorer::CombineLabelScorer(Core::Configuration const& config, ModelC
     }
 }
 
+size_t CombineLabelScorer::numLabelScorers() const {
+    return scorers_.size();
+}
+
+Score CombineLabelScorer::scale(size_t index) const {
+    require(index < scorers_.size());
+
+    auto* scorer = dynamic_cast<ScaledLabelScorer*>(scorers_[index].get());
+    require(scorer);
+
+    return scorer->scale();
+}
+
+void CombineLabelScorer::setScale(size_t index, Score scale) {
+    require(index < scorers_.size());
+
+    auto* scorer = dynamic_cast<ScaledLabelScorer*>(scorers_[index].get());
+    require(scorer);
+
+    scorer->setScale(scale);
+}
+
 void CombineLabelScorer::reset() {
     for (auto& scorer : scorers_) {
         scorer->reset();

--- a/src/Nn/LabelScorer/CombineLabelScorer.cc
+++ b/src/Nn/LabelScorer/CombineLabelScorer.cc
@@ -108,6 +108,7 @@ CombineLabelScorer::CombineLabelScorer(Core::Configuration const& config, ModelC
 }
 
 Core::Ref<ScaledLabelScorer> CombineLabelScorer::getSubScorer(size_t index) const {
+    require(index < scorers_.size());
     return scorers_[index];
 }
 

--- a/src/Nn/LabelScorer/CombineLabelScorer.cc
+++ b/src/Nn/LabelScorer/CombineLabelScorer.cc
@@ -69,26 +69,8 @@ CombineLabelScorer::CombineLabelScorer(Core::Configuration const& config, ModelC
     }
 }
 
-size_t CombineLabelScorer::numLabelScorers() const {
-    return scorers_.size();
-}
-
-Score CombineLabelScorer::scale(size_t index) const {
-    require(index < scorers_.size());
-
-    auto* scorer = dynamic_cast<ScaledLabelScorer*>(scorers_[index].get());
-    require(scorer);
-
-    return scorer->scale();
-}
-
-void CombineLabelScorer::setScale(size_t index, Score scale) {
-    require(index < scorers_.size());
-
-    auto* scorer = dynamic_cast<ScaledLabelScorer*>(scorers_[index].get());
-    require(scorer);
-
-    scorer->setScale(scale);
+Core::Ref<ScaledLabelScorer> CombineLabelScorer::getSubScorer(size_t index) const {
+    return scorers_[index];
 }
 
 void CombineLabelScorer::reset() {

--- a/src/Nn/LabelScorer/CombineLabelScorer.hh
+++ b/src/Nn/LabelScorer/CombineLabelScorer.hh
@@ -18,6 +18,7 @@
 
 #include "LabelScorer.hh"
 #include "ModelCache.hh"
+#include "ScaledLabelScorer.hh"
 
 namespace Nn {
 
@@ -37,14 +38,8 @@ public:
     CombineLabelScorer(Core::Configuration const& config, ModelCache& modelCache);
     virtual ~CombineLabelScorer() = default;
 
-    // Return the number of sub-scorers
-    size_t numLabelScorers() const;
-
-    // Return the current scale of a sub-scorer
-    Score scale(size_t index) const;
-
-    // Set the scale of a sub-scorer, overriding the value from the config
-    void setScale(size_t index, Score scale);
+    // Return the sub-scorer at `index`
+    Core::Ref<ScaledLabelScorer> getSubScorer(size_t index) const;
 
     // Reset all sub-scorers
     void reset() override;
@@ -74,7 +69,7 @@ public:
     std::vector<std::optional<ScoreAccessorRef>> getScoreAccessors(std::vector<ScoringContextRef> const& scoringContexts) override;
 
 private:
-    std::vector<Core::Ref<LabelScorer>> scorers_;
+    std::vector<Core::Ref<ScaledLabelScorer>> scorers_;
 };
 
 }  // namespace Nn

--- a/src/Nn/LabelScorer/CombineLabelScorer.hh
+++ b/src/Nn/LabelScorer/CombineLabelScorer.hh
@@ -37,6 +37,15 @@ public:
     CombineLabelScorer(Core::Configuration const& config, ModelCache& modelCache);
     virtual ~CombineLabelScorer() = default;
 
+    // Return the number of sub-scorers
+    size_t numLabelScorers() const;
+
+    // Return the current scale of a sub-scorer
+    Score scale(size_t index) const;
+
+    // Set the scale of a sub-scorer, overriding the value from the config
+    void setScale(size_t index, Score scale);
+
     // Reset all sub-scorers
     void reset() override;
 

--- a/src/Nn/LabelScorer/CtcPrefixLabelScorer.cc
+++ b/src/Nn/LabelScorer/CtcPrefixLabelScorer.cc
@@ -137,6 +137,10 @@ CtcPrefixLabelScorer::CtcPrefixLabelScorer(Core::Configuration const& config, Mo
           ctcScores_(std::make_shared<Math::FastMatrix<Score>>(vocabSize_, 0)) {
 }
 
+Core::Ref<ScaledLabelScorer> CtcPrefixLabelScorer::getCtcLabelScorer() const {
+    return ctcScorer_;
+}
+
 void CtcPrefixLabelScorer::reset() {
     ctcScorer_->reset();
     expectMoreFeatures_ = true;

--- a/src/Nn/LabelScorer/CtcPrefixLabelScorer.hh
+++ b/src/Nn/LabelScorer/CtcPrefixLabelScorer.hh
@@ -18,6 +18,7 @@
 
 #include "LabelScorer.hh"
 #include "ModelCache.hh"
+#include "ScaledLabelScorer.hh"
 
 namespace Nn {
 
@@ -54,6 +55,9 @@ public:
     CtcPrefixLabelScorer(Core::Configuration const& config, ModelCache& modelCache);
     virtual ~CtcPrefixLabelScorer() = default;
 
+    // Return the CTC label scorer
+    Core::Ref<ScaledLabelScorer> getCtcLabelScorer() const;
+
     void reset() override;
     void signalNoMoreFeatures() override;
     void addInput(DataView const& input) override;
@@ -64,10 +68,10 @@ public:
     std::optional<ScoreAccessorRef> getScoreAccessor(ScoringContextRef scoringContext) override;
 
 private:
-    LabelIndex             blankIndex_;
-    size_t                 vocabSize_;
-    Core::Ref<LabelScorer> ctcScorer_;
-    bool                   expectMoreFeatures_;
+    LabelIndex                   blankIndex_;
+    size_t                       vocabSize_;
+    Core::Ref<ScaledLabelScorer> ctcScorer_;
+    bool                         expectMoreFeatures_;
 
     std::shared_ptr<Math::FastMatrix<Score>> ctcScores_;  // Cached T x V matrix of scores
 

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.cc
@@ -17,12 +17,16 @@
 
 namespace Nn {
 
-EncoderDecoderLabelScorer::EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<LabelScorer> const& decoder)
+EncoderDecoderLabelScorer::EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<ScaledLabelScorer> const& decoder)
         : Core::Component(config),
           LabelScorer(config),
           encoder_(encoder),
           decoder_(decoder) {
     enabledTransitions_ = decoder_->enabledTransitions();
+}
+
+Core::Ref<ScaledLabelScorer> EncoderDecoderLabelScorer::getDecoderLabelScorer() const {
+    return decoder_;
 }
 
 void EncoderDecoderLabelScorer ::reset() {

--- a/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
+++ b/src/Nn/LabelScorer/EncoderDecoderLabelScorer.hh
@@ -20,6 +20,7 @@
 
 #include "Encoder.hh"
 #include "LabelScorer.hh"
+#include "ScaledLabelScorer.hh"
 
 namespace Nn {
 
@@ -33,8 +34,11 @@ namespace Nn {
  */
 class EncoderDecoderLabelScorer : public LabelScorer {
 public:
-    EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<LabelScorer> const& decoder);
+    EncoderDecoderLabelScorer(Core::Configuration const& config, Core::Ref<Encoder> const& encoder, Core::Ref<ScaledLabelScorer> const& decoder);
     virtual ~EncoderDecoderLabelScorer() = default;
+
+    // Return the decoder label scorer
+    Core::Ref<ScaledLabelScorer> getDecoderLabelScorer() const;
 
     // Resets both encoder and decoder component
     void reset() override;
@@ -67,8 +71,8 @@ public:
     std::vector<std::optional<ScoreAccessorRef>> getScoreAccessors(std::vector<ScoringContextRef> const& scoringContexts) override;
 
 private:
-    Core::Ref<Encoder>     encoder_;
-    Core::Ref<LabelScorer> decoder_;
+    Core::Ref<Encoder>           encoder_;
+    Core::Ref<ScaledLabelScorer> decoder_;
 
     // Fetch as many outputs as possible from the encoder given its available features and pass
     // these outputs over to the decoder

--- a/src/Nn/LabelScorer/ScaledLabelScorer.cc
+++ b/src/Nn/LabelScorer/ScaledLabelScorer.cc
@@ -58,6 +58,18 @@ ScaledLabelScorer::ScaledLabelScorer(Core::Configuration const& config, Core::Re
     enabledTransitions_ = scorer->enabledTransitions();
 }
 
+Core::Ref<LabelScorer> ScaledLabelScorer::labelScorer() const {
+    return scorer_;
+}
+
+Score ScaledLabelScorer::scale() const {
+    return scale_;
+}
+
+void ScaledLabelScorer::setScale(Score scale) {
+    scale_ = scale;
+}
+
 void ScaledLabelScorer::reset() {
     scorer_->reset();
 }

--- a/src/Nn/LabelScorer/ScaledLabelScorer.hh
+++ b/src/Nn/LabelScorer/ScaledLabelScorer.hh
@@ -32,6 +32,15 @@ public:
 
     ScaledLabelScorer(Core::Configuration const& config, Core::Ref<LabelScorer> const& scorer);
 
+    // Return the wrapped label scorer
+    Core::Ref<LabelScorer> labelScorer() const;
+
+    // Return the current scale
+    Score scale() const;
+
+    // Set the scale, overriding the value from the config
+    void setScale(Score scale);
+
     // Reset sub-scorer
     void reset() override;
 

--- a/src/Nn/Module.cc
+++ b/src/Nn/Module.cc
@@ -170,10 +170,14 @@ Module_::Module_()
     labelScorerFactory_.registerLabelScorer(
             "encoder-only",
             [this](Core::Configuration const& config, ModelCache& modelCache) {
+                Core::Ref<LabelScorer> decoder = Core::ref(new StepwiseNoOpLabelScorer(config));
+
+                Core::Ref<ScaledLabelScorer> scaledDecoder = Core::ref(new ScaledLabelScorer(Core::Configuration(config, "decoder"), decoder));
+
                 return Core::ref(new EncoderDecoderLabelScorer(
                         config,
                         encoderFactory_.createEncoder(Core::Configuration(config, "encoder"), modelCache),
-                        Core::ref(new StepwiseNoOpLabelScorer(config))));
+                        scaledDecoder));
             });
 
     // Compute scores by forwarding a single input feature vector without history through an ONNX model

--- a/src/Python/LabelScorer.hh
+++ b/src/Python/LabelScorer.hh
@@ -19,11 +19,7 @@
 #include <pybind11/pybind11.h>
 #include "Nn/LabelScorer/Types.hh"
 
-#include <Nn/LabelScorer/CombineLabelScorer.hh>
-#include <Nn/LabelScorer/CtcPrefixLabelScorer.hh>
-#include <Nn/LabelScorer/EncoderDecoderLabelScorer.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
-#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 
 namespace py = pybind11;
 

--- a/src/Python/LabelScorer.hh
+++ b/src/Python/LabelScorer.hh
@@ -19,9 +19,36 @@
 #include <pybind11/pybind11.h>
 #include "Nn/LabelScorer/Types.hh"
 
+#include <Nn/LabelScorer/CombineLabelScorer.hh>
+#include <Nn/LabelScorer/CtcPrefixLabelScorer.hh>
+#include <Nn/LabelScorer/EncoderDecoderLabelScorer.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
+#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 
 namespace py = pybind11;
+
+// Return the sub-scorer that is wrapped by the given label scorer
+// If the label scorer is a CombineLabelScorer, return the sub-scorer at the specified index
+static Nn::ScaledLabelScorer* getSubScorer(Nn::ScaledLabelScorer* labelScorer, std::optional<size_t> index = 0) {
+    Core::Ref<Nn::LabelScorer> wrappedLabelScorer = labelScorer->labelScorer();
+
+    auto* combineScorer = dynamic_cast<Nn::CombineLabelScorer*>(wrappedLabelScorer.get());
+    if (combineScorer) {
+        return combineScorer->getSubScorer(*index).get();
+    }
+
+    auto* encoderDecoderScorer = dynamic_cast<Nn::EncoderDecoderLabelScorer*>(wrappedLabelScorer.get());
+    if (encoderDecoderScorer) {
+        return encoderDecoderScorer->getDecoderLabelScorer().get();
+    }
+
+    auto* ctcPrefixScorer = dynamic_cast<Nn::CtcPrefixLabelScorer*>(wrappedLabelScorer.get());
+    if (ctcPrefixScorer) {
+        return ctcPrefixScorer->getCtcLabelScorer().get();
+    }
+
+    throw py::value_error("Label scorer does not a have a sub-scorer");
+}
 
 namespace Python {
 

--- a/src/Python/LabelScorer.hh
+++ b/src/Python/LabelScorer.hh
@@ -27,29 +27,6 @@
 
 namespace py = pybind11;
 
-// Return the sub-scorer that is wrapped by the given label scorer
-// If the label scorer is a CombineLabelScorer, return the sub-scorer at the specified index
-static Nn::ScaledLabelScorer* getSubScorer(Nn::ScaledLabelScorer* labelScorer, std::optional<size_t> index = 0) {
-    Core::Ref<Nn::LabelScorer> wrappedLabelScorer = labelScorer->labelScorer();
-
-    auto* combineScorer = dynamic_cast<Nn::CombineLabelScorer*>(wrappedLabelScorer.get());
-    if (combineScorer) {
-        return combineScorer->getSubScorer(*index).get();
-    }
-
-    auto* encoderDecoderScorer = dynamic_cast<Nn::EncoderDecoderLabelScorer*>(wrappedLabelScorer.get());
-    if (encoderDecoderScorer) {
-        return encoderDecoderScorer->getDecoderLabelScorer().get();
-    }
-
-    auto* ctcPrefixScorer = dynamic_cast<Nn::CtcPrefixLabelScorer*>(wrappedLabelScorer.get());
-    if (ctcPrefixScorer) {
-        return ctcPrefixScorer->getCtcLabelScorer().get();
-    }
-
-    throw py::value_error("Label scorer does not a have a sub-scorer");
-}
-
 namespace Python {
 
 /*

--- a/src/Python/Search.cc
+++ b/src/Python/Search.cc
@@ -193,3 +193,27 @@ std::vector<Traceback> SearchAlgorithm::recognizeSegmentNBest(py::array_t<f32> c
     finishSegment();
     return getCurrentNBestList(nBestSize);
 }
+
+void SearchAlgorithm::setLanguageModelScale(Mc::Scale scale) {
+    Core::Ref<Lm::ScaledLanguageModel> lm = modelCombination_.languageModel();
+
+    if (!lm) {
+        error() << "Cannot set LM scale, model combination has no language model";
+        return;
+    }
+
+    log() << "Setting LM scale to " << scale;
+
+    lm->setOwnScale(scale);
+}
+
+Mc::Scale SearchAlgorithm::languageModelScale() const {
+    Core::Ref<Lm::ScaledLanguageModel> lm = modelCombination_.languageModel();
+
+    if (!lm) {
+        error() << "Cannot set LM scale, model combination has no language model";
+        return 0.0;
+    }
+
+    return lm->scale();
+}

--- a/src/Python/Search.cc
+++ b/src/Python/Search.cc
@@ -34,6 +34,10 @@ SearchAlgorithm::SearchAlgorithm(const Core::Configuration& c)
     searchAlgorithm_->setModelCombination(modelCombination_);
 }
 
+Speech::ModelCombination& SearchAlgorithm::modelCombination() {
+    return modelCombination_;
+}
+
 void SearchAlgorithm::enterSegment() {
     searchAlgorithm_->enterSegment();
 }
@@ -192,28 +196,4 @@ std::vector<Traceback> SearchAlgorithm::recognizeSegmentNBest(py::array_t<f32> c
     putFeatures(features);
     finishSegment();
     return getCurrentNBestList(nBestSize);
-}
-
-void SearchAlgorithm::setLanguageModelScale(Mc::Scale scale) {
-    Core::Ref<Lm::ScaledLanguageModel> lm = modelCombination_.languageModel();
-
-    if (!lm) {
-        error() << "Cannot set LM scale, model combination has no language model";
-        return;
-    }
-
-    log() << "Setting LM scale to " << scale;
-
-    lm->setOwnScale(scale);
-}
-
-Mc::Scale SearchAlgorithm::languageModelScale() const {
-    Core::Ref<Lm::ScaledLanguageModel> lm = modelCombination_.languageModel();
-
-    if (!lm) {
-        error() << "Cannot set LM scale, model combination has no language model";
-        return 0.0;
-    }
-
-    return lm->scale();
 }

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -18,7 +18,6 @@
 
 #include <Flf/LatticeHandler.hh>
 #include <Flf/Lexicon.hh>
-#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Search/SearchV2.hh>
 
 #pragma push_macro("ensure")  // Macro duplication in numpy.h

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -18,6 +18,8 @@
 
 #include <Flf/LatticeHandler.hh>
 #include <Flf/Lexicon.hh>
+#include <Nn/LabelScorer/CombineLabelScorer.hh>
+#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Search/SearchV2.hh>
 
 #pragma push_macro("ensure")  // Macro duplication in numpy.h
@@ -38,9 +40,47 @@ struct TracebackItem {
 
 typedef std::vector<TracebackItem> Traceback;
 
+// Return the lanuage model
+static Lm::ScaledLanguageModel* getLanguageModel(Speech::ModelCombination& modelCombination) {
+    return modelCombination.languageModel().get();
+}
+
+// Return the label scorer as ScaledLabelScorer
+static Nn::ScaledLabelScorer* getScaledLabelScorer(Speech::ModelCombination& modelCombination, size_t index) {
+    Core::Ref<Nn::LabelScorer> labelScorer = modelCombination.labelScorer(index);
+
+    auto* scaledLabelScorer = dynamic_cast<Nn::ScaledLabelScorer*>(labelScorer.get());
+    if (!scaledLabelScorer) {
+        throw py::value_error("Label scorer is not a ScaledLabelScorer.");
+    }
+
+    return scaledLabelScorer;
+}
+
+// Return the CombineLabelScorer
+static Nn::CombineLabelScorer* getCombineLabelScorer(Speech::ModelCombination& modelCombination, size_t index) {
+    Core::Ref<Nn::LabelScorer> labelScorer = modelCombination.labelScorer(index);
+
+    auto* scaledLabelScorer = dynamic_cast<Nn::ScaledLabelScorer*>(labelScorer.get());
+    if (!scaledLabelScorer) {
+        throw py::value_error("Top-level label scorer is not a ScaledLabelScorer.");
+    }
+
+    Core::Ref<Nn::LabelScorer> wrappedLabelScorer = scaledLabelScorer->labelScorer();
+    auto*                      combineLabelScorer = dynamic_cast<Nn::CombineLabelScorer*>(wrappedLabelScorer.get());
+    if (!combineLabelScorer) {
+        throw py::value_error("Configured label scorer is not a CombineLabelScorer.");
+    }
+
+    return combineLabelScorer;
+}
+
 class SearchAlgorithm : public Core::Component {
 public:
     SearchAlgorithm(const Core::Configuration& c);
+
+    // Return the model combination used by the search.
+    Speech::ModelCombination& modelCombination();
 
     // Call at the beginning of a new segment.
     void enterSegment();
@@ -70,12 +110,6 @@ public:
     // Convenience function to recognize a full segment given all the features as a tensor of shape [T, F]
     // Returns a n-best list of recognition results
     std::vector<Traceback> recognizeSegmentNBest(py::array_t<f32> const& features, size_t nBestSize);
-
-    // Set the LM scale, overriding the value from the config.
-    void setLanguageModelScale(Mc::Scale scale);
-
-    // Return the current effective LM scale.
-    Mc::Scale languageModelScale() const;
 
 private:
     Traceback searchTracebackToPythonTraceback(Core::Ref<Search::Traceback const> traceback);

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -39,16 +39,6 @@ struct TracebackItem {
 
 typedef std::vector<TracebackItem> Traceback;
 
-// Return the lanuage model
-static Lm::ScaledLanguageModel* getLanguageModel(Speech::ModelCombination& modelCombination) {
-    return modelCombination.languageModel().get();
-}
-
-// Return the label scorer
-static Nn::ScaledLabelScorer* getLabelScorer(Speech::ModelCombination& modelCombination, std::optional<size_t> index = 0) {
-    return dynamic_cast<Nn::ScaledLabelScorer*>(modelCombination.labelScorer(*index).get());
-}
-
 class SearchAlgorithm : public Core::Component {
 public:
     SearchAlgorithm(const Core::Configuration& c);

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -18,7 +18,6 @@
 
 #include <Flf/LatticeHandler.hh>
 #include <Flf/Lexicon.hh>
-#include <Nn/LabelScorer/CombineLabelScorer.hh>
 #include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Search/SearchV2.hh>
 
@@ -45,34 +44,9 @@ static Lm::ScaledLanguageModel* getLanguageModel(Speech::ModelCombination& model
     return modelCombination.languageModel().get();
 }
 
-// Return the label scorer as ScaledLabelScorer
-static Nn::ScaledLabelScorer* getScaledLabelScorer(Speech::ModelCombination& modelCombination, size_t index) {
-    Core::Ref<Nn::LabelScorer> labelScorer = modelCombination.labelScorer(index);
-
-    auto* scaledLabelScorer = dynamic_cast<Nn::ScaledLabelScorer*>(labelScorer.get());
-    if (!scaledLabelScorer) {
-        throw py::value_error("Label scorer is not a ScaledLabelScorer.");
-    }
-
-    return scaledLabelScorer;
-}
-
-// Return the CombineLabelScorer
-static Nn::CombineLabelScorer* getCombineLabelScorer(Speech::ModelCombination& modelCombination, size_t index) {
-    Core::Ref<Nn::LabelScorer> labelScorer = modelCombination.labelScorer(index);
-
-    auto* scaledLabelScorer = dynamic_cast<Nn::ScaledLabelScorer*>(labelScorer.get());
-    if (!scaledLabelScorer) {
-        throw py::value_error("Top-level label scorer is not a ScaledLabelScorer.");
-    }
-
-    Core::Ref<Nn::LabelScorer> wrappedLabelScorer = scaledLabelScorer->labelScorer();
-    auto*                      combineLabelScorer = dynamic_cast<Nn::CombineLabelScorer*>(wrappedLabelScorer.get());
-    if (!combineLabelScorer) {
-        throw py::value_error("Configured label scorer is not a CombineLabelScorer.");
-    }
-
-    return combineLabelScorer;
+// Return the label scorer
+static Nn::ScaledLabelScorer* getLabelScorer(Speech::ModelCombination& modelCombination, std::optional<size_t> index = 0) {
+    return dynamic_cast<Nn::ScaledLabelScorer*>(modelCombination.labelScorer(*index).get());
 }
 
 class SearchAlgorithm : public Core::Component {

--- a/src/Python/Search.hh
+++ b/src/Python/Search.hh
@@ -71,6 +71,12 @@ public:
     // Returns a n-best list of recognition results
     std::vector<Traceback> recognizeSegmentNBest(py::array_t<f32> const& features, size_t nBestSize);
 
+    // Set the LM scale, overriding the value from the config.
+    void setLanguageModelScale(Mc::Scale scale);
+
+    // Return the current effective LM scale.
+    Mc::Scale languageModelScale() const;
+
 private:
     Traceback searchTracebackToPythonTraceback(Core::Ref<Search::Traceback const> traceback);
 

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -174,26 +174,10 @@ void bindLabelScorer(py::module_& module) {
             &Nn::ScaledLabelScorer::scale,
             "Return the current label scorer scale.");
 
-    py::class_<Nn::CombineLabelScorer, Nn::LabelScorer, Core::Ref<Nn::CombineLabelScorer>> pyCombineLabelScorer(
-            module,
-            "CombineLabelScorer",
-            "Label scorer that combines multiple sub-scorers.");
-
-    pyCombineLabelScorer.def(
-            "num_label_scorers",
-            &Nn::CombineLabelScorer::numLabelScorers,
-            "Return the number of sub-scorers.");
-
-    pyCombineLabelScorer.def(
-            "set_label_scorer_scale",
-            &Nn::CombineLabelScorer::setScale,
-            py::arg("index"),
-            py::arg("scale"),
-            "Set the scale of a sub-scorer, overriding the value from the config.");
-
-    pyCombineLabelScorer.def(
-            "label_scorer_scale",
-            &Nn::CombineLabelScorer::scale,
-            py::arg("index"),
-            "Return the current scale of a sub-scorer.");
+    pyScaledLabelScorer.def(
+            "get_sub_scorer",
+            &getSubScorer,
+            py::arg("index") = 0ul,
+            py::return_value_policy::reference_internal,
+            "Return the wrapped sub-scorer.");
 }

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -19,9 +19,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
-#include <Nn/LabelScorer/EncoderDecoderLabelScorer.hh>
 #include <Nn/LabelScorer/CombineLabelScorer.hh>
 #include <Nn/LabelScorer/CtcPrefixLabelScorer.hh>
+#include <Nn/LabelScorer/EncoderDecoderLabelScorer.hh>
 #include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Nn/Module.hh>
 #include <Python/LabelScorer.hh>

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -19,6 +19,8 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
+#include <Nn/LabelScorer/CombineLabelScorer.hh>
+#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Nn/Module.hh>
 #include <Python/LabelScorer.hh>
 
@@ -155,4 +157,43 @@ void bindLabelScorer(py::module_& module) {
             "    A vector of length `B` containing either `None` if the label scorer is not ready to process the requests (e.g. expects more features or segment end signal)\n"
             "    or a tuple of a score-list and a timestamp for each context. The returned timestamps will be used\n"
             "    to form word boundaries in the search traceback.");
+
+    py::class_<Nn::ScaledLabelScorer, Nn::LabelScorer, Core::Ref<Nn::ScaledLabelScorer>> pyScaledLabelScorer(
+            module,
+            "ScaledLabelScorer",
+            "Label scorer with configurable scale.");
+
+    pyScaledLabelScorer.def(
+            "set_scale",
+            &Nn::ScaledLabelScorer::setScale,
+            py::arg("scale"),
+            "Set the label scorer scale, overriding the value from the config.");
+
+    pyScaledLabelScorer.def(
+            "scale",
+            &Nn::ScaledLabelScorer::scale,
+            "Return the current label scorer scale.");
+
+    py::class_<Nn::CombineLabelScorer, Nn::LabelScorer, Core::Ref<Nn::CombineLabelScorer>> pyCombineLabelScorer(
+            module,
+            "CombineLabelScorer",
+            "Label scorer that combines multiple sub-scorers.");
+
+    pyCombineLabelScorer.def(
+            "num_label_scorers",
+            &Nn::CombineLabelScorer::numLabelScorers,
+            "Return the number of sub-scorers.");
+
+    pyCombineLabelScorer.def(
+            "set_label_scorer_scale",
+            &Nn::CombineLabelScorer::setScale,
+            py::arg("index"),
+            py::arg("scale"),
+            "Set the scale of a sub-scorer, overriding the value from the config.");
+
+    pyCombineLabelScorer.def(
+            "label_scorer_scale",
+            &Nn::CombineLabelScorer::scale,
+            py::arg("index"),
+            "Return the current scale of a sub-scorer.");
 }

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -19,7 +19,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
+#include <Nn/LabelScorer/EncoderDecoderLabelScorer.hh>
 #include <Nn/LabelScorer/CombineLabelScorer.hh>
+#include <Nn/LabelScorer/CtcPrefixLabelScorer.hh>
 #include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Nn/Module.hh>
 #include <Python/LabelScorer.hh>

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -40,6 +40,31 @@ void registerPythonLabelScorer(std::string const& name, py::object const& pyLabe
             });
 }
 
+// Return the sub-scorer that is wrapped by the given label scorer
+// If the label scorer is a CombineLabelScorer, return the sub-scorer at the specified index
+Nn::ScaledLabelScorer* getSubScorer(Nn::ScaledLabelScorer& labelScorer, size_t index = 0) {
+    auto wrappedLabelScorer = labelScorer.labelScorer();
+
+    auto* combineScorer = dynamic_cast<Nn::CombineLabelScorer*>(wrappedLabelScorer.get());
+    if (combineScorer) {
+        return combineScorer->getSubScorer(index).get();
+    }
+
+    auto* encoderDecoderScorer = dynamic_cast<Nn::EncoderDecoderLabelScorer*>(wrappedLabelScorer.get());
+    if (encoderDecoderScorer) {
+        require(index == 0);
+        return encoderDecoderScorer->getDecoderLabelScorer().get();
+    }
+
+    auto* ctcPrefixScorer = dynamic_cast<Nn::CtcPrefixLabelScorer*>(wrappedLabelScorer.get());
+    if (ctcPrefixScorer) {
+        require(index == 0);
+        return ctcPrefixScorer->getCtcLabelScorer().get();
+    }
+
+    throw py::value_error("Label scorer does not a have a sub-scorer");
+}
+
 void bindLabelScorer(py::module_& module) {
     module.def(
             "register_label_scorer_type",

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -126,4 +126,15 @@ void bindSearchAlgorithm(py::module_& module) {
             py::arg("features"),
             py::arg("n"),
             "Convenience function to start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return a n-best list of results.");
+
+    pySearchAlgorithm.def(
+            "set_lm_scale",
+            &SearchAlgorithm::setLanguageModelScale,
+            py::arg("lm_scale"),
+            "Set the LM scale, overriding the value from the config.");
+
+    pySearchAlgorithm.def(
+            "lm_scale",
+            &SearchAlgorithm::languageModelScale,
+            "Return the current effective LM scale.");
 }

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -17,7 +17,9 @@
 
 #include <sstream>
 
+#include <Lm/ScaledLanguageModel.hh>
 #include <Python/Search.hh>
+#include <Speech/ModelCombination.hh>
 
 void bindSearchAlgorithm(py::module_& module) {
     /*
@@ -54,6 +56,54 @@ void bindSearchAlgorithm(py::module_& module) {
             [](TracebackItem const& t) {
                 return t.lemma;
             });
+
+    /*
+     * =========================
+     * === Model Combination ===
+     * =========================
+     */
+    py::class_<Lm::ScaledLanguageModel> pyScaledLanguageModel(
+            module,
+            "ScaledLanguageModel",
+            "Language model with configurable scale.");
+
+    pyScaledLanguageModel.def(
+            "set_scale",
+            [](Lm::ScaledLanguageModel& lm, Mc::Scale scale) {
+                lm.setOwnScale(scale / lm.parentScale());
+            },
+            py::arg("scale"),
+            "Set the effective LM scale, overriding the value from the config.");
+
+    pyScaledLanguageModel.def(
+            "scale",
+            &Lm::ScaledLanguageModel::scale,
+            "Return the current effective LM scale.");
+
+    py::class_<Speech::ModelCombination> pyModelCombination(
+            module,
+            "ModelCombination",
+            "Combination of lexicon, acoustic model, label scorer and language model.");
+
+    pyModelCombination.def(
+            "language_model",
+            &getLanguageModel,
+            py::return_value_policy::reference_internal,
+            "Return the language model.");
+
+    pyModelCombination.def(
+            "scaled_label_scorer",
+            &getScaledLabelScorer,
+            py::arg("index") = 0ul,
+            py::return_value_policy::reference_internal,
+            "Return the ScaledLabelScorer.");
+
+    pyModelCombination.def(
+            "combine_label_scorer",
+            &getCombineLabelScorer,
+            py::arg("index") = 0ul,
+            py::return_value_policy::reference_internal,
+            "Return the CombineLabelScorer.");
 
     /*
      * ========================
@@ -128,13 +178,8 @@ void bindSearchAlgorithm(py::module_& module) {
             "Convenience function to start a segment, pass all the features as a numpy array of shape [T, F] or [1, T, F], finish the segment, and return a n-best list of results.");
 
     pySearchAlgorithm.def(
-            "set_lm_scale",
-            &SearchAlgorithm::setLanguageModelScale,
-            py::arg("lm_scale"),
-            "Set the LM scale, overriding the value from the config.");
-
-    pySearchAlgorithm.def(
-            "lm_scale",
-            &SearchAlgorithm::languageModelScale,
-            "Return the current effective LM scale.");
+            "model_combination",
+            &SearchAlgorithm::modelCombination,
+            py::return_value_policy::reference_internal,
+            "Return the model combination used by the search.");
 }

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include <Lm/ScaledLanguageModel.hh>
+#include <Nn/LabelScorer/ScaledLabelScorer.hh>
 #include <Python/Search.hh>
 #include <Speech/ModelCombination.hh>
 

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -21,6 +21,16 @@
 #include <Python/Search.hh>
 #include <Speech/ModelCombination.hh>
 
+// Return the lanuage model
+Lm::ScaledLanguageModel* getLanguageModel(Speech::ModelCombination& modelCombination) {
+    return modelCombination.languageModel().get();
+}
+
+// Return the label scorer
+Nn::ScaledLabelScorer* getLabelScorer(Speech::ModelCombination& modelCombination, size_t index = 0) {
+    return dynamic_cast<Nn::ScaledLabelScorer*>(modelCombination.labelScorer(index).get());
+}
+
 void bindSearchAlgorithm(py::module_& module) {
     /*
      * ========================

--- a/src/Tools/LibRASR/Search.cc
+++ b/src/Tools/LibRASR/Search.cc
@@ -62,6 +62,25 @@ void bindSearchAlgorithm(py::module_& module) {
      * === Model Combination ===
      * =========================
      */
+
+    py::class_<Speech::ModelCombination> pyModelCombination(
+            module,
+            "ModelCombination",
+            "Combination of lexicon, acoustic model, label scorer and language model.");
+
+    pyModelCombination.def(
+            "label_scorer",
+            &getLabelScorer,
+            py::arg("index") = 0ul,
+            py::return_value_policy::reference_internal,
+            "Return the label scorer.");
+
+    pyModelCombination.def(
+            "language_model",
+            &getLanguageModel,
+            py::return_value_policy::reference_internal,
+            "Return the language model.");
+
     py::class_<Lm::ScaledLanguageModel> pyScaledLanguageModel(
             module,
             "ScaledLanguageModel",
@@ -79,31 +98,6 @@ void bindSearchAlgorithm(py::module_& module) {
             "scale",
             &Lm::ScaledLanguageModel::scale,
             "Return the current effective LM scale.");
-
-    py::class_<Speech::ModelCombination> pyModelCombination(
-            module,
-            "ModelCombination",
-            "Combination of lexicon, acoustic model, label scorer and language model.");
-
-    pyModelCombination.def(
-            "language_model",
-            &getLanguageModel,
-            py::return_value_policy::reference_internal,
-            "Return the language model.");
-
-    pyModelCombination.def(
-            "scaled_label_scorer",
-            &getScaledLabelScorer,
-            py::arg("index") = 0ul,
-            py::return_value_policy::reference_internal,
-            "Return the ScaledLabelScorer.");
-
-    pyModelCombination.def(
-            "combine_label_scorer",
-            &getCombineLabelScorer,
-            py::arg("index") = 0ul,
-            py::return_value_policy::reference_internal,
-            "Return the CombineLabelScorer.");
 
     /*
      * ========================


### PR DESCRIPTION
Adds two new Python bindings for SearchAlgorithmV2 which act as setter and getter for the LM scale. In this way, the LM scale can be changed during the recognition without adjusting the config file, it just overwrites the value set in the config.

We need this for setups where the search is used during training to allow for a dynamic LM scale across the epochs. For standard recognition this might however not be very useful, so I would also be okay if you reject this change.