### PR TITLE
Scale the sparse LM look-ahead back-off score in AdvancedTreeSearch

### DIFF
--- a/src/Lm/ScaledLanguageModel.hh
+++ b/src/Lm/ScaledLanguageModel.hh
@@ -111,7 +111,7 @@ public:
         return languageModel_->isSparse(h);
     }
     virtual HistorySuccessors getHistorySuccessors(const History& h) const {
-        HistorySuccessors res;
+        HistorySuccessors res = languageModel_->getHistorySuccessors(h);
         res.backOffScore *= scale();
         for (auto& ws : res) {
             ws.score_ *= scale();

--- a/src/Search/AdvancedTreeSearch/SearchSpace.cc
+++ b/src/Search/AdvancedTreeSearch/SearchSpace.cc
@@ -4053,7 +4053,10 @@ Instance* SearchSpace::getBackOffInstance(Instance* instance) {
         activeInstances.push_back(new Instance(instance->key, instance));
         verify(instance->backOffInstance == activeInstances.back());
 
-        instance->backOffScore                      = lookaheadLm_->unscaled()->getBackOffScore(useHistory);
+        // The sparse look-ahead tables store their back-off score scaled by the look-ahead
+        // scale (LanguageModelLookahead::computeScoresSparse), so the offset charged for
+        // entering the back-off network has to carry the same scale to be comparable.
+        instance->backOffScore                      = lookaheadLm_->unscaled()->getBackOffScore(useHistory) * lmLookahead_->getLookaheadScale();
         instance->backOffInstance->scoreHistory     = instance->scoreHistory;
         instance->backOffInstance->lookaheadHistory = reduced;
 


### PR DESCRIPTION
`SearchSpace::getBackOffInstance` stored the back-off score taken from the **unscaled** look-ahead LM:

```cpp
instance->backOffScore = lookaheadLm_->unscaled()->getBackOffScore(useHistory);
```

The sparse look-ahead tables that this value is compared against store their back-off **scaled**. `LanguageModelLookahead::computeScoresSparse`:

```cpp
Score scale = batchRequest_->scale();
...
lookahead.backOffScore_ = successors.backOffScore * scale;
```

`instance->backOffScore` is added to `sh->score` when a state misses in the sparse table and transfers into the back-off network, and that score then becomes a prospect which beam pruning compares against entries of the back-off network's table. Those entries carry the look-ahead scale; the offset did not. The two quantities were not commensurable, so with a look-ahead scale below 1 the back-off transfer was systematically under-charged, and above 1 over-charged.

The same file already scales its other back-off offset — `SearchSpace.cc:1565`, the unigram path:

```cpp
backOffOffset *= unigramLookaheadBackoffFactor_ * lmLookahead_->getLookaheadScale();
```

so this was also an internal inconsistency between two back-off offsets in one translation unit.

This PR multiplies by the same scale:

```cpp
instance->backOffScore = lookaheadLm_->unscaled()->getBackOffScore(useHistory) * lmLookahead_->getLookaheadScale();
```

`getLookaheadScale()` returns `batchRequest_->scale()` — the *same* value `computeScoresSparse` uses — and `unscaled()` has to stay, because that scale already includes the LM scale and `ScaledLanguageModel::getBackOffScore` would apply it a second time. The expression is now the same idiom as the two other call sites that read a back-off from the look-ahead LM.

### Scope of the effect

The offset is accumulated in `Instance::totalBackOffOffset` and subtracted again at word ends (`SearchSpace.cc:2911`, `:3919`), so look-ahead values never enter a final score. The change therefore **cannot** alter a score or a lattice at an unpruned beam; everything it does, it does through pruning. There are three readers of `instance->backOffScore` in total (`:1463` early back-off, `:1632` sparse transfer, `:1815` the running total) and none of them assumed the value was unscaled.

### Measurement — and why this is not proposed as a quality improvement

Measured on AppTek models, not on an upstream setup, so treat the numbers as directional:

- Deployment test, 170 test sets, ~9.7M words: **net +859 errors**, 776 files worse, 537 better. Small and consistently negative.
- Search genuinely narrows, paired per segment and deterministic: **active instances after pruning −7.0%** (56 of 61 segments), states after pruning −2.65%.
- **Wall clock unchanged** (490 s vs 486 s) — the instances that get pruned away are cheap; cost is dominated by acoustic scoring and the ONNX LSTM calls on states.

Because the look-ahead is score-neutral (above), both variants converge at a wide beam and "scaled beats unscaled" is not a reachable outcome. The best case for this change is *the same WER for less search*, and on that configuration it did not reach even that.

The likely reason is that the configuration is tuned around the old behaviour: its look-ahead LM scale is a hand-set 0.5 against a main LM scale of 0.4, chosen while the back-off was being under-charged, so that scale may have been absorbing the inconsistency. It has not been re-tuned for the corrected arithmetic; a sweep is being done separately and is not part of this PR.

**So the argument for this PR is that the arithmetic is inconsistent with how the look-ahead table is built, not that it improves recognition.** Anyone who tuned pruning or the look-ahead scale against the old behaviour should expect to retune.

### History

For the record, in case it looks like a decision is being reversed: a scale was introduced at this line in AppTek's fork by `373fb226`, as a side effect of swapping a raw `BackingOffLm` pointer for the `lookaheadLm_` wrapper, and removed again by `708a800a`. Neither commit message, PR description nor comment records a rationale in either direction, and this repository received the end state through a bulk backport without the reasoning. The line was unjustified before this change as much as after it — which is precisely why it is worth settling on the arithmetic rather than on precedent.

### Second commit: `Lm::ScaledLanguageModel::getHistorySuccessors`

Found while tracing where the scaled and unscaled back-off values come from, and included here because it is one line in the same area of the code. The override never delegated to the wrapped LM:

```cpp
virtual HistorySuccessors getHistorySuccessors(const History& h) const {
    HistorySuccessors res;          // default-constructed: empty vector,
    res.backOffScore *= scale();    // and backOffScore is uninitialised
    for (auto& ws : res) {          // loop over an empty vector
        ws.score_ *= scale();
    }
    return res;
}
```

It returned an empty successor list, scaled an uninitialised `Score`, and ignored `h`. Now it delegates and then scales, which is what every other forwarding method in the wrapper does (`score`, `sentenceEndScore`, `sentenceBeginScore`, `getBackOffScore` are all `scale() * languageModel_->…`).

**No behaviour change:** all three `getHistorySuccessors` call sites reach the LM through `unscaled()` (`LanguageModelLookahead.cc:1753`) or `unscaled_lms_` (`CombineLm.cc:248`, `:405`), so the override is currently unreached. Happy to split it into its own PR if preferred.

### Testing

Full build green, all targets including `librasr`, `clang-format-18` clean. No recognition run in this environment; the numbers above come from the AppTek setup.

— Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
