### PR TITLE
Add opt-in per-token debug tracking to hypotheses in tree searches

### DIFF
--- a/cmake_resources/Modules.cmake
+++ b/cmake_resources/Modules.cmake
@@ -100,6 +100,9 @@ add_module_option(MODULE_SPEECH_LATTICE_RESCORING ON)
 # ****** Unit Tests ******
 add_module_option(MODULE_TEST OFF)
 
+# ****** Debugging for SearchV2 ******
+add_module_option(SEARCHV2_DEBUG OFF)
+
 # ****** Intel Threading Building Blocks ******
 add_module_option(MODULE_TBB OFF)
 

--- a/doc/search_v2.rst
+++ b/doc/search_v2.rst
@@ -1217,6 +1217,9 @@ Tuning tips
   :ref:`Multiple label scorers and per-stage parameters`.
 * ``recognizer-v2`` logs ``flf-recognizer-time`` and ``flf-recognizer-rtf`` per segment, which is the quickest
   way to check whether a parameter change affected decoding speed.
+* For ``tree-timesync-beam-search``/``tree-labelsync-beam-search``, build with ``-DSEARCHV2_DEBUG=ON`` to have
+  each hypothesis additionally track its full token sequence, per-token score deltas and per-token timeframes.
+  This carries a per-hypothesis memory/runtime cost, so it is disabled by default and meant for debugging only.
 
 See also
 ---------

--- a/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
+++ b/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
@@ -57,7 +57,15 @@ TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis()
           score(0.0),
           scaledScore(0.0),
           trace(Core::ref(new LatticeTrace(0, {0, 0}, {}))),
-          isActive(true) {}
+          isActive(true)
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(),
+          tokenScoreDeltas(),
+          tokenTimeframes()
+#endif
+{
+}
 
 TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
         TreeLabelsyncBeamSearch::LabelHypothesis const&              base,
@@ -73,7 +81,19 @@ TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
           score(extension.score),
           scaledScore(score / std::pow(length, lengthNormScale)),
           trace(base.trace),
-          isActive(extension.transitionType != Nn::TransitionType::SENTENCE_END) {
+          isActive(extension.transitionType != Nn::TransitionType::SENTENCE_END)
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(base.tokenSequence),
+          tokenScoreDeltas(base.tokenScoreDeltas),
+          tokenTimeframes(base.tokenTimeframes)
+#endif
+{
+#ifdef SEARCHV2_DEBUG
+    tokenSequence.push_back(extension.nextToken);
+    tokenScoreDeltas.push_back(extension.score - base.score);
+    tokenTimeframes.push_back(extension.timeframe);
+#endif
 }
 
 TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
@@ -90,7 +110,14 @@ TreeLabelsyncBeamSearch::LabelHypothesis::LabelHypothesis(
           score(extension.score),
           scaledScore(score / std::pow(length, lengthNormScale)),
           trace(),
-          isActive(base.isActive) {
+          isActive(base.isActive)
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(base.tokenSequence),
+          tokenScoreDeltas(base.tokenScoreDeltas),
+          tokenTimeframes(base.tokenTimeframes)
+#endif
+{
     auto newLmScore   = score - base.score;
     auto totalLmScore = base.trace->score.lm + newLmScore;
     auto totalAmScore = score - totalLmScore;
@@ -115,6 +142,22 @@ std::string TreeLabelsyncBeamSearch::LabelHypothesis::toString() const {
             ss << item.pronunciation->lemma()->symbol() << " ";
         }
     }
+
+#ifdef SEARCHV2_DEBUG
+    ss << ", tokens: ";
+    for (auto token : tokenSequence) {
+        ss << token << " ";
+    }
+    ss << ", token score deltas: ";
+    for (auto scoreDelta : tokenScoreDeltas) {
+        ss << scoreDelta << " ";
+    }
+    ss << ", token timeframes: ";
+    for (auto tf : tokenTimeframes) {
+        ss << tf << " ";
+    }
+#endif
+
     return ss.str();
 }
 

--- a/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.hh
+++ b/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.hh
@@ -126,6 +126,12 @@ protected:
         Core::Ref<LatticeTrace>            trace;            // Associated trace for traceback or lattice building of hypothesis
         bool                               isActive;         // Indicates whether the hypothesis has not produced a sentence-end label yet
 
+#ifdef SEARCHV2_DEBUG
+        std::vector<Nn::LabelIndex>         tokenSequence;     // Full sequence of predicted tokens for debugging purposes
+        std::vector<Score>                  tokenScoreDeltas;  // Score contribution of each token in `tokenSequence` for debugging purposes
+        std::vector<Speech::TimeframeIndex> tokenTimeframes;   // Timeframe of each token in `tokenSequence` for debugging purposes
+#endif
+
         LabelHypothesis();
 
         // Within-word constructor from base and within-word extension

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -53,7 +53,15 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis()
           lmHistory(),
           timeframe(0),
           score(0.0),
-          trace(Core::ref(new LatticeTrace(0, {0, 0}, {}))) {}
+          trace(Core::ref(new LatticeTrace(0, {0, 0}, {})))
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(),
+          tokenScoreDeltas(),
+          tokenTimeframes()
+#endif
+{
+}
 
 TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
         TreeTimesyncBeamSearch::LabelHypothesis const&              base,
@@ -65,7 +73,19 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
           lmHistory(base.lmHistory),
           timeframe(extension.timeframe),
           score(extension.score),
-          trace(base.trace) {
+          trace(base.trace)
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(base.tokenSequence),
+          tokenScoreDeltas(base.tokenScoreDeltas),
+          tokenTimeframes(base.tokenTimeframes)
+#endif
+{
+#ifdef SEARCHV2_DEBUG
+    tokenSequence.push_back(extension.nextToken);
+    tokenScoreDeltas.push_back(extension.score - base.score);
+    tokenTimeframes.push_back(extension.timeframe);
+#endif
 }
 
 TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
@@ -77,7 +97,14 @@ TreeTimesyncBeamSearch::LabelHypothesis::LabelHypothesis(
           currentState(extension.rootState),
           lmHistory(newLmHistory),
           timeframe(base.timeframe),
-          score(extension.score) {
+          score(extension.score)
+#ifdef SEARCHV2_DEBUG
+          ,
+          tokenSequence(base.tokenSequence),
+          tokenScoreDeltas(base.tokenScoreDeltas),
+          tokenTimeframes(base.tokenTimeframes)
+#endif
+{
     auto newLmScore   = score - base.score;
     auto totalLmScore = base.trace->score.lm + newLmScore;
     auto totalAmScore = score - totalLmScore;
@@ -105,6 +132,22 @@ std::string TreeTimesyncBeamSearch::LabelHypothesis::toString() const {
             ss << item.pronunciation->lemma()->symbol() << " ";
         }
     }
+
+#ifdef SEARCHV2_DEBUG
+    ss << ", tokens: ";
+    for (auto token : tokenSequence) {
+        ss << token << " ";
+    }
+    ss << ", token score deltas: ";
+    for (auto scoreDelta : tokenScoreDeltas) {
+        ss << scoreDelta << " ";
+    }
+    ss << ", token timeframes: ";
+    for (auto tf : tokenTimeframes) {
+        ss << tf << " ";
+    }
+#endif
+
     return ss.str();
 }
 

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.hh
@@ -119,6 +119,12 @@ protected:
         Score                              score;            // Full score of the hypothesis
         Core::Ref<LatticeTrace>            trace;            // Associated trace for traceback or lattice building of hypothesis
 
+#ifdef SEARCHV2_DEBUG
+        std::vector<Nn::LabelIndex>         tokenSequence;     // Full sequence of predicted tokens for debugging purposes
+        std::vector<Score>                  tokenScoreDeltas;  // Score contribution of each token in `tokenSequence` for debugging purposes
+        std::vector<Speech::TimeframeIndex> tokenTimeframes;   // Timeframe of each token in `tokenSequence` for debugging purposes
+#endif
+
         LabelHypothesis();
 
         // Within-word constructor from base and within-word extension


### PR DESCRIPTION
Adds a `SEARCHV2_DEBUG` CMake option (off by default) that, when enabled, makes LabelHypothesis in TreeTimesyncBeamSearch and TreeLabelsyncBeamSearch track each hypothesis's full token sequence, per-token score deltas and per-token timeframes, and include them in toString() for debugging purposes.