### PR TITLE
Update SearchV2 algorithms: Remove hypotheses with non-finite scores

### DIFF
--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -764,31 +764,27 @@ void LexiconfreeLabelsyncBeamSearch::logStatistics() const {
 
 template<typename Element>
 void LexiconfreeLabelsyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
-    hypotheses.erase(
-            std::remove_if(
-                    hypotheses.begin(),
-                    hypotheses.end(),
-                    [](auto const& hyp) {
-                        return Math::isinf(hyp.score) or hyp.score >= Core::Type<Score>::max;
-                    }),
-            hypotheses.end());
+    // Find ranges for score histogram and setting absolute threshold
+    Score lowerScore = Core::Type<Score>::max;
+    Score upperScore = Core::Type<Score>::min;
 
-    if (hypotheses.empty()) {
+    for (auto const& hyp : hypotheses) {
+        if (Math::isinf(hyp.score) or hyp.score >= Core::Type<Score>::max) {
+            continue;
+        }
+        lowerScore = std::min(lowerScore, hyp.pruningScore());
+        upperScore = std::max(upperScore, hyp.pruningScore());
+    }
+
+    if (lowerScore > upperScore) {
+        // No hypothesis with finite score is present in the beam
+        hypotheses.clear();
         return;
     }
 
     if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
         // Neither relative score pruning nor max beam size pruning triggers
         return;
-    }
-
-    // Find ranges for score histogram and setting absolute threshold
-    Score lowerScore = Core::Type<Score>::max;
-    Score upperScore = Core::Type<Score>::min;
-
-    for (auto const& hyp : hypotheses) {
-        lowerScore = std::min(lowerScore, hyp.pruningScore());
-        upperScore = std::max(upperScore, hyp.pruningScore());
     }
 
     if (lowerScore == upperScore) {

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -16,12 +16,12 @@
 #include "LexiconfreeLabelsyncBeamSearch.hh"
 
 #include <algorithm>
-#include <cmath>
 #include <numeric>
 #include <strings.h>
 
 #include <Core/CollapsedVector.hh>
 #include <Core/XmlStream.hh>
+#include <Math/Utilities.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Search/Traceback.hh>
 #include <Search/TracebackHelper.hh>
@@ -769,8 +769,7 @@ void LexiconfreeLabelsyncBeamSearch::scorePruning(std::vector<Element>& hypothes
                     hypotheses.begin(),
                     hypotheses.end(),
                     [](auto const& hyp) {
-                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
-                        or
+                        return Math::isinf(hyp.score) or hyp.score >= Core::Type<Score>::max;
                     }),
             hypotheses.end());
 

--- a/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
+++ b/src/Search/LexiconfreeLabelsyncBeamSearch/LexiconfreeLabelsyncBeamSearch.cc
@@ -16,6 +16,7 @@
 #include "LexiconfreeLabelsyncBeamSearch.hh"
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 #include <strings.h>
 
@@ -520,6 +521,12 @@ bool LexiconfreeLabelsyncBeamSearch::decodeStep() {
         if (logStepwiseStatistics_) {
             clog() << Core::XmlFull("num-hyps-after-intermediate-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
         }
+        if (extensions_.empty()) {
+            if (logStepwiseStatistics_) {
+                clog() << Core::XmlClose("search-step-stats");
+            }
+            return false;
+        }
 
         if (scorerIdx < labelScorers_.size() - 1) {
             // Prepare scoring context list for next iteration
@@ -757,6 +764,20 @@ void LexiconfreeLabelsyncBeamSearch::logStatistics() const {
 
 template<typename Element>
 void LexiconfreeLabelsyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
+    hypotheses.erase(
+            std::remove_if(
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [](auto const& hyp) {
+                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
+                        or
+                    }),
+            hypotheses.end());
+
+    if (hypotheses.empty()) {
+        return;
+    }
+
     if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
         // Neither relative score pruning nor max beam size pruning triggers
         return;

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -16,12 +16,12 @@
 #include "LexiconfreeTimesyncBeamSearch.hh"
 
 #include <algorithm>
-#include <cmath>
 #include <strings.h>
 
 #include <Core/CollapsedVector.hh>
 #include <Core/XmlStream.hh>
 #include <Lattice/LatticeAdaptor.hh>
+#include <Math/Utilities.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
 #include <Search/Histogram.hh>
@@ -732,7 +732,7 @@ void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypothese
                     hypotheses.begin(),
                     hypotheses.end(),
                     [](auto const& hyp) {
-                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
+                        return Math::isinf(hyp.score) or hyp.score >= Core::Type<Score>::max;
                     }),
             hypotheses.end());
 

--- a/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
+++ b/src/Search/LexiconfreeTimesyncBeamSearch/LexiconfreeTimesyncBeamSearch.cc
@@ -16,6 +16,7 @@
 #include "LexiconfreeTimesyncBeamSearch.hh"
 
 #include <algorithm>
+#include <cmath>
 #include <strings.h>
 
 #include <Core/CollapsedVector.hh>
@@ -538,6 +539,12 @@ bool LexiconfreeTimesyncBeamSearch::decodeStep() {
             clog() << Core::XmlFull("num-hyps-after-intermediate-pruning-" + std::to_string(scorerIdx + 1), extensions_.size());
         }
         numHypsAfterIntermediatePruning_[scorerIdx] += extensions_.size();
+        if (extensions_.empty()) {
+            if (logStepwiseStatistics_) {
+                clog() << Core::XmlClose("search-step-stats");
+            }
+            return false;
+        }
 
         if (scorerIdx < labelScorers_.size() - 1) {
             // Prepare scoring context list for next iteration
@@ -720,6 +727,19 @@ Nn::TransitionType LexiconfreeTimesyncBeamSearch::inferTransitionType(Nn::LabelI
 
 template<typename Element>
 void LexiconfreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
+    hypotheses.erase(
+            std::remove_if(
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [](auto const& hyp) {
+                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
+                    }),
+            hypotheses.end());
+
+    if (hypotheses.empty()) {
+        return;
+    }
+
     if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
         // Neither relative score pruning nor max beam size pruning triggers
         return;

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -16,6 +16,7 @@
 #include "TreeTimesyncBeamSearch.hh"
 
 #include <algorithm>
+#include <cmath>
 #include <strings.h>
 
 #include <Am/ClassicStateModel.hh>
@@ -604,6 +605,12 @@ bool TreeTimesyncBeamSearch::decodeStep() {
         if (logStepwiseStatistics_) {
             clog() << Core::XmlFull("num-hyps-after-intermediate-pruning-" + std::to_string(scorerIdx + 1), withinWordExtensions_.size());
         }
+        if (withinWordExtensions_.empty()) {
+            if (logStepwiseStatistics_) {
+                clog() << Core::XmlClose("search-step-stats");
+            }
+            return false;
+        }
 
         if (scorerIdx < labelScorers_.size() - 1) {
             // Prepare scoring context list for next iteration
@@ -895,6 +902,19 @@ Nn::TransitionType TreeTimesyncBeamSearch::inferTransitionType(Nn::LabelIndex pr
 
 template<typename Element>
 void TreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Score relativeThreshold, size_t maxBeamSize) {
+    hypotheses.erase(
+            std::remove_if(
+                    hypotheses.begin(),
+                    hypotheses.end(),
+                    [](auto const& hyp) {
+                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
+                    }),
+            hypotheses.end());
+
+    if (hypotheses.empty()) {
+        return;
+    }
+
     if (hypotheses.size() <= maxBeamSize and relativeThreshold == Core::Type<Score>::max) {
         // Neither relative score pruning nor max beam size pruning triggers
         return;

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -16,13 +16,13 @@
 #include "TreeTimesyncBeamSearch.hh"
 
 #include <algorithm>
-#include <cmath>
 #include <strings.h>
 
 #include <Am/ClassicStateModel.hh>
 #include <Core/CollapsedVector.hh>
 #include <Core/XmlStream.hh>
 #include <Lattice/LatticeAdaptor.hh>
+#include <Math/Utilities.hh>
 #include <Nn/LabelScorer/LabelScorer.hh>
 #include <Nn/LabelScorer/ScoringContext.hh>
 #include <Search/Module.hh>
@@ -907,7 +907,7 @@ void TreeTimesyncBeamSearch::scorePruning(std::vector<Element>& hypotheses, Scor
                     hypotheses.begin(),
                     hypotheses.end(),
                     [](auto const& hyp) {
-                        return not std::isfinite(hyp.score) or hyp.score >= Core::Type<Score>::max;
+                        return Math::isinf(hyp.score) or hyp.score >= Core::Type<Score>::max;
                     }),
             hypotheses.end());
 


### PR DESCRIPTION
LabelScorers like the `CtcPrefixLabelScorer` can return infinite score for impossible extensions (i.e. label-sequence requires alignments of length > T). Whenever this happens, it can crash the search during histogram pruning because the condition
```
void setLimits(Score lower, Score upper) {
    require_lt(lower, upper);
    ...
}
```
gets violated. This PR erases all hypotheses with infinite score before histogram pruning is applied.