### PR TITLE
Add LabelScorerFactory/EncoderFactory: raise an error when no label-scorer/encoder type is defined in the config

### DIFF
--- a/src/Nn/LabelScorer/EncoderFactory.cc
+++ b/src/Nn/LabelScorer/EncoderFactory.cc
@@ -15,10 +15,12 @@
 
 #include "EncoderFactory.hh"
 
+#include <Core/Application.hh>
+
 namespace Nn {
 
 EncoderFactory::EncoderFactory()
-        : choices_(), paramEncoderType("type", &choices_, "Choice from a set of encoder types."), registry_() {}
+        : choices_(), paramEncoderType("type", &choices_, "Choice from a set of encoder types.", Core::Choice::IllegalValue), registry_() {}
 
 void EncoderFactory::registerEncoder(const char* name, CreationFunction creationFunction) {
     choices_.addChoice(name, registry_.size());
@@ -27,11 +29,21 @@ void EncoderFactory::registerEncoder(const char* name, CreationFunction creation
 
 Core::Ref<Encoder> EncoderFactory::createEncoder(Core::Configuration const& config) const {
     ModelCache tempCache;
-    return registry_.at(paramEncoderType(config))(config, tempCache);
+    return createEncoder(config, tempCache);
 }
 
 Core::Ref<Encoder> EncoderFactory::createEncoder(Core::Configuration const& config, ModelCache& modelCache) const {
-    return registry_.at(paramEncoderType(config))(config, modelCache);
+    auto type = paramEncoderType(config);
+    if (type == Core::Choice::IllegalValue) {
+        std::stringstream ss;
+        ss << "No valid encoder type defined in `" << config.getSelection() << "." << paramEncoderType.name() << "`.";
+        ss << "Possible values are: ";
+        choices_.printIdentifiers(ss);
+        Core::Application::us()->criticalError("%s", ss.str().c_str());
+        return {};
+    }
+
+    return registry_.at(type)(config, modelCache);
 }
 
 }  // namespace Nn

--- a/src/Nn/LabelScorer/LabelScorerFactory.cc
+++ b/src/Nn/LabelScorer/LabelScorerFactory.cc
@@ -15,10 +15,12 @@
 
 #include "LabelScorerFactory.hh"
 
+#include <Core/Application.hh>
+
 namespace Nn {
 
 LabelScorerFactory::LabelScorerFactory()
-        : choices_(), paramLabelScorerType("type", &choices_, "Choice from a set of label scorer types."), registry_() {}
+        : choices_(), paramLabelScorerType("type", &choices_, "Choice from a set of label scorer types.", Core::Choice::IllegalValue), registry_() {}
 
 void LabelScorerFactory::registerLabelScorer(const char* name, CreationFunction creationFunction) {
     choices_.addChoice(name, registry_.size());
@@ -31,7 +33,17 @@ Core::Ref<ScaledLabelScorer> LabelScorerFactory::createLabelScorer(Core::Configu
 }
 
 Core::Ref<ScaledLabelScorer> LabelScorerFactory::createLabelScorer(Core::Configuration const& config, ModelCache& modelCache) const {
-    auto subScorer = registry_.at(paramLabelScorerType(config))(config, modelCache);
+    auto type = paramLabelScorerType(config);
+    if (type == Core::Choice::IllegalValue) {
+        std::stringstream ss;
+        ss << "No valid label scorer type defined in `" << config.getSelection() << "." << paramLabelScorerType.name() << "`.";
+        ss << "Possible values are: ";
+        choices_.printIdentifiers(ss);
+        Core::Application::us()->criticalError("%s", ss.str().c_str());
+        return {};
+    }
+
+    auto subScorer = registry_.at(type)(config, modelCache);
     return Core::ref(new ScaledLabelScorer(config, subScorer));
 }
 


### PR DESCRIPTION
The LabelScorerFactory and EncoderFactory don't define a default value for the type of LabelScorer/Encoder which means that if nothing is set in the config, they will silently fall back to the first choice that is registered in the factories. For the LabelScorerFactory this is the CombineLabelScorer which triggers an infinite recursion because the LabelScorerFactory is repeatedly called with empty subconfigs and tries to build an infinite chain of CombineLabelScorers.

This PR avoids cases like this by setting a default of `Core::Choice::IllegalValue` in the factories and interrupting the application when no type is set explicitly in the config.