### PR TITLE
Add BLANK_EXIT transition type for LabelScorers

### DIFF
--- a/src/Nn/LabelScorer/TransitionTypes.hh
+++ b/src/Nn/LabelScorer/TransitionTypes.hh
@@ -37,6 +37,7 @@ enum TransitionType {
     WORD_EXIT,
     NONWORD_EXIT,
     SILENCE_EXIT,
+    BLANK_EXIT,
     SENTENCE_END,
     numTypes,  // must remain at the end
 };
@@ -56,6 +57,7 @@ inline constexpr auto TransitionTypeArray = std::to_array<std::pair<std::string_
         {"word-exit", WORD_EXIT},
         {"nonword-exit", NONWORD_EXIT},
         {"silence-exit", SILENCE_EXIT},
+        {"blank-exit", BLANK_EXIT},
         {"sentence-end", SENTENCE_END},
 });
 static_assert(TransitionTypeArray.size() == TransitionType::numTypes, "TransitionTypeArray size must match number of TransitionType values");

--- a/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
+++ b/src/Search/TreeLabelsyncBeamSearch/TreeLabelsyncBeamSearch.cc
@@ -750,7 +750,10 @@ bool TreeLabelsyncBeamSearch::decodeStep() {
 
             Score              penalty               = 0.0;
             Nn::TransitionType wordEndtransitionType = Nn::TransitionType::WORD_EXIT;
-            if (lemma == lexicon_->specialLemma("silence")) {
+            if (lemma == lexicon_->specialLemma("blank")) {
+                wordEndtransitionType = Nn::TransitionType::BLANK_EXIT;
+            }
+            else if (lemma == lexicon_->specialLemma("silence")) {
                 wordEndtransitionType = Nn::TransitionType::SILENCE_EXIT;
             }
             else if (nonWordLemmas_.contains(lemma)) {

--- a/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
+++ b/src/Search/TreeTimesyncBeamSearch/TreeTimesyncBeamSearch.cc
@@ -723,7 +723,10 @@ bool TreeTimesyncBeamSearch::decodeStep() {
 
             Score              penalty               = 0.0;
             Nn::TransitionType wordEndtransitionType = Nn::TransitionType::WORD_EXIT;
-            if (lemma == lexicon_->specialLemma("silence")) {
+            if (lemma == lexicon_->specialLemma("blank")) {
+                wordEndtransitionType = Nn::TransitionType::BLANK_EXIT;
+            }
+            else if (lemma == lexicon_->specialLemma("silence")) {
                 wordEndtransitionType = Nn::TransitionType::SILENCE_EXIT;
             }
             else if (nonWordLemmas_.contains(lemma)) {

--- a/src/Tools/LibRASR/LabelScorer.cc
+++ b/src/Tools/LibRASR/LabelScorer.cc
@@ -94,6 +94,7 @@ void bindLabelScorer(py::module_& module) {
             .value("WORD_EXIT", Nn::TransitionType::WORD_EXIT)
             .value("NONWORD_EXIT", Nn::TransitionType::NONWORD_EXIT)
             .value("SILENCE_EXIT", Nn::TransitionType::SILENCE_EXIT)
+            .value("BLANK_EXIT", Nn::TransitionType::BLANK_EXIT)
             .value("SENTENCE_END", Nn::TransitionType::SENTENCE_END);
 
     // Specify `Python::LabelScorer` as trampoline class and `Core::Ref<Nn::LabelScorer>` as holder type


### PR DESCRIPTION
Currently, the new tree search algorithms don't distinguish blank lemma exits; they are just classified as regular WORD_EXIT transitions (or can be marked as NONWORD manually). This PR adds a BLANK_EXIT transition type which is assigned to the tree exit corresponding to the blank lemma.

There is one thing to discuss: the tree builder doesn't add loops for the blank lemma state which means that for blank segments between words, every frame counts as a separate blank lemma emission of length 1. The intention behind this is to avoid redundant paths which will later get recombined anyway but now this means that the BLANK_EXIT penalty will be applied for every frame which is unexpected (and undesirable) behavior. The main ways to fix this are:

- conditionally add loops to the blank state in the tree based on a config parameter and expect users to enable this when using a scorer that scores BLANK_EXIT
- always add loops to the blank state in the tree and just accept the redundant paths in standard cases (here we could also add a tiny default BLANK_EXIT penalty so that in recombination the loop transition is preferred over exit + forward).