### PR TITLE
Add missing libboost dependency to 2026-05-19_pytorch-2.12_onnx-1.24_v1 apptainer

### DIFF
--- a/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
+++ b/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
@@ -7,7 +7,7 @@ Stage: build
 
     # fundamental basics to compile RASR, zsh is needed because calling the cache manager might launch the user shell
     DEBIAN_FRONTEND=noninteractive apt install -y \
-        zsh bison libopenblas-dev libsndfile1-dev cmake libboost-thread-dev
+        zsh bison libopenblas-dev libsndfile1-dev cmake libboost-thread-dev libcppunit-dev
 
     pip3 install "pybind11[global]"
 

--- a/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
+++ b/apptainer/2026-05-19_pytorch-2.12_onnx-1.24_v1/image.def
@@ -7,7 +7,7 @@ Stage: build
 
     # fundamental basics to compile RASR, zsh is needed because calling the cache manager might launch the user shell
     DEBIAN_FRONTEND=noninteractive apt install -y \
-        zsh bison libopenblas-dev libsndfile1-dev cmake
+        zsh bison libopenblas-dev libsndfile1-dev cmake libboost-thread-dev
 
     pip3 install "pybind11[global]"
 

--- a/cmake_resources/CompileOptions.cmake
+++ b/cmake_resources/CompileOptions.cmake
@@ -96,8 +96,8 @@ if(${MODULE_OPENMP})
 endif()
 
 if(${MODULE_CUDA})
-    enable_language(CUDA)
     set(CMAKE_CUDA_ARCHITECTURES native)
+    enable_language(CUDA)
 endif()
 
 if(${MODULE_AUDIO_FLAC})


### PR DESCRIPTION
I tried compiling RASR with the latest apptainer image and ran into two issues. One was that cmake tried to check if nvcc works by compiling a file with compute_52 (Maxwell). Cuda 13.2 does not support that anymore and Claude tracked this to the order in which we set the architectures. I.e. we need to first set the architectures variable and only then enable Cuda. The other thing that was broken is the missing boost library needed for boost::synchronized_value.