### PR TITLE
Add github workflow to build and deploy documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: docs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -qy
+        sudo apt-get install -y doxygen graphviz make
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+        cache: pip
+        cache-dependency-path: doc/requirements.txt
+    - name: Install Python dependencies
+      run: python -m pip install -r doc/requirements.txt
+    - name: Configure GitHub Pages
+      id: pages
+      uses: actions/configure-pages@v5
+    - name: Build documentation
+      run: make -C doc html SPHINXOPTS="-D html_baseurl=${{ steps.pages.outputs.base_url }}/"
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: doc/_build/html
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+sphinx-sitemap
+breathe


### PR DESCRIPTION
This PR adds a github workflow to build and publish the Sphinx documentation from `doc/` using github Pages. The workflow installs Doxygen/Graphviz and the python documentation dependencies, then runs `make -C doc html`. The generated HTML from doc/_build/html is uploaded as a GitHub Pages artifact.

Once this is merged into master, github should run the new docs workflow and the deploy job will publish the generated documentation to the repository’s github pages site.